### PR TITLE
feat(markdown): support single-tilde strikethrough

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,12 +15,13 @@ VS Code commands ────────────────> src/commands.
 
 `activate` registers every command and configuration listener in the extension context, then returns `extendMarkdownIt`. VS Code calls that hook with its own `markdown-it` instance. The plugin order is intentional:
 
-1. task lists
-2. alerts
-3. emoji
-4. footnotes
-5. theme metadata
-6. HTML image URL rewriting
+1. GitHub-compatible strikethrough
+2. task lists
+3. alerts
+4. emoji
+5. footnotes
+6. theme metadata
+7. HTML image URL rewriting
 
 Each behavior lives under `src/plugins/`. Plugins transform tokens or renderer rules while the built-in preview remains responsible for document lifecycle, webview security, syntax highlighting, and navigation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+### Markdown preview
+
+- Text wrapped in single tildes now appears struck through to match GitHub, while double tildes, escapes, code spans, empty or unmatched markers, and longer tilde runs keep their existing behavior.
+
 ## [v4.1.1] - 2026-07-15
 
 v4.1.1 keeps Mermaid diagrams aligned with both preview color schemes and restores your previous Mermaid preferences when synchronization is turned off. It also makes the extension easier to find and its installation, migration, and theme controls clearer.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This project focuses on three practical outcomes:
 ### GitHub-Flavored Markdown
 
 - **Task Lists** — `- [x]` and `- [ ]` render as GitHub-style disabled checkboxes.
+- **Strikethrough** — `~text~` renders as GitHub-style strikethrough while existing `~~text~~` syntax, escapes, and inline code remain intact.
 - **Footnotes** — `[^1]` references with automatic numbering, backrefs, and a footnotes section at the bottom.
 - **Alerts** — `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, and `[!CAUTION]` render with proper icons and styling.
 - **Emoji Shortcodes** — `:rocket:`, `:+1:`, `:tada:` and thousands more, including both Unicode emoji and image-based custom emoji from GitHub.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,6 +62,7 @@ VS Code 自带的 Markdown Preview 更偏通用渲染，而开发者真正关心
 ### GitHub 风格 Markdown
 
 - **任务列表** — `- [x]` 和 `- [ ]` 渲染为 GitHub 风格的禁用复选框。
+- **删除线** — `~文本~` 会渲染为 GitHub 风格删除线，同时保留既有的 `~~文本~~` 语法、转义和行内代码行为。
 - **脚注** — `[^1]` 引用自动编号、自动回跳链接，并在文末生成脚注区域。
 - **Alerts** — `[!NOTE]`、`[!TIP]`、`[!IMPORTANT]`、`[!WARNING]`、`[!CAUTION]` 五种提示框，附带正确的图标和样式。
 - **Emoji 短代码** — `:rocket:`、`:+1:`、`:tada:` 等数千个短代码，同时支持 Unicode emoji 和 GitHub 自定义图片 emoji。

--- a/scripts/parity/cases.ts
+++ b/scripts/parity/cases.ts
@@ -19,7 +19,7 @@ export type VisualParityCase = {
 
 const fixtures = {
   formatting:
-    "# Heading\n\n**Bold**, *italic*, ~~deleted~~, and `inline code`.\n\n> A blockquote.\n",
+    "# Heading\n\n**Bold**, *italic*, ~~Hi~~ Hello, ~there~ world!, and `inline code`.\n\n> A blockquote.\n",
   lists:
     "- [x] Completed task\n- [ ] Pending task\n\n| Feature | Status |\n| --- | --- |\n| Tables | Supported |\n",
   alerts: "> [!NOTE]\n> Useful information.\n\n> [!WARNING]\n> Check this carefully.\n",

--- a/scripts/parity/local.ts
+++ b/scripts/parity/local.ts
@@ -3,10 +3,12 @@ import alerts from "../../src/plugins/markdown-it-github-alerts";
 import emoji from "../../src/plugins/markdown-it-github-emoji";
 import footnotes from "../../src/plugins/markdown-it-github-footnotes";
 import imageUrl from "../../src/plugins/markdown-it-github-image-url";
+import strikethrough from "../../src/plugins/markdown-it-github-strikethrough";
 import taskLists from "../../src/plugins/markdown-it-github-task-lists";
 
 export function renderLocalMarkdown(markdown: string): string {
   return new MarkdownIt({ html: true, linkify: true })
+    .use(strikethrough)
     .use(taskLists)
     .use(alerts)
     .use(emoji)

--- a/scripts/verify/index.ts
+++ b/scripts/verify/index.ts
@@ -13,5 +13,7 @@ registerHooks({
 const { verifyMarkdownCompatibility } = await import("./markdown");
 verifyMarkdownCompatibility();
 
-console.log("Verified task lists, footnotes, alerts, emoji, and Mermaid dependency boundaries");
+console.log(
+  "Verified task lists, footnotes, alerts, emoji, strikethrough, and Mermaid dependency boundaries"
+);
 console.log("Visual fixture: tests/fixtures/github-flavored-markdown-checklist.md");

--- a/scripts/verify/markdown.ts
+++ b/scripts/verify/markdown.ts
@@ -4,11 +4,13 @@ import { readFileSync } from "node:fs";
 import githubAlerts from "../../src/plugins/markdown-it-github-alerts";
 import githubEmoji from "../../src/plugins/markdown-it-github-emoji";
 import githubFootnotes from "../../src/plugins/markdown-it-github-footnotes";
+import githubStrikethrough from "../../src/plugins/markdown-it-github-strikethrough";
 import githubTaskLists from "../../src/plugins/markdown-it-github-task-lists";
 import { project } from "../shared/project";
 
 export function verifyMarkdownCompatibility(): void {
   const markdown = new MarkdownIt({ html: true })
+    .use(githubStrikethrough)
     .use(githubTaskLists)
     .use(githubAlerts)
     .use(githubEmoji)
@@ -18,7 +20,24 @@ export function verifyMarkdownCompatibility(): void {
   verifyFootnotes(markdown);
   verifyAlerts(markdown);
   verifyEmoji(markdown);
+  verifyStrikethrough(markdown);
   verifyMermaidBoundary();
+}
+
+function verifyStrikethrough(markdown: MarkdownIt): void {
+  const html = markdown.render(
+    "~~Hi~~ Hello, ~there~ world!\n\n\\~escaped\\~ `~code~` ~~ ~open ~~~not~~~\n"
+  );
+  assert.match(
+    html,
+    /<s>Hi<\/s> Hello, <del>there<\/del> world!/,
+    "single-tilde strikethrough and existing double-tilde markup"
+  );
+  assert.match(
+    html,
+    /~escaped~ <code>~code~<\/code> ~~ ~open ~~~not~~~/,
+    "literal escaped, code-span, empty, unmatched, and long tilde sequences"
+  );
 }
 
 function verifyTaskLists(markdown: MarkdownIt): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import alerts from "./plugins/markdown-it-github-alerts";
 import emoji from "./plugins/markdown-it-github-emoji";
 import footnotes from "./plugins/markdown-it-github-footnotes";
 import imageUrl from "./plugins/markdown-it-github-image-url";
+import strikethrough from "./plugins/markdown-it-github-strikethrough";
 import taskLists from "./plugins/markdown-it-github-task-lists";
 import theme from "./plugins/markdown-it-github-theme";
 
@@ -24,7 +25,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<{
 
   return {
     extendMarkdownIt(md: MarkdownIt): MarkdownIt {
-      return md.use(taskLists).use(alerts).use(emoji).use(footnotes).use(theme).use(imageUrl);
+      return md
+        .use(strikethrough)
+        .use(taskLists)
+        .use(alerts)
+        .use(emoji)
+        .use(footnotes)
+        .use(theme)
+        .use(imageUrl);
     }
   };
 }

--- a/src/plugins/markdown-it-github-strikethrough.ts
+++ b/src/plugins/markdown-it-github-strikethrough.ts
@@ -1,0 +1,88 @@
+import type MarkdownIt from "markdown-it";
+import type StateInline from "markdown-it/lib/rules_inline/state_inline.mjs";
+import type { Delimiter } from "markdown-it/lib/rules_inline/state_inline.mjs";
+
+const tildeCharacter = 0x7e;
+const singleTildeDelimiter = 0x1007e;
+const doubleTildeDelimiter = 0x2007e;
+
+export default function markdownItGitHubStrikethrough(md: MarkdownIt): MarkdownIt {
+  md.inline.ruler.at("strikethrough", tokenizeStrikethrough);
+  md.inline.ruler2.at("strikethrough", postProcessStrikethrough);
+  return md;
+}
+
+function tokenizeStrikethrough(state: StateInline, silent: boolean): boolean {
+  if (silent || state.src.charCodeAt(state.pos) !== tildeCharacter) {
+    return false;
+  }
+
+  const scanned = state.scanDelims(state.pos, true);
+  const token = state.push("text", "", 0);
+  token.content = "~".repeat(scanned.length);
+  state.pos += scanned.length;
+
+  if (scanned.length > 2) {
+    return true;
+  }
+
+  state.delimiters.push({
+    marker: scanned.length === 1 ? singleTildeDelimiter : doubleTildeDelimiter,
+    length: 0,
+    token: state.tokens.length - 1,
+    end: -1,
+    open: scanned.can_open,
+    close: scanned.can_close
+  });
+  return true;
+}
+
+function postProcessStrikethrough(state: StateInline): boolean {
+  applyStrikethroughTokens(state, state.delimiters);
+
+  for (const metadata of state.tokens_meta) {
+    if (metadata) {
+      applyStrikethroughTokens(state, metadata.delimiters);
+    }
+  }
+
+  return true;
+}
+
+function applyStrikethroughTokens(state: StateInline, delimiters: Delimiter[]): void {
+  for (const opening of delimiters) {
+    if (!isStrikethroughDelimiter(opening.marker) || opening.end < 0) {
+      continue;
+    }
+
+    const closing = delimiters[opening.end];
+    if (!closing) {
+      continue;
+    }
+
+    const isSingleTilde = opening.marker === singleTildeDelimiter;
+    const markup = isSingleTilde ? "~" : "~~";
+    const tag = isSingleTilde ? "del" : "s";
+    const openingToken = state.tokens[opening.token];
+    const closingToken = state.tokens[closing.token];
+    if (!openingToken || !closingToken) {
+      continue;
+    }
+
+    openingToken.type = `${tag}_open`;
+    openingToken.tag = tag;
+    openingToken.nesting = 1;
+    openingToken.markup = markup;
+    openingToken.content = "";
+
+    closingToken.type = `${tag}_close`;
+    closingToken.tag = tag;
+    closingToken.nesting = -1;
+    closingToken.markup = markup;
+    closingToken.content = "";
+  }
+}
+
+function isStrikethroughDelimiter(marker: number): boolean {
+  return marker === singleTildeDelimiter || marker === doubleTildeDelimiter;
+}

--- a/tests/fixtures/parity-baseline.json
+++ b/tests/fixtures/parity-baseline.json
@@ -6,8 +6,8 @@
   "referenceCssSha256": "dea7b713f96c2de158406beaedecae58f936455dd0fdc15bd95604cebdb42167",
   "cases": {
     "formatting-light": {
-      "markdownSha256": "26d9429332e8f08003b2e8a28b161fd4c586bfbf6c9beb556632a8600eedd06b",
-      "inputSha256": "830dd580e5249adc2703474ec1f26bcc3d6ba0c00cc8bee712a6df9c471dd09f",
+      "markdownSha256": "16496fee7215af02a09d7e51d9bd1aacef9840cf9946c8a16dc73c58d244303d",
+      "inputSha256": "115f3c7da70ccb9fdb47a3e744b2b772432b81c9141f20dde49796603d71c738",
       "theme": "light",
       "themeName": "light",
       "linkUnderlines": true,
@@ -18,11 +18,11 @@
       "localComparison": {
         "kind": "exact"
       },
-      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>deleted</del>, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
+      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>Hi</del> Hello, <del>there</del> world!, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
     },
     "formatting-dark": {
-      "markdownSha256": "26d9429332e8f08003b2e8a28b161fd4c586bfbf6c9beb556632a8600eedd06b",
-      "inputSha256": "830dd580e5249adc2703474ec1f26bcc3d6ba0c00cc8bee712a6df9c471dd09f",
+      "markdownSha256": "16496fee7215af02a09d7e51d9bd1aacef9840cf9946c8a16dc73c58d244303d",
+      "inputSha256": "115f3c7da70ccb9fdb47a3e744b2b772432b81c9141f20dde49796603d71c738",
       "theme": "dark",
       "themeName": "dark",
       "linkUnderlines": true,
@@ -33,7 +33,7 @@
       "localComparison": {
         "kind": "exact"
       },
-      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>deleted</del>, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
+      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>Hi</del> Hello, <del>there</del> world!, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
     },
     "lists-light": {
       "markdownSha256": "15905b348c41ff6b43e4f077053aca7594c75aa150d52ccd8e07bef846efe06f",
@@ -838,8 +838,8 @@
       "githubHtml": "<div class=\"markdown-heading\" dir=\"auto\"><h1 class=\"heading-element\" dir=\"auto\">十二、HTML 元素</h1><a id=\"user-content-十二html-元素\" class=\"anchor\" aria-label=\"Permalink: 十二、HTML 元素\" href=\"#十二html-元素\"><svg data-component=\"Octicon\" class=\"octicon octicon-link\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path d=\"m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z\"></path></svg></a></div>\n<blockquote>\n<p dir=\"auto\"><strong>用途：</strong> 在 VS Code 中打开此文件，使用 <code>vscode-github-markdown</code> 预览，与 <a href=\"https://github.com/lzm0x219/vscode-github-markdown/blob/main/test/fixtures/github-flavored-markdown/12-html-elements.md\">GitHub 上的渲染结果</a> 逐项对比。</p>\n<p dir=\"auto\"><strong>索引：</strong> <a href=\"../github-flavored-markdown-checklist.md\">返回总清单</a></p>\n</blockquote>\n<p dir=\"auto\"><strong><code>&lt;kbd&gt;</code> 键盘按键：</strong></p>\n<p dir=\"auto\">按 <kbd>Ctrl</kbd> + <kbd>C</kbd> 复制，按 <kbd>Command</kbd> + <kbd>V</kbd> 粘贴。</p>\n<hr>\n"
     },
     "theme-light_colorblind": {
-      "markdownSha256": "26d9429332e8f08003b2e8a28b161fd4c586bfbf6c9beb556632a8600eedd06b",
-      "inputSha256": "830dd580e5249adc2703474ec1f26bcc3d6ba0c00cc8bee712a6df9c471dd09f",
+      "markdownSha256": "16496fee7215af02a09d7e51d9bd1aacef9840cf9946c8a16dc73c58d244303d",
+      "inputSha256": "115f3c7da70ccb9fdb47a3e744b2b772432b81c9141f20dde49796603d71c738",
       "theme": "light",
       "themeName": "light_colorblind",
       "linkUnderlines": true,
@@ -850,11 +850,11 @@
       "localComparison": {
         "kind": "exact"
       },
-      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>deleted</del>, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
+      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>Hi</del> Hello, <del>there</del> world!, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
     },
     "theme-light_high_contrast": {
-      "markdownSha256": "26d9429332e8f08003b2e8a28b161fd4c586bfbf6c9beb556632a8600eedd06b",
-      "inputSha256": "830dd580e5249adc2703474ec1f26bcc3d6ba0c00cc8bee712a6df9c471dd09f",
+      "markdownSha256": "16496fee7215af02a09d7e51d9bd1aacef9840cf9946c8a16dc73c58d244303d",
+      "inputSha256": "115f3c7da70ccb9fdb47a3e744b2b772432b81c9141f20dde49796603d71c738",
       "theme": "light",
       "themeName": "light_high_contrast",
       "linkUnderlines": true,
@@ -865,11 +865,11 @@
       "localComparison": {
         "kind": "exact"
       },
-      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>deleted</del>, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
+      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>Hi</del> Hello, <del>there</del> world!, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
     },
     "theme-light_tritanopia": {
-      "markdownSha256": "26d9429332e8f08003b2e8a28b161fd4c586bfbf6c9beb556632a8600eedd06b",
-      "inputSha256": "830dd580e5249adc2703474ec1f26bcc3d6ba0c00cc8bee712a6df9c471dd09f",
+      "markdownSha256": "16496fee7215af02a09d7e51d9bd1aacef9840cf9946c8a16dc73c58d244303d",
+      "inputSha256": "115f3c7da70ccb9fdb47a3e744b2b772432b81c9141f20dde49796603d71c738",
       "theme": "light",
       "themeName": "light_tritanopia",
       "linkUnderlines": true,
@@ -880,11 +880,11 @@
       "localComparison": {
         "kind": "exact"
       },
-      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>deleted</del>, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
+      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>Hi</del> Hello, <del>there</del> world!, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
     },
     "theme-dark_colorblind": {
-      "markdownSha256": "26d9429332e8f08003b2e8a28b161fd4c586bfbf6c9beb556632a8600eedd06b",
-      "inputSha256": "830dd580e5249adc2703474ec1f26bcc3d6ba0c00cc8bee712a6df9c471dd09f",
+      "markdownSha256": "16496fee7215af02a09d7e51d9bd1aacef9840cf9946c8a16dc73c58d244303d",
+      "inputSha256": "115f3c7da70ccb9fdb47a3e744b2b772432b81c9141f20dde49796603d71c738",
       "theme": "dark",
       "themeName": "dark_colorblind",
       "linkUnderlines": true,
@@ -895,11 +895,11 @@
       "localComparison": {
         "kind": "exact"
       },
-      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>deleted</del>, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
+      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>Hi</del> Hello, <del>there</del> world!, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
     },
     "theme-dark_dimmed": {
-      "markdownSha256": "26d9429332e8f08003b2e8a28b161fd4c586bfbf6c9beb556632a8600eedd06b",
-      "inputSha256": "830dd580e5249adc2703474ec1f26bcc3d6ba0c00cc8bee712a6df9c471dd09f",
+      "markdownSha256": "16496fee7215af02a09d7e51d9bd1aacef9840cf9946c8a16dc73c58d244303d",
+      "inputSha256": "115f3c7da70ccb9fdb47a3e744b2b772432b81c9141f20dde49796603d71c738",
       "theme": "dark",
       "themeName": "dark_dimmed",
       "linkUnderlines": true,
@@ -910,11 +910,11 @@
       "localComparison": {
         "kind": "exact"
       },
-      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>deleted</del>, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
+      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>Hi</del> Hello, <del>there</del> world!, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
     },
     "theme-dark_high_contrast": {
-      "markdownSha256": "26d9429332e8f08003b2e8a28b161fd4c586bfbf6c9beb556632a8600eedd06b",
-      "inputSha256": "830dd580e5249adc2703474ec1f26bcc3d6ba0c00cc8bee712a6df9c471dd09f",
+      "markdownSha256": "16496fee7215af02a09d7e51d9bd1aacef9840cf9946c8a16dc73c58d244303d",
+      "inputSha256": "115f3c7da70ccb9fdb47a3e744b2b772432b81c9141f20dde49796603d71c738",
       "theme": "dark",
       "themeName": "dark_high_contrast",
       "linkUnderlines": true,
@@ -925,11 +925,11 @@
       "localComparison": {
         "kind": "exact"
       },
-      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>deleted</del>, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
+      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>Hi</del> Hello, <del>there</del> world!, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
     },
     "theme-dark_tritanopia": {
-      "markdownSha256": "26d9429332e8f08003b2e8a28b161fd4c586bfbf6c9beb556632a8600eedd06b",
-      "inputSha256": "830dd580e5249adc2703474ec1f26bcc3d6ba0c00cc8bee712a6df9c471dd09f",
+      "markdownSha256": "16496fee7215af02a09d7e51d9bd1aacef9840cf9946c8a16dc73c58d244303d",
+      "inputSha256": "115f3c7da70ccb9fdb47a3e744b2b772432b81c9141f20dde49796603d71c738",
       "theme": "dark",
       "themeName": "dark_tritanopia",
       "linkUnderlines": true,
@@ -940,7 +940,7 @@
       "localComparison": {
         "kind": "exact"
       },
-      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>deleted</del>, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
+      "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>Hi</del> Hello, <del>there</del> world!, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
     }
   }
 }

--- a/tests/host/smoke.ts
+++ b/tests/host/smoke.ts
@@ -19,7 +19,24 @@ export async function run(): Promise<void> {
     "Theme commands are registered after activation"
   );
 
-  const markdown = "- [x] Host smoke test\n\n> [!NOTE]\n> :rocket: Ready.";
+  const markdown = [
+    "- [x] Host smoke test",
+    "",
+    "> [!NOTE]",
+    "> :rocket: Ready.",
+    "",
+    "~~Hi~~ Hello, ~there~ world!",
+    "",
+    "Escaped: \\~escaped\\~.",
+    "",
+    "Code: `~code~`.",
+    "",
+    "Empty: ~~.",
+    "",
+    "Unmatched: ~open.",
+    "",
+    "Long run: ~~~not~~~."
+  ].join("\n");
   const directHtml = api.extendMarkdownIt(new MarkdownIt({ html: true })).render(markdown);
   assertRenderedMarkdown(directHtml, "exported Markdown-it hook");
 
@@ -41,6 +58,13 @@ function assertRenderedMarkdown(html: string | undefined, source: string): void 
   assert(html.includes("task-list-item-checkbox"), "Task lists are rendered");
   assert(html.includes("markdown-alert-note"), "Alerts are rendered");
   assert(html.includes("🚀"), "Emoji shortcodes are rendered");
+  assert(html.includes("<s>Hi</s>"), "Double-tilde strikethrough keeps its existing markup");
+  assert(html.includes("<del>there</del>"), "Single-tilde strikethrough is rendered");
+  assert(html.includes("Escaped: ~escaped~."), "Escaped tildes remain literal");
+  assert(html.includes("<code>~code~</code>"), "Tildes in code spans remain literal");
+  assert(html.includes("Empty: ~~."), "Empty strikethrough delimiters remain literal");
+  assert(html.includes("Unmatched: ~open."), "Unmatched tildes remain literal");
+  assert(html.includes("Long run: ~~~not~~~."), "Runs longer than two tildes remain literal");
 }
 
 function assert(value: unknown, message: string): asserts value {

--- a/tests/plugins/integration.test.ts
+++ b/tests/plugins/integration.test.ts
@@ -31,11 +31,13 @@ import alerts from "../../src/plugins/markdown-it-github-alerts";
 import emoji from "../../src/plugins/markdown-it-github-emoji";
 import footnotes from "../../src/plugins/markdown-it-github-footnotes";
 import imageUrl from "../../src/plugins/markdown-it-github-image-url";
+import strikethrough from "../../src/plugins/markdown-it-github-strikethrough";
 import taskLists from "../../src/plugins/markdown-it-github-task-lists";
 import theme from "../../src/plugins/markdown-it-github-theme";
 
 function createChain(): MarkdownIt {
   return new MarkdownIt({ html: true })
+    .use(strikethrough)
     .use(taskLists)
     .use(alerts)
     .use(emoji)

--- a/tests/plugins/strikethrough.test.ts
+++ b/tests/plugins/strikethrough.test.ts
@@ -1,0 +1,25 @@
+import MarkdownIt from "markdown-it";
+import { describe, expect, it } from "vitest";
+import strikethrough from "../../src/plugins/markdown-it-github-strikethrough";
+
+function render(markdown: string): string {
+  return new MarkdownIt().use(strikethrough).render(markdown);
+}
+
+describe("markdown-it-github-strikethrough", () => {
+  it("adds del markup for one tilde and preserves existing markup for two", () => {
+    expect(render("~~Hi~~ Hello, ~there~ world!\n")).toBe(
+      "<p><s>Hi</s> Hello, <del>there</del> world!</p>\n"
+    );
+  });
+
+  it.each([
+    ["escaped tildes", "\\~escaped\\~\n", "<p>~escaped~</p>\n"],
+    ["code spans", "`~code~`\n", "<p><code>~code~</code></p>\n"],
+    ["empty delimiters", "~~\n", "<p>~~</p>\n"],
+    ["unmatched delimiters", "~open\n", "<p>~open</p>\n"],
+    ["runs longer than two", "Long: ~~~not~~~.\n", "<p>Long: ~~~not~~~.</p>\n"]
+  ])("keeps %s literal", (_name, markdown, expected) => {
+    expect(render(markdown)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## 变更

- 通过现有 Markdown-it 扩展钩子支持单波浪线删除线
- 保留双波浪线、转义、代码跨度、空内容和未配对标记的既有行为
- 同步中英文文档、CHANGELOG、宿主验证与 GitHub 视觉基线

## 验证

- VS Code 1.74 桌面端、稳定版桌面端、稳定版 Web 端
- 187 项单元测试
- oxlint、type-aware lint、oxfmt
- Markdown 兼容性校验、视觉一致性（0 像素差异）、VSIX 打包

Closes #1134