### PR TITLE
feat(markdown): match GFM tagfilter behavior for raw HTML

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,12 +16,13 @@ VS Code commands ────────────────> src/commands.
 `activate` registers every command and configuration listener in the extension context, then returns `extendMarkdownIt`. VS Code calls that hook with its own `markdown-it` instance. The plugin order is intentional:
 
 1. GitHub-compatible strikethrough
-2. task lists
-3. alerts
-4. emoji
-5. footnotes
-6. theme metadata
-7. HTML image URL rewriting
+2. GFM tagfilter
+3. task lists
+4. alerts
+5. emoji
+6. footnotes
+7. theme metadata
+8. HTML image URL rewriting
 
 Each behavior lives under `src/plugins/`. Plugins transform tokens or renderer rules while the built-in preview remains responsible for document lifecycle, webview security, syntax highlighting, and navigation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file records notable changes that people can observe or act on when using t
 
 ### Markdown preview
 
+- Raw HTML tags covered by GFM tagfilter, such as `<script>` and `<iframe>`, now appear as text in the preview instead of being interpreted as HTML. Other allowed HTML and project-root image paths continue to work.
 - Text wrapped in single tildes now appears struck through to match GitHub, while double tildes, escapes, code spans, empty or unmatched markers, and longer tilde runs keep their existing behavior.
 
 ## [v4.1.1] - 2026-07-15

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This project focuses on three practical outcomes:
 
 - **Task Lists** — `- [x]` and `- [ ]` render as GitHub-style disabled checkboxes.
 - **Strikethrough** — `~text~` renders as GitHub-style strikethrough while existing `~~text~~` syntax, escapes, and inline code remain intact.
+- **GFM Tagfilter** — raw tags such as `<title>`, `<script>`, and `<iframe>` appear as text to match GitHub, while allowed HTML remains rendered.
 - **Footnotes** — `[^1]` references with automatic numbering, backrefs, and a footnotes section at the bottom.
 - **Alerts** — `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, and `[!CAUTION]` render with proper icons and styling.
 - **Emoji Shortcodes** — `:rocket:`, `:+1:`, `:tada:` and thousands more, including both Unicode emoji and image-based custom emoji from GitHub.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -63,6 +63,7 @@ VS Code 自带的 Markdown Preview 更偏通用渲染，而开发者真正关心
 
 - **任务列表** — `- [x]` 和 `- [ ]` 渲染为 GitHub 风格的禁用复选框。
 - **删除线** — `~文本~` 会渲染为 GitHub 风格删除线，同时保留既有的 `~~文本~~` 语法、转义和行内代码行为。
+- **GFM Tagfilter** — `<title>`、`<script>`、`<iframe>` 等原始标签会像 GitHub 一样显示为文本，同时保留受允许 HTML 的渲染行为。
 - **脚注** — `[^1]` 引用自动编号、自动回跳链接，并在文末生成脚注区域。
 - **Alerts** — `[!NOTE]`、`[!TIP]`、`[!IMPORTANT]`、`[!WARNING]`、`[!CAUTION]` 五种提示框，附带正确的图标和样式。
 - **Emoji 短代码** — `:rocket:`、`:+1:`、`:tada:` 等数千个短代码，同时支持 Unicode emoji 和 GitHub 自定义图片 emoji。

--- a/scripts/parity/cases.ts
+++ b/scripts/parity/cases.ts
@@ -20,6 +20,8 @@ export type VisualParityCase = {
 const fixtures = {
   formatting:
     "# Heading\n\n**Bold**, *italic*, ~~Hi~~ Hello, ~there~ world!, and `inline code`.\n\n> A blockquote.\n",
+  tagfilter:
+    '<strong>Allowed HTML</strong>\n\nFiltered tags: <title data-case="title">title</title> <textarea>textarea</textarea> <style>style</style> <xmp>xmp</xmp> <iframe>iframe</iframe> <noembed>noembed</noembed> <noframes>noframes</noframes> <script>script</script> <plaintext>plaintext</plaintext>.\n',
   lists:
     "- [x] Completed task\n- [ ] Pending task\n\n| Feature | Status |\n| --- | --- |\n| Tables | Supported |\n",
   alerts: "> [!NOTE]\n> Useful information.\n\n> [!WARNING]\n> Check this carefully.\n",
@@ -94,6 +96,7 @@ const repository =
   process.env["GITHUB_MARKDOWN_REPOSITORY"]?.trim() || "lzm0x219/vscode-github-markdown";
 const limits = {
   formatting: { maxDiffPixelRatio: 0, maxDiffPixels: 0, maxDiffAreaPixels: 0 },
+  tagfilter: { maxDiffPixelRatio: 0, maxDiffPixels: 0, maxDiffAreaPixels: 0 },
   lists: { maxDiffPixelRatio: 0, maxDiffPixels: 0, maxDiffAreaPixels: 0 },
   alerts: { maxDiffPixelRatio: 0, maxDiffPixels: 0, maxDiffAreaPixels: 0 },
   emoji: { maxDiffPixelRatio: 0, maxDiffPixels: 0, maxDiffAreaPixels: 0 },

--- a/scripts/parity/local.ts
+++ b/scripts/parity/local.ts
@@ -4,11 +4,13 @@ import emoji from "../../src/plugins/markdown-it-github-emoji";
 import footnotes from "../../src/plugins/markdown-it-github-footnotes";
 import imageUrl from "../../src/plugins/markdown-it-github-image-url";
 import strikethrough from "../../src/plugins/markdown-it-github-strikethrough";
+import tagfilter from "../../src/plugins/markdown-it-github-tagfilter";
 import taskLists from "../../src/plugins/markdown-it-github-task-lists";
 
 export function renderLocalMarkdown(markdown: string): string {
   return new MarkdownIt({ html: true, linkify: true })
     .use(strikethrough)
+    .use(tagfilter)
     .use(taskLists)
     .use(alerts)
     .use(emoji)

--- a/scripts/verify/index.ts
+++ b/scripts/verify/index.ts
@@ -14,6 +14,6 @@ const { verifyMarkdownCompatibility } = await import("./markdown");
 verifyMarkdownCompatibility();
 
 console.log(
-  "Verified task lists, footnotes, alerts, emoji, strikethrough, and Mermaid dependency boundaries"
+  "Verified task lists, footnotes, alerts, emoji, strikethrough, tagfilter, and Mermaid dependency boundaries"
 );
 console.log("Visual fixture: tests/fixtures/github-flavored-markdown-checklist.md");

--- a/scripts/verify/markdown.ts
+++ b/scripts/verify/markdown.ts
@@ -5,12 +5,14 @@ import githubAlerts from "../../src/plugins/markdown-it-github-alerts";
 import githubEmoji from "../../src/plugins/markdown-it-github-emoji";
 import githubFootnotes from "../../src/plugins/markdown-it-github-footnotes";
 import githubStrikethrough from "../../src/plugins/markdown-it-github-strikethrough";
+import githubTagfilter from "../../src/plugins/markdown-it-github-tagfilter";
 import githubTaskLists from "../../src/plugins/markdown-it-github-task-lists";
 import { project } from "../shared/project";
 
 export function verifyMarkdownCompatibility(): void {
   const markdown = new MarkdownIt({ html: true })
     .use(githubStrikethrough)
+    .use(githubTagfilter)
     .use(githubTaskLists)
     .use(githubAlerts)
     .use(githubEmoji)
@@ -21,7 +23,33 @@ export function verifyMarkdownCompatibility(): void {
   verifyAlerts(markdown);
   verifyEmoji(markdown);
   verifyStrikethrough(markdown);
+  verifyTagfilter(markdown);
   verifyMermaidBoundary();
+}
+
+function verifyTagfilter(markdown: MarkdownIt): void {
+  const html = markdown.render(
+    "<strong>allowed</strong> <title>title</title> <textarea>textarea</textarea> <style>style</style> <xmp>xmp</xmp> <iframe>iframe</iframe> <noembed>noembed</noembed> <noframes>noframes</noframes> <script>script</script> <plaintext>plaintext</plaintext>\n"
+  );
+  assert.match(html, /<strong>allowed<\/strong>/, "allowed raw HTML");
+  assert.doesNotMatch(
+    html,
+    /<(?:title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext)(?:[\s/>]|$)/i,
+    "disallowed raw HTML tags"
+  );
+  for (const tag of [
+    "title",
+    "textarea",
+    "style",
+    "xmp",
+    "iframe",
+    "noembed",
+    "noframes",
+    "script",
+    "plaintext"
+  ]) {
+    assert.match(html, new RegExp(`&lt;${tag}(?:[\\s/>]|$)`, "i"), `${tag} tagfilter output`);
+  }
 }
 
 function verifyStrikethrough(markdown: MarkdownIt): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import emoji from "./plugins/markdown-it-github-emoji";
 import footnotes from "./plugins/markdown-it-github-footnotes";
 import imageUrl from "./plugins/markdown-it-github-image-url";
 import strikethrough from "./plugins/markdown-it-github-strikethrough";
+import tagfilter from "./plugins/markdown-it-github-tagfilter";
 import taskLists from "./plugins/markdown-it-github-task-lists";
 import theme from "./plugins/markdown-it-github-theme";
 
@@ -27,6 +28,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<{
     extendMarkdownIt(md: MarkdownIt): MarkdownIt {
       return md
         .use(strikethrough)
+        .use(tagfilter)
         .use(taskLists)
         .use(alerts)
         .use(emoji)

--- a/src/plugins/markdown-it-github-tagfilter.ts
+++ b/src/plugins/markdown-it-github-tagfilter.ts
@@ -1,0 +1,25 @@
+import type MarkdownIt from "markdown-it";
+
+const disallowedRawHtmlTag =
+  /<(?=\/?(?:title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext)(?:[\t\n\f\r />]|$))/gi;
+
+function filterDisallowedRawHtml(html: string): string {
+  return html.replace(disallowedRawHtmlTag, "&lt;");
+}
+
+export default function markdownItGitHubTagfilter(md: MarkdownIt): MarkdownIt {
+  for (const ruleName of ["html_block", "html_inline"] as const) {
+    const defaultRender =
+      md.renderer.rules[ruleName] ??
+      ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options));
+
+    md.renderer.rules[ruleName] = (tokens, idx, options, env, self) => {
+      if (tokens[idx]) {
+        tokens[idx].content = filterDisallowedRawHtml(tokens[idx].content);
+      }
+      return defaultRender(tokens, idx, options, env, self);
+    };
+  }
+
+  return md;
+}

--- a/tests/fixtures/parity-baseline.json
+++ b/tests/fixtures/parity-baseline.json
@@ -941,6 +941,36 @@
         "kind": "exact"
       },
       "githubHtml": "<h1 dir=\"auto\">Heading</h1>\n<p dir=\"auto\"><strong>Bold</strong>, <em>italic</em>, <del>Hi</del> Hello, <del>there</del> world!, and <code class=\"notranslate\">inline code</code>.</p>\n<blockquote>\n<p dir=\"auto\">A blockquote.</p>\n</blockquote>"
+    },
+    "tagfilter-light": {
+      "markdownSha256": "956247d66a9a8dc4599e0bb60b693415b3c92ef47600063b4c62ba58e17cd2be",
+      "inputSha256": "96d6f4e0fff1072e62570cbc73403617884cf898f65c069073a6f6edea1c1274",
+      "theme": "light",
+      "themeName": "light",
+      "linkUnderlines": true,
+      "reference": {
+        "kind": "markdown-api"
+      },
+      "htmlNormalization": "none",
+      "localComparison": {
+        "kind": "exact"
+      },
+      "githubHtml": "<p dir=\"auto\"><strong>Allowed HTML</strong></p>\n<p dir=\"auto\">Filtered tags: &lt;title data-case=\"title\"&gt;title&lt;/title&gt; &lt;textarea&gt;textarea&lt;/textarea&gt; &lt;style&gt;style&lt;/style&gt; &lt;xmp&gt;xmp&lt;/xmp&gt; &lt;iframe&gt;iframe&lt;/iframe&gt; &lt;noembed&gt;noembed&lt;/noembed&gt; &lt;noframes&gt;noframes&lt;/noframes&gt; &lt;script&gt;script&lt;/script&gt; &lt;plaintext&gt;plaintext&lt;/plaintext&gt;.</p>"
+    },
+    "tagfilter-dark": {
+      "markdownSha256": "956247d66a9a8dc4599e0bb60b693415b3c92ef47600063b4c62ba58e17cd2be",
+      "inputSha256": "96d6f4e0fff1072e62570cbc73403617884cf898f65c069073a6f6edea1c1274",
+      "theme": "dark",
+      "themeName": "dark",
+      "linkUnderlines": true,
+      "reference": {
+        "kind": "markdown-api"
+      },
+      "htmlNormalization": "none",
+      "localComparison": {
+        "kind": "exact"
+      },
+      "githubHtml": "<p dir=\"auto\"><strong>Allowed HTML</strong></p>\n<p dir=\"auto\">Filtered tags: &lt;title data-case=\"title\"&gt;title&lt;/title&gt; &lt;textarea&gt;textarea&lt;/textarea&gt; &lt;style&gt;style&lt;/style&gt; &lt;xmp&gt;xmp&lt;/xmp&gt; &lt;iframe&gt;iframe&lt;/iframe&gt; &lt;noembed&gt;noembed&lt;/noembed&gt; &lt;noframes&gt;noframes&lt;/noframes&gt; &lt;script&gt;script&lt;/script&gt; &lt;plaintext&gt;plaintext&lt;/plaintext&gt;.</p>"
     }
   }
 }

--- a/tests/host/smoke.ts
+++ b/tests/host/smoke.ts
@@ -5,6 +5,18 @@ type ExtensionApi = {
   extendMarkdownIt(markdownIt: MarkdownIt): MarkdownIt;
 };
 
+const disallowedRawHtmlTags = [
+  "title",
+  "textarea",
+  "style",
+  "xmp",
+  "iframe",
+  "noembed",
+  "noframes",
+  "script",
+  "plaintext"
+] as const;
+
 export async function run(): Promise<void> {
   const extension = vscode.extensions.getExtension<ExtensionApi>("lzm0x219.vscode-github-markdown");
   assert(extension, "Extension is available in the development host");
@@ -35,13 +47,46 @@ export async function run(): Promise<void> {
     "",
     "Unmatched: ~open.",
     "",
-    "Long run: ~~~not~~~."
+    "Long run: ~~~not~~~.",
+    "",
+    'Allowed HTML: <strong data-allowed="true">strong</strong>.',
+    "",
+    "<details open><summary>Allowed details</summary><p>Details body</p></details>",
+    "",
+    '<picture><source srcset="/image.webp"><img src="/image.png" alt="allowed"></picture>',
+    "",
+    'title: <TiTlE data-case="mixed">title content</TiTlE>.',
+    "",
+    'textarea: <textarea rows="2">textarea content</textarea>.',
+    "",
+    'style: <style media="screen">style content</style>.',
+    "",
+    'xmp: <xmp data-case="xmp">xmp content</xmp>.',
+    "",
+    'iframe: <iframe src="/frame">iframe content</iframe>.',
+    "",
+    'noembed: <noembed data-case="noembed">noembed content</noembed>.',
+    "",
+    'noframes: <noframes data-case="noframes">noframes content</noframes>.',
+    "",
+    'script: <script type="text/plain">script content</script>.',
+    "",
+    'plaintext: <plaintext data-case="plaintext">plaintext content</plaintext>.',
+    "",
+    "Code span: `<script>inline code</script>`.",
+    "",
+    "Escaped: \\<iframe>escaped\\</iframe>.",
+    "",
+    "```html",
+    "<style>fenced-tagfilter-literal</style>",
+    "```"
   ].join("\n");
   const directHtml = api.extendMarkdownIt(new MarkdownIt({ html: true })).render(markdown);
   assertRenderedMarkdown(directHtml, "exported Markdown-it hook");
 
   const previewHtml = await vscode.commands.executeCommand<string>("markdown.api.render", markdown);
   assertRenderedMarkdown(previewHtml, "VS Code Markdown renderer contribution");
+  assertTagfilter(previewHtml);
 
   const previewStyles = extension.packageJSON.contributes?.["markdown.previewStyles"] as
     | string[]
@@ -65,6 +110,36 @@ function assertRenderedMarkdown(html: string | undefined, source: string): void 
   assert(html.includes("Empty: ~~."), "Empty strikethrough delimiters remain literal");
   assert(html.includes("Unmatched: ~open."), "Unmatched tildes remain literal");
   assert(html.includes("Long run: ~~~not~~~."), "Runs longer than two tildes remain literal");
+}
+
+function assertTagfilter(html: string | undefined): void {
+  assert(html, "VS Code Markdown renderer contribution returns HTML for tagfilter checks");
+  const lowerHtml = html.toLowerCase();
+  for (const tag of disallowedRawHtmlTags) {
+    assert(lowerHtml.includes(`&lt;${tag}`), `${tag} opening tag is rendered as text`);
+    assert(lowerHtml.includes(`&lt;/${tag}>`), `${tag} closing tag is rendered as text`);
+    assert(!lowerHtml.includes(`<${tag}`), `${tag} is absent from final raw HTML`);
+  }
+
+  assert(
+    html.includes('<strong data-allowed="true">strong</strong>'),
+    "Allowed raw HTML remains rendered"
+  );
+  assert(html.includes("<details open>"), "Details remain rendered");
+  assert(html.includes("<picture>"), "Picture remains rendered");
+  assert(html.includes('src="./image.png"'), "Root HTML image paths remain rewritten");
+  assert(
+    html.includes("<code>&lt;script&gt;inline code&lt;/script&gt;</code>"),
+    "Code spans keep raw tag text literal"
+  );
+  assert(
+    html.includes("&lt;iframe&gt;escaped&lt;/iframe&gt;"),
+    "Escaped raw tag input remains literal"
+  );
+  assert(
+    html.includes("<pre><code") && html.includes("fenced-tagfilter-literal"),
+    "Fenced code keeps its block and raw tag text"
+  );
 }
 
 function assert(value: unknown, message: string): asserts value {

--- a/tests/plugins/integration.test.ts
+++ b/tests/plugins/integration.test.ts
@@ -32,12 +32,14 @@ import emoji from "../../src/plugins/markdown-it-github-emoji";
 import footnotes from "../../src/plugins/markdown-it-github-footnotes";
 import imageUrl from "../../src/plugins/markdown-it-github-image-url";
 import strikethrough from "../../src/plugins/markdown-it-github-strikethrough";
+import tagfilter from "../../src/plugins/markdown-it-github-tagfilter";
 import taskLists from "../../src/plugins/markdown-it-github-task-lists";
 import theme from "../../src/plugins/markdown-it-github-theme";
 
 function createChain(): MarkdownIt {
   return new MarkdownIt({ html: true })
     .use(strikethrough)
+    .use(tagfilter)
     .use(taskLists)
     .use(alerts)
     .use(emoji)

--- a/tests/plugins/tagfilter.test.ts
+++ b/tests/plugins/tagfilter.test.ts
@@ -1,0 +1,61 @@
+import MarkdownIt from "markdown-it";
+import { describe, expect, it } from "vitest";
+import tagfilter from "../../src/plugins/markdown-it-github-tagfilter";
+
+const disallowedTags = [
+  "title",
+  "textarea",
+  "style",
+  "xmp",
+  "iframe",
+  "noembed",
+  "noframes",
+  "script",
+  "plaintext"
+] as const;
+
+function render(markdown: string): string {
+  return new MarkdownIt({ html: true }).use(tagfilter).render(markdown);
+}
+
+describe("markdown-it-github-tagfilter", () => {
+  it("matches the GFM tagfilter example", () => {
+    const html = render(
+      "<strong> <title> <style> <em>\n\n<blockquote>\n  <xmp> is disallowed.  <XMP> is also disallowed.\n</blockquote>\n"
+    );
+
+    expect(html).toContain("<strong> &lt;title> &lt;style> <em>");
+    expect(html).toContain("&lt;xmp> is disallowed.  &lt;XMP> is also disallowed.");
+  });
+
+  it.each(disallowedTags)("filters mixed-case %s tags with attributes", (tag) => {
+    const uppercaseTag = tag.toUpperCase();
+    const html = render(
+      `before <${uppercaseTag} data-case="mixed">content</${uppercaseTag}> after\n`
+    );
+
+    expect(html).toContain(`&lt;${uppercaseTag} data-case="mixed">content&lt;/${uppercaseTag}>`);
+  });
+
+  it("leaves allowed and similarly prefixed HTML tags unchanged", () => {
+    const html = render(
+      "<strong>strong</strong> <details>details</details> <picture>picture</picture> <scripture>custom</scripture> <style-guide>custom</style-guide>\n"
+    );
+
+    expect(html).toContain("<strong>strong</strong>");
+    expect(html).toContain("<details>details</details>");
+    expect(html).toContain("<picture>picture</picture>");
+    expect(html).toContain("<scripture>custom</scripture>");
+    expect(html).toContain("<style-guide>custom</style-guide>");
+  });
+
+  it("leaves code spans, fenced code, and escaped input literal", () => {
+    const html = render(
+      "`<script>inline</script>`\n\n\\<iframe>escaped\\</iframe>\n\n```html\n<style>fenced</style>\n```\n"
+    );
+
+    expect(html).toContain("<code>&lt;script&gt;inline&lt;/script&gt;</code>");
+    expect(html).toContain("&lt;iframe&gt;escaped&lt;/iframe&gt;");
+    expect(html).toContain("&lt;style&gt;fenced&lt;/style&gt;");
+  });
+});

--- a/tests/scripts/parity/cases.test.ts
+++ b/tests/scripts/parity/cases.test.ts
@@ -5,6 +5,7 @@ describe("visual parity cases", () => {
   it("covers each visual feature in light and dark mode with zero tolerance", () => {
     const features = [
       "formatting",
+      "tagfilter",
       "lists",
       "alerts",
       "emoji",


### PR DESCRIPTION
## 摘要

- 在最终 VS Code Markdown 预览中按 GFM tagfilter 规则转义九类原始 HTML 标签
- 保留允许 HTML、details、picture 和根路径 HTML 图片改写
- 增加桌面最低版、桌面稳定版、Web 稳定版宿主断言及 GitHub 视觉基准

## 验证

- 199 项 Vitest 测试通过
- 桌面 VS Code 1.74.0、桌面稳定版与 Web 稳定版宿主测试通过
- oxlint、type-aware lint、oxfmt、构建、打包与 Markdown 验证通过
- tagfilter 亮/暗主题与 GitHub 均为 0 像素差异
- Opengrep 聚焦扫描 0 项发现

Closes #1135