### PR TITLE
ci(release): decouple release notes tests from the gate

### DIFF
--- a/scripts/release/index.ts
+++ b/scripts/release/index.ts
@@ -1,21 +1,13 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-import { writeTextIfChanged } from "../shared/files";
 import { project } from "../shared/project";
-import { extractRelease } from "./changelog";
+import { writeReleaseNotes } from "./notes";
 
 const workspace = process.env["GITHUB_WORKSPACE"];
 if (!workspace) {
   throw new Error("Cannot write release notes: GITHUB_WORKSPACE is not set");
 }
 
-const changelog = await readFile(project.paths.changelog, "utf8");
-const packageJson = JSON.parse(await readFile(project.paths.packageJson, "utf8")) as {
-  version?: unknown;
-};
-if (typeof packageJson.version !== "string") {
-  throw new Error("Cannot write release notes: package.json version is missing");
-}
-
-const releaseNotes = extractRelease(changelog, packageJson.version);
-await writeTextIfChanged(join(workspace, "release-CHANGELOG.txt"), `${releaseNotes}\n`);
+await writeReleaseNotes({
+  workspace,
+  packageJsonPath: project.paths.packageJson,
+  changelogPath: project.paths.changelog
+});

--- a/scripts/release/notes.ts
+++ b/scripts/release/notes.ts
@@ -1,0 +1,23 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { writeTextIfChanged } from "../shared/files";
+import { extractRelease } from "./changelog";
+
+export type ReleaseNotesInput = {
+  workspace: string;
+  packageJsonPath: string;
+  changelogPath: string;
+};
+
+export async function writeReleaseNotes(input: ReleaseNotesInput): Promise<void> {
+  const changelog = await readFile(input.changelogPath, "utf8");
+  const packageJson = JSON.parse(await readFile(input.packageJsonPath, "utf8")) as {
+    version?: unknown;
+  };
+  if (typeof packageJson.version !== "string") {
+    throw new Error("Cannot write release notes: package.json version is missing");
+  }
+
+  const releaseNotes = extractRelease(changelog, packageJson.version);
+  await writeTextIfChanged(join(input.workspace, "release-CHANGELOG.txt"), `${releaseNotes}\n`);
+}

--- a/tests/scripts/release/index.test.ts
+++ b/tests/scripts/release/index.test.ts
@@ -1,26 +1,58 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeReleaseNotes } from "../../../scripts/release/notes";
 
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
-  vi.unstubAllEnvs();
   await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })));
 });
 
 describe("release notes output", () => {
-  it("writes the generated notes inside GITHUB_WORKSPACE", async () => {
-    const workspace = await mkdtemp(join(tmpdir(), "vscode-github-markdown-release-"));
-    temporaryDirectories.push(workspace);
-    vi.stubEnv("GITHUB_WORKSPACE", workspace);
-    vi.resetModules();
+  it("writes notes from explicit package and changelog inputs", async () => {
+    const workspace = await createReleaseFixture(
+      "2.0.0",
+      "# Changelog\n\n## [v2.0.0] - 2026-07-15\n\nRelease summary.\n"
+    );
 
-    await import("../../../scripts/release/index");
+    await writeReleaseNotes(releaseNotesInput(workspace));
 
-    await expect(readFile(join(workspace, "release-CHANGELOG.txt"), "utf8")).resolves.toContain(
-      "## What's Changed"
+    await expect(readFile(join(workspace, "release-CHANGELOG.txt"), "utf8")).resolves.toBe(
+      "## What's Changed\n\nRelease summary.\n"
     );
   });
+
+  it("rejects a release whose changelog has no matching version", async () => {
+    const workspace = await createReleaseFixture(
+      "3.0.0",
+      "# Changelog\n\n## [v2.0.0] - 2026-07-15\n\nPrevious release.\n"
+    );
+
+    await expect(writeReleaseNotes(releaseNotesInput(workspace))).rejects.toThrow(
+      "Cannot extract release notes: version 3.0.0 was not found"
+    );
+    await expect(readFile(join(workspace, "release-CHANGELOG.txt"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT"
+    });
+  });
 });
+
+function releaseNotesInput(workspace: string) {
+  return {
+    workspace,
+    packageJsonPath: join(workspace, "package.json"),
+    changelogPath: join(workspace, "CHANGELOG.md")
+  };
+}
+
+async function createReleaseFixture(version: string, changelog: string): Promise<string> {
+  const workspace = await mkdtemp(join(tmpdir(), "vscode-github-markdown-release-"));
+  temporaryDirectories.push(workspace);
+  await Promise.all([
+    writeFile(join(workspace, "package.json"), JSON.stringify({ version }), "utf8"),
+    writeFile(join(workspace, "CHANGELOG.md"), changelog, "utf8")
+  ]);
+  return workspace;
+}


### PR DESCRIPTION
## 摘要

- 将发布说明生成提取为接收显式 workspace、package 和 CHANGELOG 路径的公开函数
- 让常规测试只使用临时 fixture，不再依赖 Release Please 分支的仓库版本状态
- 保留真实 `release:note` 对仓库文件的读取与缺少版本段时的失败门禁

## 验证

- TDD：新接口测试先失败，最小实现后通过
- 35 个测试文件、200 项测试全部通过
- 发布脚本聚焦测试 9/9 通过
- 真实 `release:note` 命令通过
- oxlint、type-aware lint、oxfmt 与构建通过
- Opengrep 未发现本次新增问题

Closes #1149