### PR TITLE
docs(roadmap): record v4.2 to v4.4 research

### DIFF
--- a/docs/agents/research/github-parity-coverage.md
+++ b/docs/agents/research/github-parity-coverage.md
@@ -1,0 +1,130 @@
+# GitHub Markdown 一致性覆盖矩阵
+
+## 结论
+
+当前仓库对既有扩展能力的视觉基线较完整：57 个校验用例中，53 个要求与 GitHub 截图精确一致，4 个把语法高亮和客户端渲染器明确作为集成边界；桌面最低版本、桌面稳定版和 Web 稳定版的宿主冒烟测试也已通过。但宿主冒烟仅覆盖主题容器、任务列表、NOTE 提示框、`:rocket:` 表情和 CSS 可达性，不能证明其余语法在真实 VS Code 桌面与 Web 宿主中的行为。
+
+基于 GitHub 官方规范、GitHub Markdown API 的可复现输出和本地渲染链，v4.2 应只处理三个可验证候选：单波浪线删除线、GFM 禁用原始 HTML 标签、RTL 内容的 `dir="auto"`。三者均已确认 GitHub API 与仓库本地一致性渲染器存在差异；但真实 VS Code 桌面或 Web 宿主目前**没有已证实的新缺口**，必须先增加两端的 `markdown.api.render` 或最终 Webview DOM 断言，复现后才决定是否由扩展补齐，未复现则不实施。
+
+图表、数学公式和语法高亮属于宿主或配套渲染器边界，放入 v4.3；漂移监控与基线治理放入 v4.4。GitHub 仓库上下文功能不应被误报为扩展缺陷。
+
+## 证据方法与可信度
+
+证据按以下顺序使用：
+
+1. GitHub 官方文档与 [GFM 规范 0.29](https://github.github.com/gfm/) 定义目标语义。
+2. [GitHub Markdown REST API](https://docs.github.com/en/rest/markdown/markdown) 的 `gfm` 模式用于最小输入复现。该 API 能确认 GitHub 服务端 HTML，但不能代表 GitHub 页面上的全部客户端增强。
+3. 仓库源码、测试和校验产物用于确认扩展当前实现及覆盖范围。
+4. 真实 VS Code 宿主测试优先于仓库的本地一致性渲染器。后者直接运行 MarkdownIt 和扩展插件，且截图禁用 JavaScript，因此只证明其声明范围内的静态视觉结果。
+
+可信度定义：
+
+- **已验证**：目标语义和当前行为均有可复现证据，或已在真实宿主断言。
+- **局部验证**：静态视觉或少量宿主样例已覆盖，但语义、交互、平台或完整输入范围未覆盖。
+- **未知**：没有足够证据判断桌面、Web 或 GitHub 页面行为；不得据此声称已支持或存在缺陷。
+
+## 责任边界
+
+| 层级                  | 负责内容                                                                                                  | 本项目应做什么                                                                                              |
+| --------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| GitHub 服务与页面     | 仓库上下文解析、Issue/PR/提交引用、提及、自动链接规则、上传、颜色预览、任务状态交互、图表和数学等页面增强 | 作为目标或边界记录；没有可复现的本地预览等价物时不得伪造支持                                                |
+| VS Code Markdown 宿主 | CommonMark/GFM 基础解析、预览 Webview、链接导航、语法高亮及扩展贡献点加载                                 | 优先通过内置 `markdown.markdownItPlugins`、`markdown.previewStyles` 和现有宿主行为集成；先在桌面与 Web 验证 |
+| 本扩展                | 主题容器与样式、任务列表、提示框、表情、脚注、根路径 HTML 图片改写、Mermaid 主题同步                      | 只补齐宿主缺失且属于本地预览语义的高影响差异；保持 Web 扩展兼容，不引入自定义预览系统                       |
+| 配套扩展              | Mermaid 等客户端渲染器                                                                                    | 本项目只维护明确的集成契约，不捆绑渲染器或把配套扩展结果当作本扩展实现                                      |
+
+VS Code 官方文档说明，内置 Markdown 预览以 CommonMark 为基础，`markdown.previewStyles` 改变外观，`markdown.markdownItPlugins` 扩展语法，`markdown.previewScripts` 用于需要客户端脚本的高级渲染。本项目清单当前仅贡献 MarkdownIt 插件和预览样式，并同时声明桌面与 Web 入口；这决定了能力边界。[VS Code Markdown 扩展指南](https://code.visualstudio.com/api/extension-guides/markdown-extension)；[package.json](https://github.com/lzm0x219/vscode-github-markdown/blob/main/package.json)
+
+## 覆盖矩阵
+
+“桌面”和“Web”列只表示真实宿主证据，不用本地 Chromium 截图替代。
+
+| 能力                                                     | GitHub 上游行为                                                                                                | 当前实现与责任方                                                                              | 桌面                       | Web                        | 证据与覆盖缺口                                                                                      | 用户影响                                                                       | 建议版本                              |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------- |
+| 标题、段落、强调、引用、列表、链接、图片、行内与围栏代码 | GFM 继承 CommonMark，并增加页面属性和仓库上下文行为                                                            | 基础解析由 VS Code 宿主负责；扩展负责主题样式                                                 | 局部验证                   | 局部验证                   | 本地精确视觉用例覆盖常用静态输入；宿主冒烟未覆盖完整基础语法，锚点、相对导航和语义属性未知          | 高频；当前无已确认回归                                                         | 保持，缺口随具体复现进入 v4.2 或 v4.4 |
+| GFM 表格                                                 | 支持表头、对齐和单元格内格式                                                                                   | VS Code 宿主解析，扩展样式                                                                    | 未知                       | 未知                       | 本地视觉精确一致；校验会归一化 GitHub 的无障碍表格包裹，因此未证明 DOM 等价                         | 高频；静态外观风险低，语义仍未知                                               | 保持；真实宿主断言纳入回归建设        |
+| GFM 删除线（双波浪线）                                   | `~~文本~~` 生成 `<del>`                                                                                        | VS Code 宿主解析                                                                              | 未知                       | 未知                       | 本地视觉精确一致；没有真实宿主专项断言                                                              | 中频；当前无已确认回归                                                         | 保持                                  |
+| GFM 删除线（单波浪线）                                   | GFM 允许一个或两个波浪线；GitHub API 将 `~文本~` 输出为 `<del>`                                                | 本地 MarkdownIt 保留原文；若真实宿主也缺失，应由扩展 MarkdownIt 插件补齐                      | 未知                       | 未知                       | 已确认 GitHub API 与本地渲染链差异；尚未运行桌面/Web `markdown.api.render` 最小复现                 | 中高频；预览会把有效 GitHub 格式误显示为普通文本                               | **v4.2 候选 1**                       |
+| GFM 自动链接                                             | URL、`www` 地址和邮箱可自动链接；页面还可能添加属性                                                            | VS Code 宿主解析                                                                              | 未知                       | 未知                       | 本地语义链接已复现；GitHub 的 `rel`、`dir` 等属性及真实宿主导航未覆盖                               | 高频；基本语义已有，交互未知                                                   | 保持；不单独进入 v4.2                 |
+| GFM 禁用原始 HTML 标签                                   | GFM tagfilter 转义 `title`、`textarea`、`style`、`xmp`、`iframe`、`noembed`、`noframes`、`script`、`plaintext` | 本地一致性渲染器会保留这些原始标签；真实 VS Code Webview 可能另有清理，责任须先按宿主结果判定 | 未知                       | 未知                       | GitHub API 与本地链差异已复现；截图只观察渲染结果，不能证明 Webview DOM 或清理阶段                  | 中频但差异明显；可能误导用户认为 GitHub 接受嵌入内容。当前证据不足以作安全结论 | **v4.2 候选 2，条件式**               |
+| 普通原始 HTML、`details`、`picture`                      | GitHub 在清理规则允许范围内渲染 HTML；`details` 支持折叠区域                                                   | VS Code 宿主负责 HTML；扩展仅改写原始 HTML `<img src="/...">` 根路径                          | 未知                       | 未知                       | 本地静态视觉与图片改写单测有覆盖；交互、允许标签集、`srcset`、Markdown 图片根路径和真实宿主结果未知 | 中频；错误改写会造成资源预览偏差                                               | 不扩入 v4.2；先补证据                 |
+| RTL 自动方向                                             | GitHub API 为阿拉伯语等标题和段落输出 `dir="auto"`                                                             | 本地 MarkdownIt 核心节点没有该属性；扩展生成的提示框含 `dir="auto"`，其余节点责任待宿主验证   | 未知                       | 未知                       | GitHub API 与本地链差异已复现；桌面/Web 对标题、段落、列表、脚注的结果未知                          | 对 RTL 用户为可访问性和混排方向问题                                            | **v4.2 候选 3，条件式**               |
+| 任务列表                                                 | GitHub 显示复选框；Issue 中还可交互和跟踪任务                                                                  | 扩展插件生成禁用复选框、GitHub 类名和本地化无障碍标签；交互状态属于 GitHub 平台               | 已验证基本项               | 已验证基本项               | 本地视觉精确一致，桌面/Web 宿主冒烟覆盖一个基本项；嵌套、跨 Issue 跟踪和交互不属于当前宿主证据      | 高频；静态写作预览已覆盖                                                       | 保持；平台交互排除                    |
+| 五类提示框                                               | GitHub 支持 NOTE、TIP、IMPORTANT、WARNING、CAUTION，且不支持嵌套                                               | 扩展 MarkdownIt 插件负责结构、图标和样式                                                      | 已验证 NOTE                | 已验证 NOTE                | 本地覆盖五类和多行内容；宿主只断言 NOTE，嵌套边界未形成宿主回归                                     | 高频文档能力；已有能力风险低                                                   | 保持；扩充宿主回归可进 v4.4           |
+| GitHub 表情短代码                                        | GitHub 将受支持别名渲染为表情或自定义图像；编辑器补全属于平台                                                  | 扩展用生成的别名表负责渲染                                                                    | 已验证 `:rocket:`          | 已验证 `:rocket:`          | 本地覆盖表情语料；宿主只覆盖一个别名，别名更新与自定义图像加载范围未全面验证                        | 高频；当前无已确认功能缺口                                                     | 保持；漂移治理进 v4.4                 |
+| 脚注                                                     | GitHub 支持脚注引用、定义和反向链接                                                                            | 扩展插件负责渲染                                                                              | 未知                       | 未知                       | 本地视觉和单元测试覆盖连续定义及简单多行定义；真实宿主、键盘导航、复杂嵌套未知                      | 中频；现有静态结果可信，宿主风险未量化                                         | 保持；先补宿主断言                    |
+| 主题、浅深色与链接下划线                                 | GitHub 外观随主题变化                                                                                          | 扩展主题容器和 CSS 负责九个主题、系统模式及下划线选项                                         | CSS 可达性已验证；视觉未知 | CSS 可达性已验证；视觉未知 | 主主题有广泛视觉语料；其余主题只覆盖简单格式。宿主冒烟只验证样式文件存在和容器输出                  | 高频；属于扩展核心，但无具体已确认差异                                         | 不凭空扩充 v4.2；后续以具体复现驱动   |
+| 代码语法高亮                                             | GitHub 根据语言标识高亮围栏代码                                                                                | VS Code 宿主负责高亮，扩展映射 GitHub 主题颜色                                                | 未知                       | 未知                       | 当前作为视觉集成边界，允许约 2.12 万差异像素；本地对照会归一化 token，不能证明高亮引擎一致          | 高频；版本和主题变化敏感                                                       | **v4.3**                              |
+| Mermaid                                                  | GitHub 页面客户端渲染 Mermaid                                                                                  | `bierner.markdown-mermaid` 负责渲染；本扩展只同步其主题设置并在卸载时恢复                     | 未知                       | 未知                       | 当前截图禁用 JavaScript，平台语料仅作为高阈值集成边界；没有配套扩展的桌面/Web 端到端证据            | 中高频；边界清晰但兼容性未知                                                   | **v4.3**                              |
+| GeoJSON、TopoJSON、STL                                   | GitHub 页面客户端渲染地图和 3D 模型                                                                            | VS Code 宿主或配套扩展责任；本扩展未实现渲染器                                                | 未知                       | 未知                       | 当前只保留源代码块并纳入高阈值边界，不能宣称与 GitHub 等价                                          | 低至中频；实现成本和 Web 风险高                                                | v4.3 调研或明确不支持                 |
+| 数学公式                                                 | GitHub 使用 MathJax 支持行内、块级和 `math` 围栏                                                               | VS Code 宿主或配套扩展责任；本扩展未实现渲染器                                                | 未知                       | 未知                       | 当前截图禁用 JavaScript，平台语料不能证明数学渲染                                                   | 中频；若捆绑渲染器会显著扩大范围                                               | v4.3 调研或明确不支持                 |
+| 提及、Issue/PR/提交引用、关闭关键字、自定义自动链接      | GitHub 依赖仓库、用户、权限和服务端上下文解析                                                                  | GitHub 平台责任；本地预览无可靠等价上下文                                                     | 不适用                     | 不适用                     | GitHub API `context` 只能覆盖部分引用，无法复制完整页面行为                                         | 用户可见但不属于扩展可独立实现的 Markdown 语义                                 | 排除 v4.2；文档说明边界               |
+| 上传附件、颜色预览、标题大纲、锚点 UI、交互式任务        | GitHub 编辑器或页面功能                                                                                        | GitHub 平台责任                                                                               | 不适用                     | 不适用                     | 不属于静态 Markdown 渲染；当前仓库没有实现声明                                                      | 用户可见但错误实现会制造虚假一致性                                             | 明确不实现，除非未来建立独立产品目标  |
+
+## v4.2 缺口排序与执行建议
+
+### 1. 补齐单波浪线删除线语义一致性
+
+这是证据最完整、范围最小的候选。GFM 规范明确允许一个或两个波浪线，GitHub API 可稳定复现 `<del>`，而当前本地渲染链保留字面文本。
+
+执行条件与验收：
+
+- 先为 VS Code 1.74 桌面、桌面稳定版和 Web 稳定版增加 `markdown.api.render('~文本~')` 断言。
+- 仅当宿主未生成 `<del>` 时，在现有 MarkdownIt 插件链中增加最小兼容实现；不得改变双波浪线、代码跨度和转义波浪线行为。
+- 增加 GitHub API 基准 fixture、DOM 语义断言和精确视觉用例；未知输入必须保持字面文本，而不是宽松吞并。
+
+### 2. 对齐 GFM 禁用原始 HTML 标签
+
+GitHub API 与本地链的差异已经确认，但实际 VS Code 预览 Webview 可能在后续阶段处理原始 HTML，因此该项只能作为条件式 v4.2 工作。
+
+执行条件与验收：
+
+- 在桌面最低版本、桌面稳定版与 Web 稳定版分别断言九类 tagfilter 标签的最终预览 DOM，而不只检查 MarkdownIt 中间 HTML。
+- 若宿主最终结果与 GitHub 不同，修复必须只影响 GFM 指定的九类标签，并保留普通允许 HTML、`details`、`picture` 和现有图片改写。
+- 把该项表述为渲染一致性，不在没有威胁路径证据时宣称安全漏洞。
+
+### 3. 对齐 RTL 内容自动方向
+
+GitHub API 对 RTL 标题和段落输出 `dir="auto"`，当前本地链缺失。该差异影响可访问性和双向文本布局，但责任仍需由真实宿主结果决定。
+
+执行条件与验收：
+
+- 在桌面与 Web 宿主覆盖阿拉伯语及中英混排的标题、段落、列表、提示框和脚注。
+- 比较最终 DOM 的 `dir` 语义与视觉方向；避免把 `dir="auto"` 重复或错误添加到代码节点。
+- 若需扩展处理，只修改扩展可控节点或通过最小 MarkdownIt core 规则补齐，不引入自定义预览。
+
+## v4.2 明确排除
+
+- 不实现或捆绑 Mermaid、GeoJSON、TopoJSON、STL、MathJax、语法高亮引擎；这些属于 v4.3 的宿主与配套渲染器兼容性工作。
+- 不实现提及、Issue/PR/提交引用、关闭关键字、自定义自动链接、上传、颜色预览、标题大纲或交互式任务；这些依赖 GitHub 服务和页面上下文。
+- 不新增 `markdown.previewScripts` 或自定义预览系统来绕过 VS Code 内置宿主。
+- 不在没有具体复现的情况下扩充主题、设置或重写已有提示框、表情、脚注、任务列表和图片逻辑。
+- 不把基线刷新、上游漂移监控或长期回归框架塞入 v4.2；这些属于 v4.4。
+
+## 未知项与取证路径
+
+1. **三个 v4.2 候选的真实宿主结果**：扩展 `tests/host/smoke.ts`，在 VS Code 1.74 桌面、桌面稳定版和 Web 稳定版检查 `markdown.api.render` 与最终 Webview DOM。中间 MarkdownIt HTML不能替代最终结果。
+2. **客户端渲染器**：为 Mermaid 等配套扩展建立单独的桌面/Web 集成测试，启用 JavaScript，并记录配套扩展版本。当前禁用 JavaScript 的 Chromium 截图不能回答此问题。
+3. **资源 URL 行为**：在已提交 fixture 中覆盖 Markdown 图片、原始 HTML `img`、`picture`/`source srcset`、相对路径和根路径，并在真实工作区预览验证桌面/Web。未取证前不扩大图片重写范围。
+4. **九个主题的广度**：目前附加主题只覆盖简单格式；后续应按用户证据选择高风险构造，而不是机械复制整个主主题语料。
+5. **链接、锚点和脚注交互**：用宿主 UI 测试检查点击、键盘焦点和返回导航，或在产品边界中明确不保证。截图零差异不证明交互。
+6. **GitHub 上下文差异**：同一 Markdown 在仓库文件、Issue、PR、讨论和 Wiki 中可能得到不同增强。任何新增承诺都要记录目标表面，并用对应官方页面或 API 复现。
+
+## 仓库证据
+
+- 扩展入口及插件链：[src/extension.ts](https://github.com/lzm0x219/vscode-github-markdown/blob/main/src/extension.ts)
+- 任务列表、提示框、表情、脚注、主题和图片改写：[src/plugins](https://github.com/lzm0x219/vscode-github-markdown/tree/main/src/plugins)
+- 一致性用例与边界声明：[scripts/parity/cases.ts](https://github.com/lzm0x219/vscode-github-markdown/blob/main/scripts/parity/cases.ts)
+- Chromium 截图禁用 JavaScript：[scripts/parity/browser.ts](https://github.com/lzm0x219/vscode-github-markdown/blob/main/scripts/parity/browser.ts)
+- 真实宿主冒烟范围：[tests/host/smoke.ts](https://github.com/lzm0x219/vscode-github-markdown/blob/main/tests/host/smoke.ts)
+- 桌面最低版、桌面稳定版和 Web 稳定版矩阵：[.github/workflows/ci.yml](https://github.com/lzm0x219/vscode-github-markdown/blob/main/.github/workflows/ci.yml)
+- 最近一次三类宿主任务均成功的主分支运行：[GitHub Actions 运行 29394603420](https://github.com/lzm0x219/vscode-github-markdown/actions/runs/29394603420)
+
+## 上游资料
+
+- [GitHub 基本写作与格式语法](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
+- [GitHub 表格](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables)
+- [GitHub 折叠区域](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections)
+- [GitHub 代码块与语法高亮](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks)
+- [GitHub 图表](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)
+- [GitHub 数学表达式](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions)
+- [GitHub 自动链接引用与 URL](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls)

--- a/docs/agents/research/host-integration-compatibility.md
+++ b/docs/agents/research/host-integration-compatibility.md
@@ -1,0 +1,139 @@
+# 跨宿主与伴生渲染器兼容矩阵
+
+- 调研日期：2026-07-15
+- 项目基线：`04bbb46aaa7e7bf03ade8ddab83f804b826e2903`
+
+## 结论摘要
+
+1. **桌面端与 Web 端的基础扩展路径可用，但验证深度不足。** `main` 与 `browser` 指向同一 bundle；CI 在 VS Code 1.74.0、桌面稳定版和 Web 稳定版中验证激活、Markdown-it 插件链与预览样式文件。现有宿主测试没有验证九套主题的实际 CSS、运行时配色切换、Mermaid 或 KaTeX 的最终渲染。[扩展清单](../../../package.json)、[宿主 smoke](../../../tests/host/smoke.ts)、[CI](../../../.github/workflows/ci.yml)
+2. **VS Code 1.121 及以上存在已确认的 Mermaid 主题同步断点。** VS Code 1.121 将原 `markdown-mermaid` 合并为内置的 `vscode.mermaid-markdown-features`；它沿用 `markdown-mermaid.lightModeTheme` 和 `markdown-mermaid.darkModeTheme` 设置。当前实现却先检查 `bierner.markdown-mermaid` 是否存在，不存在便返回，因此只安装新内置扩展时不会同步 GitHub 主题。新内置扩展的两个槽位默认都是 `vscode`，而不是本项目期望的 `default`/`dark`。[VS Code 1.121 发布说明](https://code.visualstudio.com/updates/v1_121#_mermaid-diagrams-in-markdown-preview-and-notebooks)、[内置扩展清单（固定版本）](https://github.com/microsoft/vscode/blob/bc2ac764ddd66802104366c182d490a03253f7e1/extensions/mermaid-markdown-features/package.json)、[当前同步实现](../../../src/integrations/mermaid.ts)
+3. **九套 GitHub 主题的正文选择逻辑完整，Mermaid 只保持亮暗方向而非主题等价。** 四套亮色主题全部映射为 Mermaid `default`，五套暗色主题全部映射为 `dark`；色盲、高对比度、Tritanopia 与 Dimmed 的差异不会传递给 Mermaid。这符合当前 README 所承诺的“匹配亮色或暗色”，但不能证明与 GitHub 的图表配色一致。[主题逻辑](../../../src/theme.ts)、[Mermaid 映射](../../../src/integrations/mermaid.ts)、[README](../../../README.md#mermaid-diagrams)
+4. **System 模式依赖 CSS `prefers-color-scheme`，而不是 VS Code 明示的 Webview 主题类。** VS Code 官方为当前编辑器主题提供 `body.vscode-light`、`body.vscode-dark`、`body.vscode-high-contrast`；本项目生成的主题 CSS 只使用亮/暗媒体查询。操作系统自动配色时两者预期趋同，但手动切换 VS Code 主题、高对比度切换以及桌面/Web 是否完全一致仍缺少真实宿主证据，不能视为已验证。[主题 CSS 生成](../../../scripts/build/github-css.ts)、[VS Code Webview 主题契约](https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content)、[VS Code 自动配色说明](https://code.visualstudio.com/docs/configure/themes#_automatically-switch-based-on-os-color-scheme)
+5. **KaTeX 是应保留的回归边界，不是已确认的新缺陷。** VS Code 当前内置预览使用 KaTeX；项目历史 [Issue #604](https://github.com/lzm0x219/vscode-github-markdown/issues/604) 记录过长公式导致双滚动条。该问题已关闭，当前代码没有专门的真实宿主回归测试，因此 v4.3 应先复现再决定是否改 CSS。[VS Code Markdown 数学公式说明](https://code.visualstudio.com/docs/languages/markdown#_math-formula-rendering)
+
+## 范围与风险定义
+
+- **高：** 已有源码级确定性冲突，或会使 GitHub 可渲染内容退化、主题明显错误、预览不可用。
+- **中：** 基础路径存在，但缺少真实宿主/切换/组合验证，或历史上发生过用户可见故障。
+- **低：** 当前实现和至少一层宿主测试一致，剩余风险主要是视觉覆盖不足。
+- “当前行为”区分“由测试证明”和“由源码推断”；未在真实宿主复现的项目明确标为待验证。
+
+GitHub 的目标行为是：`mermaid` 围栏代码块在 Markdown 文件、Issue、PR、Discussion 和 Wiki 中渲染为图表，而不是普通代码块。GitHub 同时提醒第三方 Mermaid 插件可能产生错误，因此本项目应验证组合行为，不能只验证单个插件输出。[GitHub 图表文档](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams)
+
+## 兼容矩阵
+
+| 宿主                                           | 主题模式                                | 伴生/宿主渲染器                             | 预期行为                                                                         | 当前行为与证据                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 风险                           |
+| ---------------------------------------------- | --------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| 桌面 VS Code 1.74.0                            | Single，九主题任一                      | 无                                          | 扩展激活，GitHub 语法插件和固定主题生效                                          | CI 真实宿主 smoke 覆盖激活、插件链和样式文件；未截图或检查最终主题变量。[CI](../../../.github/workflows/ci.yml)、[宿主 smoke](../../../tests/host/smoke.ts)                                                                                                                                                                                                                                                                                                                    | 低（功能）/中（视觉）          |
+| 桌面稳定版                                     | Single，九主题任一                      | 无                                          | 与最低版本相同，且跟随当前 VS Code Markdown API                                  | CI 有稳定版 smoke；测试内容不含主题断言、Mermaid 或数学公式。[宿主 smoke](../../../tests/host/smoke.ts)                                                                                                                                                                                                                                                                                                                                                                        | 低（功能）/中（视觉）          |
+| Web 稳定版（`vscode.dev`/`github.dev` 类环境） | Single，九主题任一                      | 无                                          | 与桌面端产生相同插件 HTML 和 GitHub 主题                                         | `browser` 入口和 WebWorker 宿主 smoke 已覆盖；同一 bundle 避免了实现分叉，但测试仍只验证插件 HTML 与样式存在。[扩展清单](../../../package.json)、[CI](../../../.github/workflows/ci.yml)、[VS Code Web 扩展契约](https://code.visualstudio.com/api/extension-guides/web-extensions#web-extension-main-file)                                                                                                                                                                    | 低（功能）/中（视觉）          |
+| 桌面与 Web                                     | System，普通亮/暗系统配色               | 无                                          | 操作系统配色变化时，在配置的 GitHub 亮/暗主题之间切换                            | 包装元素写入 `data-color-mode="auto"`，生成 CSS 使用 `prefers-color-scheme`；单测只断言属性，没有在真实宿主触发切换。[主题插件](../../../src/plugins/markdown-it-github-theme.ts)、[主题单测](../../../tests/theme.test.ts)                                                                                                                                                                                                                                                    | 中，待真实宿主验证             |
+| 桌面与 Web                                     | System，手动切换 VS Code 主题或高对比度 | 无                                          | 必须明确产品语义：跟随 OS，或跟随当前 VS Code 主题；无论选哪一种都应在两宿主一致 | 官方 Webview 契约提供 VS Code 当前主题类及独立高对比度类别；当前 CSS 未使用这些信号，只区分媒体查询亮/暗。是否产生实际错配待复现。[VS Code Webview 主题契约](https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content)                                                                                                                                                                                                                               | 中                             |
+| 桌面与 Web，VS Code 1.100–1.120                | Single                                  | 外置 `bierner.markdown-mermaid` 当前版      | Mermaid 图表渲染；两个 Mermaid 槽位都与固定 GitHub 主题保持同一亮暗方向          | 当前实现把两个槽位都写为 `default` 或 `dark`；单元测试覆盖映射和恢复。外置扩展同时提供 `main`、`browser`、Markdown 插件和预览脚本，但项目没有真实双扩展宿主测试。[Mermaid 单测](../../../tests/integrations/mermaid.test.ts)、[外置扩展清单（固定版本）](https://github.com/mjbvz/vscode-markdown-mermaid/blob/9f4d37ded0cc7fdf05bbab17fb082a6fc118e269/package.json)                                                                                                          | 中                             |
+| 桌面与 Web，VS Code 1.100–1.120                | System                                  | 外置 `bierner.markdown-mermaid` 当前版      | Mermaid 分别使用与 GitHub 亮/暗槽位相符的主题，并可恢复用户原值                  | 源码与单测证明首次同步会保存全局值、写入 `default`/`dark`，关闭同步后恢复；尚未验证多窗口、用户在同步期间修改 Mermaid 设置或 Web 宿主重载。[同步实现](../../../src/integrations/mermaid.ts)、[Mermaid 单测](../../../tests/integrations/mermaid.test.ts)                                                                                                                                                                                                                       | 中                             |
+| 桌面与 Web，VS Code 1.121+                     | Single 或 System                        | 内置 `vscode.mermaid-markdown-features`     | Mermaid 图表渲染且继续与选定 GitHub 主题保持亮暗一致                             | 图表由 VS Code 内置扩展渲染；本项目只查找旧 ID，所以主题同步提前返回。内置扩展沿用设置键，但默认两个槽位均为 `vscode`。这是源码级可复现断点。[VS Code 1.121 发布说明](https://code.visualstudio.com/updates/v1_121#_mermaid-diagrams-in-markdown-preview-and-notebooks)、[内置扩展清单](https://github.com/microsoft/vscode/blob/bc2ac764ddd66802104366c182d490a03253f7e1/extensions/mermaid-markdown-features/package.json)、[同步实现](../../../src/integrations/mermaid.ts) | **高**                         |
+| 桌面与 Web                                     | Single 或 System                        | VS Code 内置 KaTeX                          | 长公式正常渲染，页面只有一个主滚动容器，正文主题不破坏公式可读性                 | 官方确认内置预览使用 KaTeX；历史 Issue 曾出现双滚动条，当前宿主 smoke 与视觉 parity 都没有执行真实 KaTeX 客户端渲染。[Issue #604](https://github.com/lzm0x219/vscode-github-markdown/issues/604)、[平台边界定义](../../../scripts/parity/cases.ts)                                                                                                                                                                                                                             | 中，待复现                     |
+| 桌面与 Web                                     | 任意                                    | GeoJSON、TopoJSON、STL 或其他第三方预览脚本 | 不破坏宿主或第三方渲染；是否追求 GitHub 功能等价由一致性覆盖矩阵决定             | GitHub 支持这些客户端渲染器；本项目只保留源代码块并把它们列为 integration boundary，没有伴生扩展或历史 Issue 证明应在 v4.3 实现。[GitHub 图表文档](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)、[平台边界测试](../../../tests/scripts/parity/platform-features.test.ts)                                                                                                                                       | 中（验证缺口），不直接纳入实现 |
+
+## 九主题映射
+
+| GitHub 主题           | 类别 | Single 正文选择            | System 槽位 | 外置 Mermaid 同步值 | VS Code 1.121+ 内置 Mermaid 当前结果 |
+| --------------------- | ---- | -------------------------- | ----------- | ------------------- | ------------------------------------ |
+| `light`               | 亮   | 固定 `light`               | light       | `default`           | 不由本扩展更新；新配置默认 `vscode`  |
+| `light_colorblind`    | 亮   | 固定 `light_colorblind`    | light       | `default`           | 同上                                 |
+| `light_high_contrast` | 亮   | 固定 `light_high_contrast` | light       | `default`           | 同上                                 |
+| `light_tritanopia`    | 亮   | 固定 `light_tritanopia`    | light       | `default`           | 同上                                 |
+| `dark`                | 暗   | 固定 `dark`                | dark        | `dark`              | 同上                                 |
+| `dark_colorblind`     | 暗   | 固定 `dark_colorblind`     | dark        | `dark`              | 同上                                 |
+| `dark_dimmed`         | 暗   | 固定 `dark_dimmed`         | dark        | `dark`              | 同上                                 |
+| `dark_high_contrast`  | 暗   | 固定 `dark_high_contrast`  | dark        | `dark`              | 同上                                 |
+| `dark_tritanopia`     | 暗   | 固定 `dark_tritanopia`     | dark        | `dark`              | 同上                                 |
+
+正文映射由 [主题实现](../../../src/theme.ts) 和 [主题 CSS 生成器](../../../scripts/build/github-css.ts)确定；Mermaid 映射由 [集成实现](../../../src/integrations/mermaid.ts)确定。当前单测覆盖九主题枚举和亮暗分支，但没有逐主题真实宿主截图。[主题单测](../../../tests/theme.test.ts)
+
+## 可复现的高影响不一致
+
+### 1. VS Code 1.121+ 内置 Mermaid 不再同步主题（已确认）
+
+复现前提：VS Code 1.121 或以上，不安装已弃用的外置 `bierner.markdown-mermaid`。
+
+1. 保持 `githubMarkdown.mermaid.syncTheme = true`。
+2. 选择 Single `dark_dimmed`，或在 System 中配置任意 GitHub 亮/暗主题。
+3. 打开含 `mermaid` 围栏代码块的 Markdown 预览。
+4. 内置 Mermaid 能渲染图表，但 `updateMermaidThemeSync` 因找不到旧扩展 ID 而在读取设置前返回；`markdown-mermaid.*ModeTheme` 不会被本项目更新。
+
+影响：v4 当前稳定宿主的 Mermaid 图表会使用内置扩展的有效主题（新配置默认 `vscode`），而不是项目声明的 GitHub 主题亮暗映射。功能没有退化为代码块，但主题一致性承诺失效。
+
+### 2. System 模式与 VS Code 手动主题/高对比度的关系不明确（待真实宿主确认）
+
+候选复现：固定 OS 为亮色，System 模式配置 `light`/`dark`，手动把 VS Code 从亮色切到暗色及高对比度，再分别观察桌面与 Web 预览。当前 CSS 只读 `prefers-color-scheme`，而官方推荐的当前 VS Code 主题信号是 `body.vscode-*`。在完成真实宿主验证前，不断言一定错配；但这必须在 v4.3 确定语义并锁定测试。
+
+### 3. 长 KaTeX 内容可能再次产生双滚动条（历史高影响回归，当前待确认）
+
+使用 [Issue #604](https://github.com/lzm0x219/vscode-github-markdown/issues/604) 的长公式场景，在桌面稳定版和 Web 稳定版打开预览，检查页面与公式容器的滚动区域。旧问题已关闭，只有当前版本复现后才能创建 CSS 修复 Ticket；无复现时只保留回归测试。
+
+## 建议纳入 v4.3 的范围
+
+### P0：兼容 VS Code 1.121+ 内置 Mermaid
+
+可拆为独立实现 Ticket：
+
+- 同时识别内置 `vscode.mermaid-markdown-features` 与旧 `bierner.markdown-mermaid`，或改为以设置能力检测为准；不得提高 `engines.vscode`。
+- 保持现有设置键和关闭同步时的恢复语义，补充旧扩展、内置扩展、两者均不存在三类单测。
+- 在桌面稳定版与 Web 稳定版真实渲染 Mermaid，验证 Single/System 的亮暗切换；最低版宿主继续验证无 Mermaid 依赖时扩展可用。
+
+### P1：建立真实宿主主题与客户端渲染回归
+
+可拆为独立测试 Ticket：
+
+- 桌面最低版、桌面稳定版、Web 稳定版继续作为宿主轴。
+- 以四个亮色与五个暗色的 DOM 主题属性全覆盖；视觉验证至少覆盖普通、色盲、高对比度、Dimmed/Tritanopia 各类别，不把九主题只压缩成一个亮暗样例。
+- System 模式分别验证浏览器/OS 亮暗切换、VS Code 手动主题切换和高对比度；根据结果明确“跟随 OS”还是“跟随 VS Code 当前主题”。
+- 在稳定宿主加入 Mermaid 与长 KaTeX 内容，断言不是原始代码块、文本可读且不存在第二个页面滚动条。
+
+### P2：收紧 Mermaid 设置所有权（复现后实施）
+
+当前同步写入 `ConfigurationTarget.Global`，只监听 `githubMarkdown` 配置变化，并用一次性快照恢复。先用多窗口、同步期间用户修改 Mermaid 设置、安装/禁用渲染器三种场景验证；只有证明会覆盖新值或跨窗口漂移后，再拆分实现 Ticket，避免凭假设重构。
+
+## 依赖与排除项
+
+### 依赖
+
+- 版本范围汇总应读取“一致性覆盖矩阵”对 GeoJSON、STL、数学等平台功能的归属决定；本调研只确定组合风险，不替代功能差距排序。
+- P0 依赖 VS Code 1.121 的内置扩展清单作为上游契约，同时必须保留旧扩展路径以覆盖最低版本区间。
+- P1 可与 P0 并行搭建，但内置 Mermaid 的通过断言要等 P0 完成。
+
+### 排除
+
+- 不创建自定义 Markdown 预览或 Webview；继续使用 VS Code 的 `markdown.markdownItPlugins`、`markdown.previewStyles` 与宿主脚本组合契约。[VS Code Markdown 扩展指南](https://code.visualstudio.com/api/extension-guides/markdown-extension)
+- 不重新内置 Mermaid 运行时。VS Code 1.121+ 已内置；旧版本继续通过可选伴生扩展兼容。
+- 不在没有用户/源码证据时新增 GeoJSON、TopoJSON、STL 伴生渲染器。
+- 不承诺 Mermaid、KaTeX 等宿主客户端渲染器的逐像素等价；v4.3 的门槛是正确渲染、主题方向一致、可读、无布局破坏。
+- 不把 Notebook、Chat 或独立 Mermaid 编辑器纳入本项目范围；本项目贡献点只面向 VS Code 内置 Markdown 预览。
+
+## 验证方式与通过标准
+
+| 轴           | 最小验证                                   | 通过标准                                                            |
+| ------------ | ------------------------------------------ | ------------------------------------------------------------------- |
+| 桌面最低版   | VS Code 1.74.0 宿主 smoke                  | 扩展激活、插件链与样式存在；未安装 Mermaid 渲染器时无异常           |
+| 桌面稳定版   | 内置 Markdown 预览端到端                   | 九主题元数据正确；Single/System 切换刷新；Mermaid 和 KaTeX 正常渲染 |
+| Web 稳定版   | `@vscode/test-web` Chromium                | 与桌面稳定版使用相同断言；不依赖 Node API                           |
+| 外置 Mermaid | 兼容其 `engines.vscode` 的旧宿主           | 两主题槽位同步、关闭后恢复原值、图表不是代码块                      |
+| 内置 Mermaid | VS Code 1.121+                             | 新内置 ID/能力被识别；Single/System 下图表亮暗与正文一致            |
+| System 模式  | OS/浏览器亮暗、手动 VS Code 主题、高对比度 | 产品语义明确且两宿主一致；每次切换无需重启预览                      |
+| KaTeX        | 长行与多行公式                             | 公式可读；页面只有一个主滚动区；无横向内容截断                      |
+
+现有像素 parity 把 Mermaid、GeoJSON、STL 和数学标为 `integration-boundary`，且本地路径只保留源代码块，因此不能替代上述真实宿主测试。[Parity cases](../../../scripts/parity/cases.ts)、[平台边界测试](../../../tests/scripts/parity/platform-features.test.ts)
+
+## 关键来源
+
+- [VS Code：Markdown 扩展贡献点](https://code.visualstudio.com/api/extension-guides/markdown-extension)
+- [VS Code：Web 扩展运行时与测试](https://code.visualstudio.com/api/extension-guides/web-extensions)
+- [VS Code：Webview 当前主题信号](https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content)
+- [VS Code 1.121：内置 Mermaid](https://code.visualstudio.com/updates/v1_121#_mermaid-diagrams-in-markdown-preview-and-notebooks)
+- [VS Code 内置 Mermaid 清单，固定提交](https://github.com/microsoft/vscode/blob/bc2ac764ddd66802104366c182d490a03253f7e1/extensions/mermaid-markdown-features/package.json)
+- [旧 `markdown-mermaid` 清单，固定提交](https://github.com/mjbvz/vscode-markdown-mermaid/blob/9f4d37ded0cc7fdf05bbab17fb082a6fc118e269/package.json)
+- [GitHub：创建 Mermaid、GeoJSON、TopoJSON 与 STL 图表](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)
+- [VS Code：内置 Markdown KaTeX](https://code.visualstudio.com/docs/languages/markdown#_math-formula-rendering)
+- [历史 Mermaid 冲突 Issue #203](https://github.com/lzm0x219/vscode-github-markdown/issues/203)
+- [历史 KaTeX 双滚动条 Issue #604](https://github.com/lzm0x219/vscode-github-markdown/issues/604)

--- a/docs/agents/research/upstream-drift-and-regression.md
+++ b/docs/agents/research/upstream-drift-and-regression.md
@@ -1,0 +1,123 @@
+# 上游漂移与回归保障缺口调研
+
+- 调研日期：2026-07-15
+- 对应 Ticket：[评估上游漂移与回归保障缺口](https://github.com/lzm0x219/vscode-github-markdown/issues/1128)
+- 结论性质：基于当前仓库、GitHub 动态配置和第一方来源的规划输入，不直接修改工具链
+
+## 结论
+
+当前方案已经解决了“构建时依赖 GitHub 可用性”的问题：发布构建只读取已提交的 CSS 快照，基线又用输入、渲染配置和 CSS 的 SHA-256 防止静默失配。现有 57 个视觉用例中，大多数本地比较采用零容差；桌面最低版本、桌面稳定版和 Web 稳定版另有宿主冒烟测试。[构建实现](../../../scripts/build/css.ts#L7-L15) · [基线校验](../../../scripts/parity/baseline.ts#L114-L161) · [CI 宿主矩阵](../../../.github/workflows/ci.yml#L65-L98)
+
+但它还不能形成可靠的“上游变化 → 判断用户影响 → 修复 → 阻止带偏差版本发布”闭环，主要风险按优先级为：
+
+1. **GitHub 参照 CSS 可能先被提取器静默裁剪。** `generate-github-markdown-css@6.6.0` 从一个 GitHub 仓库页面收集 CSS 链接，再按标签、类名、`data-*` 和 at-rule 规则过滤；非 `@layer` at-rule（包括媒体查询）、多数含 `data-*` 的选择器以及未进入允许列表的新类都可能被丢弃。远端像素比较使用这份提取结果，而不是实际 GitHub 页面 CSS，因此被丢弃的上游变化无法被任何像素阈值发现。[上游提取入口](https://github.com/sindresorhus/generate-github-markdown-css/blob/v6.6.0/index.js#L260-L296) · [上游过滤逻辑](https://github.com/sindresorhus/generate-github-markdown-css/blob/v6.6.0/index.js#L5-L99) · [本仓库参照 CSS 生成](../../../scripts/parity/browser.ts#L114-L117)
+2. **发现漂移不是发布门禁。** 远端检查每周一运行一次，且只有 `schedule` 事件会执行；标签发布只运行本地基线比较，不重新对照当前 GitHub，也不执行桌面/Web 宿主冒烟测试。[CI 定时条件](../../../.github/workflows/ci.yml#L3-L9) · [远端检查条件](../../../.github/workflows/ci.yml#L45-L52) · [发布验证](../../../.github/workflows/publish.yml#L55-L77)。GitHub 明确说明定时任务可能延迟甚至被丢弃，并且公共仓库无活动 60 天后会自动停用定时任务；因此现状没有可承诺的最大检测时延。[GitHub `schedule` 说明](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule)
+3. **部分非零预算覆盖了整张截图，而不是已知宿主区域。** 语法高亮边界允许最多 24,000 个差异像素，平台渲染器用例允许最多 4,000,000 个差异像素、35% 比例和 700,000 像素连通区域；同一截图中发生的扩展自有布局、颜色或间距回归也可被这些总量预算吞掉。[预算定义](../../../scripts/parity/cases.ts#L149-L180) · [通过判定](../../../scripts/parity/cli.ts#L118-L148)
+4. **失败信号缺少用户影响与故障类型。** 远端模式只比较“旧 GitHub + 旧提取 CSS”和“当前 GitHub + 当前提取 CSS”，不会同时给出“当前扩展与当前 GitHub”的差异；CSS 抓取、API 限流、HTML 提取失败和真实像素漂移也都表现为同一个失败工作流。若失败发生在截图报告写入前，上传步骤会忽略不存在的产物。[远端比较路径](../../../scripts/parity/cli.ts#L73-L173) · [产物上传](../../../.github/workflows/ci.yml#L54-L60)
+5. **CI 存在制度性绕过。** 2026-07-15 使用 `gh api repos/lzm0x219/vscode-github-markdown/branches/main/protection` 核查时，`main` 的保护响应没有 `required_status_checks`，且允许 force push；GitHub 官方说明，未启用 required status checks 时，协作者可以在检查未通过或未完成时合并。[GitHub 分支保护说明](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging)。发布工作流虽会再次执行单元测试和本地像素基线，但无法补回远端当前态与宿主测试缺口。
+
+因此，**v4.4 必须优先保证参照物完整、漂移探针独立、已知边界不遮蔽扩展回归，并把当前 GitHub 一致性接入发布门禁**。单纯增加更多像素用例或提高运行频率，不能修复参照 CSS 已被过滤这一根本问题。
+
+## 当前检测链路
+
+```mermaid
+flowchart TD
+  A["GitHub Markdown API / Contents API / github.com CSS"] --> B["generate-github-markdown-css 过滤并重写 CSS"]
+  B --> C["update:parity 刷新 GitHub HTML、CSS 快照和元数据"]
+  C --> D["提交 parity-baseline.json 与 parity-reference.css"]
+  D --> E["普通构建离线提取 10 个 CSS 资产"]
+  D --> F["PR/main CI：旧 GitHub 基线 vs 当前本地渲染"]
+  A --> G["每周远端检查：旧 GitHub 基线 vs 当前 GitHub 提取结果"]
+  F --> H["标签发布：单测、本地基线、构建、打包"]
+  H --> I["VS Code Marketplace / GitHub Release"]
+  G -. "目前不阻塞发布" .-> H
+```
+
+具体过程：
+
+1. `update:parity` 通过 GitHub Markdown API 获取普通 GFM HTML，通过 Contents API 的 raw/html 媒体类型校验并获取仓库页面 HTML；仓库文件引用先解析为 40 位提交 SHA。GitHub 官方把 Markdown API 定义为“把 Markdown 文档渲染为 HTML”，并说明 `gfm`/`context` 参数；Contents API 的 HTML 媒体类型则由 GitHub Markup 渲染。[本仓库 GitHub 客户端](../../../scripts/parity/github.ts#L14-L71) · [GitHub Markdown API](https://docs.github.com/en/rest/markdown/markdown#render-a-markdown-document) · [GitHub Contents API](https://docs.github.com/en/rest/repos/contents#get-repository-content)
+2. 同一刷新命令调用 `generate-github-markdown-css@6.6.0`，生成共享样式和九套主题变量，再保存 `parity-reference.css`；同时记录生成时间、Chromium 版本、渲染配置哈希、CSS 哈希、输入哈希和 GitHub HTML。[CSS 资产生成](../../../scripts/build/github-css.ts#L70-L109) · [基线结构](../../../scripts/parity/baseline.ts#L19-L39) · [刷新实现](../../../scripts/parity/cli.ts#L183-L203)
+3. 普通 `build` 不联网，只从已提交参照 CSS 拆出一个共享文件和九个主题文件。这是可靠的供应链冻结点，即使 GitHub 临时不可用，用户仍能得到与已审核快照一致的扩展。[离线读取](../../../scripts/build/github-css.ts#L34-L67) · [架构说明](../../../ARCHITECTURE.md#presentation-and-themes)
+4. PR 和 `main` CI 先校验基线指纹，再在同一个无 JavaScript、`1024×720`、DPR 1 的 Chromium 页面中比较旧 GitHub HTML/旧参照 CSS与当前本地 Markdown/CSS；失败时写出 expected、actual、diff 和 JSON/Markdown 报告。[浏览器配置](../../../scripts/parity/browser.ts#L21-L45) · [截图实现](../../../scripts/parity/browser.ts#L77-L111) · [报告实现](../../../scripts/parity/cli.ts#L353-L388)
+5. 每周定时运行把“当前 GitHub HTML + 当前提取 CSS”与已提交 GitHub 基线比较，所有远端用例固定零容差。最近可见的定时运行于 2026-07-13 成功，但一次成功只能证明当时、当前样本和提取范围内没有像素变化。[远端零容差](../../../scripts/parity/cli.ts#L125-L138) · [定时运行记录](https://github.com/lzm0x219/vscode-github-markdown/actions/runs/29229256224)
+6. `v*` 标签触发发布：校验标签/版本、审计、lint、单测、本地像素基线、构建、发行说明和打包，随后发布 Marketplace 和 GitHub Release；这里没有当前 GitHub 远端检查或宿主矩阵。[发布工作流](../../../.github/workflows/publish.yml)
+
+## 控制措施与盲区
+
+| 领域          | 当前控制                                                                                                                                                      | 覆盖盲区或误报来源                                                                                                                                                                                                          | 用户影响                                                                            | 判断                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| 构建可复现性  | CSS 快照提交到仓库；普通构建离线；依赖锁定 `generate-github-markdown-css@6.6.0`。[package.json](../../../package.json)                                        | 快照只有结果哈希，没有抓取页面、CSS 资产 URL/内容哈希、提取器版本和过滤统计；无法复现上游输入或确认“未变化”是否因提取遗漏。                                                                                                 | 漂移发生后难以快速区分 GitHub 变化、提取器变化与抓取故障，延长恢复时间。            | 必须修复 provenance；保留离线构建。                                          |
+| 上游 CSS 参照 | 远端检查请求当前 GitHub HTML；CSS 最长可使用 1 天缓存，fixture HTML 最长可使用 7 天缓存。                                                                     | 上游提取器会丢弃多数 `data-*` 选择器、未知类以及非 `@layer` at-rule；还会注入手写样式。参照物不是原始 GitHub 页面样式。[过滤逻辑](https://github.com/sindresorhus/generate-github-markdown-css/blob/v6.6.0/index.js#L5-L99) | 新响应式规则、交互状态或结构类可能已改变，远端检查仍全绿。                          | **最高优先级：先建立清单、过滤契约与三方报告，再由观测决定是否替换提取器。** |
+| GitHub HTML   | Markdown API 覆盖手写用例，Contents API 覆盖仓库 fixture；raw 内容必须与本地一致；仓库 ref 固化为 SHA。[github.ts](../../../scripts/parity/github.ts#L21-L47) | Markdown API 是文档 HTML，不等同于完整 GitHub 页面；平台客户端渲染器被关闭 JavaScript 或标记为边界。                                                                                                                        | GitHub 页面后处理、宿主脚本和页面容器变化可能不可见。                               | 扩展自有语义必须覆盖；平台渲染器留给 v4.3 边界契约。                         |
+| 用例与主题    | 57 个用例；默认 light/dark 覆盖 12 组手写 fixture 和 12 个 corpus 文件；另有七个主题用例。[cases.ts](../../../scripts/parity/cases.ts#L20-L147)               | 七个附加主题只渲染基础格式 fixture；没有用表格、警告、脚注、代码、任务列表验证其专用变量。                                                                                                                                  | 主题变量变化只影响未采样元素时，远端漂移和本地回归都可能漏检。                      | 值得改进，使用代表性压力 fixture，避免全笛卡尔积。                           |
+| 视口与状态    | 固定 Chromium、固定尺寸、禁用动画、图片替换为确定性 SVG，降低噪声。[browser.ts](../../../scripts/parity/browser.ts#L46-L111)                                  | 只有 1024 px、DPR 1、默认静态状态；没有窄预览、hover/focus 或高 DPR。                                                                                                                                                       | 响应式断行、表格溢出、焦点可见性和细边框问题可能只在用户实际窗口出现。              | 窄/宽视口与交互状态值得纳入；跨操作系统像素矩阵成本高，暂不纳入。            |
+| 像素判定      | `pixelmatch` 阈值为 0，并同时统计总像素、比例、最大连通区域；尺寸差异也计入。[visual.ts](../../../scripts/parity/visual.ts#L13-L36)                           | 四个宿主边界用例使用整图预算，尤其平台用例预算过大；预算没有空间遮罩。                                                                                                                                                      | 同一截图中的扩展回归可在预算内通过。                                                | **必须将边界拆分或按区域遮罩。**                                             |
+| 本地真实性    | 单元/像素测试覆盖扩展插件；桌面最低/稳定和 Web 稳定执行真实 VS Code API 冒烟。[host smoke](../../../tests/host/smoke.ts)                                      | 像素测试使用独立 `MarkdownIt` 管线而非 VS Code 预览 DOM；宿主测试只断言 HTML 片段和 CSS 文件存在，不截图、不检查样式顺序。[local.ts](../../../scripts/parity/local.ts)                                                      | VS Code 内置 Markdown、Webview 容器或浏览器宿主变化可能导致用户预览偏差但测试通过。 | 实际宿主视觉验证属于 v4.3；v4.4 只负责把其结果接入门禁。                     |
+| 探针可靠性    | GitHub 客户端有 15 秒超时、三次重试、限流识别和 5 MiB 响应上限。[github.ts](../../../scripts/parity/github.ts#L74-L167)                                       | CSS 提取器自己的抓取只有缓存与单次 `fetch`，没有相同的超时/重试；本地缓存最长 1 天，fixture HTML 最长 7 天。[上游缓存/请求](https://github.com/sindresorhus/generate-github-markdown-css/blob/v6.6.0/utilities.js#L29-L97)  | 网络故障可伪装成漂移；本地手工刷新可能混用不同时间的输入。                          | 值得改进，必须分类失败并记录 freshness。                                     |
+| 调度与响应    | 每周定时运行；失败上传像素产物。                                                                                                                              | 远端步骤排在安装、lint、单测和本地基线之后，前序失败会阻止探针；没有 `workflow_dispatch`、过期探针告警、自动 Issue 或恢复 runbook。                                                                                         | 已发布快照落后 GitHub 数天或更久，维护者可能只看到普通红色 CI。                     | **必须拆成独立探针并定义检测 SLO。**                                         |
+| 合并与发布    | 发布标签会重新执行大部分静态和本地验证。                                                                                                                      | `main` 未要求 CI 状态检查；发布不运行当前 GitHub 比较或真实宿主冒烟。                                                                                                                                                       | 失败或未完成的 CI 仍可能进入主线，标签可发布未验证的宿主/上游一致性。               | **必须增加受保护门禁。**                                                     |
+
+## 改进建议（按风险和成本排序）
+
+### P0：必须纳入 v4.4
+
+1. **建立可审计的 GitHub 参照采集器（风险：严重；成本：L）。** 保留已提交快照和离线构建，但刷新时生成 provenance manifest：提取器包/版本、API 版本、抓取时间、入口页面、每个 CSS 资产 URL 与 SHA-256、解析到/保留/丢弃的 selector 和 at-rule 计数、九个主题集合、fixture 提交 SHA。对 `@media`、`data-*`、新类和 CSS 文件命名变化建立契约测试；任何相关规则被过滤必须成为显式失败或审核清单，不能静默“全绿”。若上游包无法提供这些信息，在本仓库包装或固定维护一个最小 adapter；不要求立刻自建完整 CSS 抓取器。
+2. **把漂移探针拆为独立、可手动运行且有时效 SLO 的工作流（风险：高；成本：M）。** 不让 lint、单测或本地基线失败阻止远端探针；至少每日运行并支持 `workflow_dispatch`。记录最近一次成功探针时间，超过 30 小时自动产生明确告警；真实差异创建或更新一个去重 Issue，网络/API/提取故障使用不同结论。GitHub 定时任务可能延迟或丢弃，因此 freshness 监控比单纯 cron 更重要。[GitHub `schedule` 限制](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule)
+3. **输出三方比较并接入发布门禁（风险：严重；成本：M）。** 同一报告必须区分：基线 GitHub ↔ 当前 GitHub（是否漂移）、当前扩展 ↔ 当前 GitHub（是否影响用户）、当前扩展 ↔ 已提交基线（是否内部回归），并把 fetch/extract/render/compare 分阶段记录。Marketplace 发布前必须有针对标签 SHA、未超过 24 小时的成功“当前扩展 ↔ 当前 GitHub”结果；上游故障时只允许带报告链接和原因的显式人工覆盖。
+4. **消除整图宽松预算（风险：高；成本：M）。** 拆分 platform/syntax fixture，或对已知宿主区域使用稳定空间遮罩；扩展自有区域继续零容差。任何非零预算都必须包含原因、所有者、最大区域和到期/复核条件，且报告分别统计遮罩内外差异。
+5. **强制主线与发布检查（风险：高；成本：S，需仓库管理员权限）。** 将 CI `check`、桌面最低/稳定和 Web 稳定宿主检查设为 `main` required status checks，禁止 force push；发布验证复用或重新执行宿主门禁。GitHub 官方确认 required status checks 会阻止未成功检查的合并。[GitHub 分支保护说明](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging)
+
+### P1：值得改进，可在 v4.4 容量允许时纳入
+
+1. **扩展高收益采样矩阵（风险：中；成本：M）。** 九个主题都运行一个覆盖标题、表格、代码、警告、任务列表、脚注、链接的压力 fixture；默认 light/dark 增加窄/宽视口和 link underline 开/关；为 hover/focus 增加少量状态截图。不要把全部 corpus 与全部主题做笛卡尔积。
+2. **固化恢复 runbook（风险：中；成本：S）。** 文档化“确认 provenance → 三方比较 → 刷新 baseline/CSS → 修复本地 HTML/CSS → 本地/宿主验证 → 审核快照 → 发布”的顺序，并给出回滚到上一 CSS 快照和重跑手动探针的命令。`update:parity:offline` 只能同步已验证、输入哈希相同的 HTML，这个安全边界应保留。[离线同步保护](../../../scripts/parity/cli.ts#L206-L245)
+3. **保存结构化历史指标（风险：中；成本：S/M）。** 每次探针保留 report JSON、provenance、运行 SHA 和差异摘要，用趋势而不是单次红/绿判断频繁上游变化；明确产物保留期。
+
+### 不应作为 v4.4 用户价值项的纯内部优化
+
+- 仅重命名/拆分 parity 模块、迁移测试框架、调整日志文案。
+- 只为缩短 CI 时间而并行截图或 API 请求，除非当前运行时间已经妨碍每日探针 SLO。
+- 无用户可见变化的依赖升级或快照格式美化。
+- 为绕开现有边界而新建自定义 Markdown 预览系统；这违反项目继续使用 VS Code 内置 Markdown hooks 的约束。
+
+## 建议的 v4.4 范围
+
+### 可直接拆分的实现 Ticket
+
+| Ticket 建议名                                 | 交付边界                                                          | 依赖                                            | 可测量验收标准                                                                                                                 |
+| --------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 为 GitHub CSS 快照增加 provenance 与过滤契约  | manifest、资产哈希、过滤统计、九主题完整性、提取失败分类          | `generate-github-markdown-css@6.6.0` 的适配策略 | 在合成输入中加入 `@media`、`data-*`、未知类和新 CSS 文件名时，刷新必须保留或明确失败；任一快照可由 manifest 定位全部上游输入。 |
+| 拆分独立上游漂移探针并建立 freshness SLO      | 独立 workflow、每日 cron、手动触发、30 小时过期告警、去重 Issue   | GitHub Actions `issues: write` 权限；通知归属   | 模拟 lint/单测失败时探针仍运行；最后成功时间超过 30 小时时出现可见告警；真实 diff 与网络失败产生不同结论。                     |
+| 生成 GitHub 基线/当前 GitHub/当前扩展三方报告 | 三组指标、阶段化错误、结构化 JSON/Markdown/图片产物               | provenance Ticket                               | 注入 CSS 漂移、本地插件回归、HTTP 503 和提取器异常时，四种场景分别归类且总能产生报告。                                         |
+| 隔离宿主边界并收紧像素预算                    | fixture 拆分或区域 mask、预算所有者和复核规则                     | v4.3 对宿主/平台渲染边界的结论                  | 扩展自有区域所有像素预算为 0；在原 `corpus-11` 非平台区域注入 1 px 变化时测试必失败。                                          |
+| 扩充主题、视口和交互状态的代表性矩阵          | 九主题压力 fixture、窄/宽视口、少量 hover/focus                   | v4.2 的高影响差异清单                           | 九主题均覆盖核心语义元素；至少一个窄视口能发现表格/长链接溢出；新增矩阵运行时间保持在团队设定预算内。                          |
+| 强制主线与发布一致性门禁                      | required checks、禁 force push、标签 SHA 的新鲜远端结果、宿主门禁 | 仓库管理员；前三个 Ticket                       | 通过 API 可见 `main` 必需检查；故意失败的远端当前比较或任一宿主测试无法合并/发布；人工覆盖留下原因和报告链接。                 |
+| 编写漂移恢复与回滚 runbook                    | 诊断、刷新、修复、审核、发布和回滚步骤                            | 三方报告和 provenance 的最终命令                | 维护者可用一次模拟漂移在一个 PR 内完成判因、刷新、验证与回滚演练，所有步骤引用生成的证据。                                     |
+
+### 版本依赖
+
+- **来自 v4.2：** 高影响 GitHub 渲染差异清单决定必须进入压力 fixture 的语义元素，避免 v4.4 自行发明功能范围。
+- **来自 v4.3：** 明确 VS Code 桌面/Web、语法高亮、Mermaid/GeoJSON/STL/数学渲染的所有权边界；v4.4 只把这些边界变成可执行 mask、预算和门禁。
+- **外部依赖：** GitHub Actions 与 REST API 可用性、仓库管理员修改分支保护、Issue 写权限、上游 CSS 提取器的可扩展性。GitHub Markdown API 和 Contents API 是支持的 HTML 来源，但 GitHub 完整页面 CSS 不是稳定公开 API，因此必须依靠 provenance、契约和故障分类控制风险。[GitHub Markdown API](https://docs.github.com/en/rest/markdown/markdown) · [GitHub Contents API](https://docs.github.com/en/rest/repos/contents)
+
+### 排除项
+
+- 不在 v4.4 修复具体 Markdown 语义差异；具体 parity 修复属于 v4.2。
+- 不在 v4.4 重新划分桌面/Web/伴生渲染器职责；边界决策属于 v4.3。
+- 不捆绑 Mermaid、GeoJSON、STL 或数学运行时，不创建自定义 Markdown 预览系统。
+- 不承诺跨 Firefox/Safari 或所有操作系统达到逐像素一致；扩展实际运行在 VS Code Webview/浏览器宿主，v4.4 先覆盖受支持宿主和高收益视口。
+- 不追求“所有 GitHub 页面 CSS”全量复制；目标是让纳入范围、被过滤内容和用户影响均可证明，且发布不会越过已知偏差。
+
+## v4.4 整体验收标准
+
+v4.4 只有同时满足以下条件才达到“长期回归保障”目标：
+
+1. 任一 GitHub 参照快照都带完整 provenance，过滤器遇到新的相关 selector/at-rule/主题资产时不会静默成功。
+2. 漂移探针每日且可手动运行；最近成功结果超过 30 小时会告警；前序本地 CI 失败不会阻止探针。
+3. 报告能独立回答“GitHub 是否变化”“用户当前是否受影响”“扩展是否内部回归”，并区分上游不可用与真实像素差异。
+4. 扩展自有像素区域保持零容差；宿主边界使用独立 fixture 或空间 mask，不再用整图高预算吸收差异。
+5. 九主题至少经过一个核心语义压力 fixture；默认 light/dark 至少覆盖窄/宽视口与链接下划线配置。
+6. `main` 必需检查和标签发布门禁可由 GitHub API 验证；失败的当前态 parity 或受支持宿主测试无法进入 Marketplace。
+7. 完成一次模拟上游 CSS 漂移演练：在 30 小时 SLO 内告警，生成三方报告，按 runbook 完成刷新/修复/回滚，并保留可审计证据。
+
+达到这些标准后，v4.4 才能把当前“有快照、有像素测试、有周检”提升为“参照可证明、漂移可判因、发布可阻断、恢复可演练”的完整闭环。

--- a/docs/agents/research/user-priority-evidence.md
+++ b/docs/agents/research/user-priority-evidence.md
@@ -1,0 +1,75 @@
+# 历史反馈与高价值使用场景
+
+## 结论摘要
+
+- 最明确的高价值场景是：在 VS Code 内使用内置 Markdown 预览编写 README、项目文档和最终发布到 GitHub 的内容，并尽量避免推送后才发现差异。当前 Marketplace 只有一条带文字的评价支持这一场景，因此它是方向证据，不是高频需求证据。
+- 历史外部用户 Issue 中，Mermaid 扩展冲突和 KaTeX 双滚动条是两个相关但不同的单例；它们共同提示伴生渲染边界值得验证，但不能合并为高频需求。v4.3 的最高优先级由当前已确认的 Mermaid 主题同步断点进一步支撑。
+- HTML 图片根路径和 GitHub Alerts 各有一条外部用户报告，现有版本已经覆盖；应保留为回归样例，不应在没有新缺口证据时重新包装成版本功能。
+- GitHub 语法、样式和主题一致性在 v1、v2、v4 规划及历次发布中反复出现，但主要是维护者信号。v4.2 应由当前覆盖矩阵选出仍未解决的高影响差异，不能从旧清单直接推导需求。
+- 上游漂移检测、Web 宿主支持和长期可维护性目前缺少重复的外部用户反馈。它们适合作为保护已验证场景的工程约束，而不是宣称为用户主动要求的功能。
+
+## 调研范围与证据分级
+
+检索日期为 **2026-07-15**。本次检查了：
+
+- 新路线图建立前的全部 41 个历史 GitHub Issue：35 个由维护者创建、4 个由外部用户创建、2 个由机器人创建。外部用户 Issue 是 [HTML 图片根路径](https://github.com/lzm0x219/vscode-github-markdown/issues/74)、[GitHub Alerts](https://github.com/lzm0x219/vscode-github-markdown/issues/197)、[Mermaid 扩展冲突](https://github.com/lzm0x219/vscode-github-markdown/issues/203)和 [KaTeX 双滚动条](https://github.com/lzm0x219/vscode-github-markdown/issues/604)。该快照可用 `gh issue list --state all --limit 500` 从[项目 Issue 列表](https://github.com/lzm0x219/vscode-github-markdown/issues?q=is%3Aissue)复核。
+- [v1 路线图](https://github.com/lzm0x219/vscode-github-markdown/issues/2)、[v2 路线图](https://github.com/lzm0x219/vscode-github-markdown/issues/59)和 [v4 规划](https://github.com/lzm0x219/vscode-github-markdown/issues/298)。项目没有单独的 v3 路线图 Issue，因此以 [v3.0.0](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v3.0.0)和 [v3.1.0](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v3.1.0)发布记录补足。
+- 当前 [README](https://github.com/lzm0x219/vscode-github-markdown/blob/main/README.md)、[CHANGELOG](https://github.com/lzm0x219/vscode-github-markdown/blob/main/CHANGELOG.md)和 GitHub Releases。
+- Visual Studio Marketplace 的[当前扩展页面](https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown)、[当前扩展公开评价 API](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/lzm0x219/extensions/vscode-github-markdown/reviews?api-version=7.2-preview.1)和[旧扩展公开评价 API](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/lzm0x219/extensions/vscode-markdown-github/reviews?api-version=7.2-preview.1)。当前扩展只有一条带文字评价；旧扩展有两条仅评分评价，其中一名评价者与当前扩展评价者相同，不能重复计为独立证据。
+
+本文使用以下分级，避免把维护者规划误写成用户需求：
+
+| 分级           | 判定标准                                                           |
+| -------------- | ------------------------------------------------------------------ |
+| 高频用户证据   | 至少两名独立外部用户报告同一类需求；本样本很小，不代表整体用户分布 |
+| 单例用户证据   | 一名外部用户的 Issue 或带文字公开评价                              |
+| 维护者反复信号 | 同一方向至少出现在两个维护者拥有的路线图、发布记录或项目说明中     |
+| 维护者假设     | 只有维护者单次规划或未验证 TODO 支持                               |
+
+## 使用场景与证据矩阵
+
+| 使用场景                                               | 证据与出现频率                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 影响                                                   | 现有覆盖                                                                                                                                                                          | 未解决问题                                                                                                                               | 版本对应                                                                        |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| 在本地编写 README 和项目文档，预览接近最终 GitHub 效果 | **单例用户 + 维护者反复信号。** 当前 Marketplace 的唯一文字评价明确提到 README、项目文档、最终发布到 GitHub 的内容，并认可内置预览工作流；[README](https://github.com/lzm0x219/vscode-github-markdown/blob/main/README.md#why-this-project)把减少推送后的渲染意外定义为项目目标；[v1 路线图](https://github.com/lzm0x219/vscode-github-markdown/issues/2)和 [v2 路线图](https://github.com/lzm0x219/vscode-github-markdown/issues/59)持续强调完整样式与主题一致性                                                                                                                          | 高：这是扩展存在的核心价值                             | 内置预览增强、GitHub 语法、九套主题及像素回归已覆盖                                                                                                                               | 没有尚未解决的具体用户报告；需由一致性覆盖矩阵确认当前高影响缺口                                                                         | **v4.2 主场景**；v4.4 保护其长期稳定性                                          |
+| 与 Mermaid、KaTeX 等伴生渲染器共同工作，不破坏预览     | **两个相关的单例用户证据。** [Mermaid 扩展冲突](https://github.com/lzm0x219/vscode-github-markdown/issues/203)和 [KaTeX 双滚动条](https://github.com/lzm0x219/vscode-github-markdown/issues/604)来自两名独立用户，但故障类型不同；[v2 路线图](https://github.com/lzm0x219/vscode-github-markdown/issues/59)、[v3.1.0](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v3.1.0)、[v4.0.0](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v4.0.0)和 [v4.1.1](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v4.1.1)显示项目多次调整集成方式 | 高：冲突会使图表退化成代码块或导致预览不可用           | v4 不再内置 Mermaid，改为同步 `markdown-mermaid` 主题；README 声明对 Mermaid、GeoJSON、STL、数学等宿主渲染内容设置独立回归预算                                                    | 当前公开证据没有证明 Mermaid 与数学渲染在桌面端、Web 端及不同伴生扩展组合中都可靠；旧版“内置渲染”与 v4“伴生扩展”模型也未经过用户对比验证 | **v4.3 最高优先级候选**；v4.3 建立真实宿主回归，v4.4 将其接入持续探针与发布门禁 |
+| GitHub 新语法或样式出现后，本地预览及时跟进            | **单例用户 + 维护者反复信号。** 用户通过 [Alerts 请求](https://github.com/lzm0x219/vscode-github-markdown/issues/197)要求跟进 GitHub 已支持的块引用语法；[v4 规划](https://github.com/lzm0x219/vscode-github-markdown/issues/298)再次要求同步块引用和标题样式；[v3.0.0](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v3.0.0)和 [v4.0.0](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v4.0.0)记录了交付                                                                                                                                               | 中高：语法不识别会直接造成 GitHub 与本地输出不同       | v4 已支持五类 GitHub Alerts；[CI](https://github.com/lzm0x219/vscode-github-markdown/blob/main/.github/workflows/ci.yml)执行本地像素基线，并定时检查远端 GitHub Markdown 渲染漂移 | 缺少对“GitHub 新能力发现—纳入样例—发布”的覆盖与时效证据；需结合上游漂移和一致性覆盖调研判断                                              | **v4.2** 处理已确认的语义/视觉缺口；**v4.4** 处理持续发现机制                   |
+| 项目根路径形式的 HTML 图片在本地预览正常显示           | **单例用户证据。** [Issue #74](https://github.com/lzm0x219/vscode-github-markdown/issues/74)给出可复现失败；[v2.0.1](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v2.0.1)交付路径兼容；[v4.0.0](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v4.0.0)继续保留                                                                                                                                                                                                                                                                                         | 对使用根路径组织仓库文档的用户影响高，但证据只出现一次 | v4 会把 HTML `<img>` 的根路径改写为 Webview 可用路径                                                                                                                              | 当前无未解决报告；应验证并保留回归样例，不应默认需要新增功能                                                                             | **v4.2 回归基线**，除非覆盖矩阵发现新缺口                                       |
+| 保留 VS Code 内置 Markdown 预览及其快速、原生工作流    | **单例用户 + 明确产品约束。** 当前 Marketplace 文字评价认可快速预览、与内置工作流无缝集成及不替换原生流程的方向；[README Quick Start](https://github.com/lzm0x219/vscode-github-markdown/blob/main/README.md#quick-start)明确不引入独立预览编辑器                                                                                                                                                                                                                                                                                                                                          | 高：替换工作流会改变产品定位并扩大兼容面               | v4 通过 VS Code 内置 Markdown 扩展钩子工作                                                                                                                                        | 伴生渲染器冲突说明“原生”不自动等于“可组合”；仍需跨扩展验证                                                                               | **v4.3 设计约束**，不是独立功能                                                 |
+| 深色、浅色及无障碍主题下保持 GitHub 外观               | **维护者反复信号，缺少独立需求报告。** [v1 路线图](https://github.com/lzm0x219/vscode-github-markdown/issues/2)、[v2 路线图](https://github.com/lzm0x219/vscode-github-markdown/issues/59)、[v1.2.0](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v1.2.0)、[v2.0.0](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v2.0.0)和 v4 发布记录持续投入主题；当前文字评价只笼统认可样式，不能证明具体主题需求                                                                                                                                                 | 中高：视觉偏差直接损害核心承诺，但当前没有公开缺陷     | 九套 GitHub 主题、Single/System 模式、链接下划线和 Mermaid 主题同步已覆盖                                                                                                         | 没有公开用户报告指出具体主题缺口；不应仅凭历史投入扩展更多主题或配置                                                                     | **v4.4 回归保护**；只有发现具体差异时进入 v4.2                                  |
+| 桌面端与 Web 扩展宿主行为一致                          | **维护者假设。** [v4 规划](https://github.com/lzm0x219/vscode-github-markdown/issues/298)要求 Web 扩展支持，[README](https://github.com/lzm0x219/vscode-github-markdown/blob/main/README.md#desktop-and-web)记录当前覆盖；未发现外部用户请求或缺陷                                                                                                                                                                                                                                                                                                                                         | 潜在影响高，但需求频率未知                             | 当前声明支持桌面端和 Web 端并执行宿主冒烟测试                                                                                                                                     | 尚无公开证据说明用户主要使用哪些 Web 场景，也没有具体跨宿主差异报告                                                                      | **v4.3 兼容性门槛**，不宜单独宣称为用户优先功能                                 |
+
+## 证据不足或相互冲突的需求
+
+1. **Mermaid 应内置还是由伴生扩展提供。** [Issue #203](https://github.com/lzm0x219/vscode-github-markdown/issues/203)最初报告与 `markdown-mermaid` 冲突，v3.1 通过内置 Mermaid 处理；[v4.0.0](https://github.com/lzm0x219/vscode-github-markdown/releases/tag/v4.0.0)又改为不内置渲染器。现有资料证明“不能互相破坏”，但不能证明用户偏好哪种交付模型。v4.3 应验证可组合性，不应重启架构争论，除非出现新证据。
+2. **GeoJSON、TopoJSON、STL、数学表达式和代码块复制的优先级。** 它们来自 [v2 路线图](https://github.com/lzm0x219/vscode-github-markdown/issues/59)的维护者清单；除 KaTeX 布局缺陷外，没有独立用户需求证据。是否纳入后续版本应由当前 GitHub 能力覆盖和宿主边界决定。
+3. **Emoji 自动补全和任务列表关联 Issue/PR。** [Emoji Issue](https://github.com/lzm0x219/vscode-github-markdown/issues/22)和[任务列表 Issue](https://github.com/lzm0x219/vscode-github-markdown/issues/21)保留了 TODO，但它们偏向编辑辅助或 GitHub 服务端上下文，且没有外部反馈，不应从旧 TODO 自动进入 v4.2–v4.4。
+4. **Web 宿主、链接下划线与迁移体验。** 当前实现和发布记录覆盖这些方向，但没有公开用户报告能排序其后续投入。它们应作为兼容或回归约束，除非新的可复现问题改变证据等级。
+5. **Marketplace 样本量不足。** 当前扩展只有一条文字评价；旧扩展两条评价均无文字，且其中一名评价者与当前扩展重合。评分可以证明满意度个例，不能用于推断功能频率或版本优先级。
+6. **当前没有未解决的用户功能积压。** 除机器人依赖面板和本次 Wayfinder Ticket 外，没有开放的用户功能或缺陷 Issue；因此任何新功能承诺都需要覆盖矩阵、上游差异或新反馈支持。
+
+## 对 v4.2–v4.4 的优先级建议
+
+### v4.2：高影响 GitHub 渲染差异
+
+1. 以“README/项目文档发布到 GitHub 前的本地预览”作为价值判断场景。
+2. 由一致性覆盖矩阵选择仍然存在、可复现且影响该场景的差异；历史上已解决的 Alerts 和 HTML 图片路径只作为回归基线。
+3. 不因 v1/v2 旧清单或单个未验证 TODO 承诺编辑辅助、服务端交互或新的客户端渲染器。
+
+### v4.3：跨宿主与伴生渲染器兼容
+
+1. 优先验证 Mermaid 与数学渲染边界：两类历史故障各有一个独立用户报告，且当前宿主调研已确认 Mermaid 主题同步断点。
+2. 在桌面端和 Web 端检查内置预览、主题切换、长内容滚动及伴生扩展启停；保持“不自建预览系统”的已确认边界。
+3. 对 GeoJSON、STL 等宿主渲染能力先验证责任边界，再决定是否需要项目实现 Ticket。
+
+### v4.4：上游漂移与长期回归保障
+
+1. 把主题、GitHub 新语法、HTML 图片路径及 v4.3 已建立的伴生渲染器用例接入持续探针与发布门禁，优先保护已有用户价值。
+2. 将漂移检测表述为降低本地与 GitHub 再次分叉的风险，而不是声称存在高频用户请求。
+3. 为后续反馈保留“宿主、伴生扩展、GitHub 示例、最小复现”字段，使新的单例能够被聚合为可判断的频率证据。
+
+## 给其他调研 Ticket 的校正信号
+
+- 一致性覆盖调研应优先回答核心 README/文档场景中的未解决差异，不要把“历史上做过”视为“当前仍有需求”。
+- 跨宿主兼容调研应把 Mermaid 与数学渲染列为第一组组合测试；Web 支持本身只有维护者证据，应按风险验证而非按需求频率排序。
+- 漂移与回归调研应覆盖 Alerts、HTML 图片根路径、主题和伴生渲染器边界；这些样例分别代表上游变化、宿主路径差异、视觉一致性和扩展组合风险。
+- 最终版本汇总应保留证据等级。伴生渲染器只有两个不同故障类型的相关单例；其优先级还需要当前技术断点支撑，其他候选项同样需技术覆盖或新反馈补强。


### PR DESCRIPTION
## 变更

新增四份中文路线图研究资产：

- GitHub Markdown 一致性覆盖矩阵
- 跨宿主与伴生渲染器兼容矩阵
- 上游漂移与回归保障缺口
- 历史反馈与高价值使用场景

## 关键结论

- v4.2 暂无已证实的真实宿主缺口，三个候选必须先验证后实施
- VS Code 1.121+ 内置 Mermaid 使当前主题同步探测失效
- v4.4 需要可审计 CSS provenance、独立漂移探针、三方报告与发布门禁
- Mermaid 与 KaTeX 历史问题是两个相关单例，不作为高频需求证据

## 验证

- `nubx oxfmt --check docs/agents/research/*.md`
- `git diff --cached --check`
- 宿主/主题相关的 5 个聚焦测试文件共 26 项测试通过
- 研究文档独立交叉复核，无阻断级事实错误