### PR TITLE
feat(markdown): match automatic direction for RTL content

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,8 +21,9 @@ VS Code commands ────────────────> src/commands.
 4. alerts
 5. emoji
 6. footnotes
-7. theme metadata
-8. HTML image URL rewriting
+7. automatic text direction
+8. theme metadata
+9. HTML image URL rewriting
 
 Each behavior lives under `src/plugins/`. Plugins transform tokens or renderer rules while the built-in preview remains responsible for document lifecycle, webview security, syntax highlighting, and navigation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ This file records notable changes that people can observe or act on when using t
 
 ## [v4.2.0] - 2026-07-15
 
-v4.2.0 makes raw HTML and strikethrough syntax behave more like GitHub while preserving allowed HTML and literal Markdown syntax.
+v4.2.0 makes raw HTML, strikethrough syntax, and bidirectional text behave more like GitHub while preserving allowed HTML, literal Markdown syntax, code direction, and explicit direction settings.
 
 ### Markdown preview
 
+- Arabic and other right-to-left or mixed-direction headings, paragraphs, lists, alerts, and footnotes now use GitHub-style automatic direction in the preview, while code and explicit direction settings remain unchanged.
 - Raw HTML tags covered by GFM tagfilter, such as `<script>` and `<iframe>`, now appear as text in the preview instead of being interpreted as HTML. Other allowed HTML and project-root image paths continue to work.
 - Text wrapped in single tildes now appears struck through to match GitHub, while double tildes, escapes, code spans, empty or unmatched markers, and longer tilde runs keep their existing behavior.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This project focuses on three practical outcomes:
 - **Task Lists** — `- [x]` and `- [ ]` render as GitHub-style disabled checkboxes.
 - **Strikethrough** — `~text~` renders as GitHub-style strikethrough while existing `~~text~~` syntax, escapes, and inline code remain intact.
 - **GFM Tagfilter** — raw tags such as `<title>`, `<script>`, and `<iframe>` appear as text to match GitHub, while allowed HTML remains rendered.
+- **Automatic Text Direction** — Arabic and other right-to-left or mixed-direction content follows GitHub's automatic direction, while code and explicit directions remain unchanged.
 - **Footnotes** — `[^1]` references with automatic numbering, backrefs, and a footnotes section at the bottom.
 - **Alerts** — `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, and `[!CAUTION]` render with proper icons and styling.
 - **Emoji Shortcodes** — `:rocket:`, `:+1:`, `:tada:` and thousands more, including both Unicode emoji and image-based custom emoji from GitHub.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,6 +64,7 @@ VS Code 自带的 Markdown Preview 更偏通用渲染，而开发者真正关心
 - **任务列表** — `- [x]` 和 `- [ ]` 渲染为 GitHub 风格的禁用复选框。
 - **删除线** — `~文本~` 会渲染为 GitHub 风格删除线，同时保留既有的 `~~文本~~` 语法、转义和行内代码行为。
 - **GFM Tagfilter** — `<title>`、`<script>`、`<iframe>` 等原始标签会像 GitHub 一样显示为文本，同时保留受允许 HTML 的渲染行为。
+- **自动文本方向** — 阿拉伯语等从右到左或混排内容会采用与 GitHub 一致的自动方向，同时保持代码和显式方向不变。
 - **脚注** — `[^1]` 引用自动编号、自动回跳链接，并在文末生成脚注区域。
 - **Alerts** — `[!NOTE]`、`[!TIP]`、`[!IMPORTANT]`、`[!WARNING]`、`[!CAUTION]` 五种提示框，附带正确的图标和样式。
 - **Emoji 短代码** — `:rocket:`、`:+1:`、`:tada:` 等数千个短代码，同时支持 Unicode emoji 和 GitHub 自定义图片 emoji。

--- a/scripts/parity/cases.ts
+++ b/scripts/parity/cases.ts
@@ -22,6 +22,8 @@ const fixtures = {
     "# Heading\n\n**Bold**, *italic*, ~~Hi~~ Hello, ~there~ world!, and `inline code`.\n\n> A blockquote.\n",
   tagfilter:
     '<strong>Allowed HTML</strong>\n\nFiltered tags: <title data-case="title">title</title> <textarea>textarea</textarea> <style>style</style> <xmp>xmp</xmp> <iframe>iframe</iframe> <noembed>noembed</noembed> <noframes>noframes</noframes> <script>script</script> <plaintext>plaintext</plaintext>.\n',
+  directionality:
+    '# مرحباً بالعالم\n\nفقرة عربية لاختبار اتجاه النص.\n\nMixed English العربية 123.\n\n- عنصر عربي\n- Mixed item العربية\n\n> [!NOTE]\n> تنبيه عربي with English.\n\nFootnote reference العربية.[^1]\n\n[^1]: ملاحظة هامشية mixed English.\n\nInline `code العربية`.\n\n```text\nblock العربية\n```\n\n<p dir="rtl">Explicit RTL العربية</p>\n',
   lists:
     "- [x] Completed task\n- [ ] Pending task\n\n| Feature | Status |\n| --- | --- |\n| Tables | Supported |\n",
   alerts: "> [!NOTE]\n> Useful information.\n\n> [!WARNING]\n> Check this carefully.\n",
@@ -97,6 +99,7 @@ const repository =
 const limits = {
   formatting: { maxDiffPixelRatio: 0, maxDiffPixels: 0, maxDiffAreaPixels: 0 },
   tagfilter: { maxDiffPixelRatio: 0, maxDiffPixels: 0, maxDiffAreaPixels: 0 },
+  directionality: { maxDiffPixelRatio: 0, maxDiffPixels: 0, maxDiffAreaPixels: 0 },
   lists: { maxDiffPixelRatio: 0, maxDiffPixels: 0, maxDiffAreaPixels: 0 },
   alerts: { maxDiffPixelRatio: 0, maxDiffPixels: 0, maxDiffAreaPixels: 0 },
   emoji: { maxDiffPixelRatio: 0, maxDiffPixels: 0, maxDiffAreaPixels: 0 },

--- a/scripts/parity/local.ts
+++ b/scripts/parity/local.ts
@@ -1,5 +1,6 @@
 import MarkdownIt from "markdown-it";
 import alerts from "../../src/plugins/markdown-it-github-alerts";
+import directionality from "../../src/plugins/markdown-it-github-directionality";
 import emoji from "../../src/plugins/markdown-it-github-emoji";
 import footnotes from "../../src/plugins/markdown-it-github-footnotes";
 import imageUrl from "../../src/plugins/markdown-it-github-image-url";
@@ -15,6 +16,7 @@ export function renderLocalMarkdown(markdown: string): string {
     .use(alerts)
     .use(emoji)
     .use(footnotes)
+    .use(directionality)
     .use(imageUrl)
     .render(markdown);
 }

--- a/scripts/verify/index.ts
+++ b/scripts/verify/index.ts
@@ -14,6 +14,6 @@ const { verifyMarkdownCompatibility } = await import("./markdown");
 verifyMarkdownCompatibility();
 
 console.log(
-  "Verified task lists, footnotes, alerts, emoji, strikethrough, tagfilter, and Mermaid dependency boundaries"
+  "Verified task lists, footnotes, alerts, emoji, strikethrough, tagfilter, directionality, and Mermaid dependency boundaries"
 );
 console.log("Visual fixture: tests/fixtures/github-flavored-markdown-checklist.md");

--- a/scripts/verify/markdown.ts
+++ b/scripts/verify/markdown.ts
@@ -2,6 +2,7 @@ import MarkdownIt from "markdown-it";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import githubAlerts from "../../src/plugins/markdown-it-github-alerts";
+import githubDirectionality from "../../src/plugins/markdown-it-github-directionality";
 import githubEmoji from "../../src/plugins/markdown-it-github-emoji";
 import githubFootnotes from "../../src/plugins/markdown-it-github-footnotes";
 import githubStrikethrough from "../../src/plugins/markdown-it-github-strikethrough";
@@ -16,7 +17,8 @@ export function verifyMarkdownCompatibility(): void {
     .use(githubTaskLists)
     .use(githubAlerts)
     .use(githubEmoji)
-    .use(githubFootnotes);
+    .use(githubFootnotes)
+    .use(githubDirectionality);
 
   verifyTaskLists(markdown);
   verifyFootnotes(markdown);
@@ -24,7 +26,19 @@ export function verifyMarkdownCompatibility(): void {
   verifyEmoji(markdown);
   verifyStrikethrough(markdown);
   verifyTagfilter(markdown);
+  verifyDirectionality(markdown);
   verifyMermaidBoundary();
+}
+
+function verifyDirectionality(markdown: MarkdownIt): void {
+  const html = markdown.render(
+    '# العربية\n\nMixed English العربية.\n\n- عنصر عربي\n\n`code العربية`\n\n```text\nblock العربية\n```\n\n<p dir="rtl">explicit العربية</p>\n'
+  );
+  assert.match(html, /<h1 dir="auto">العربية<\/h1>/, "heading automatic direction");
+  assert.match(html, /<p dir="auto">Mixed English العربية\.<\/p>/, "paragraph direction");
+  assert.match(html, /<ul dir="auto">/, "list automatic direction");
+  assert.doesNotMatch(html, /<(?:pre|code)\b[^>]*\bdir=/, "code direction");
+  assert.match(html, /<p dir="rtl">explicit العربية<\/p>/, "explicit direction");
 }
 
 function verifyTagfilter(markdown: MarkdownIt): void {
@@ -72,7 +86,7 @@ function verifyTaskLists(markdown: MarkdownIt): void {
   const html = markdown.render(
     "- [x] #739\n- [ ] [https://github.com/octo-org/octo-repo/issues/740](https://github.com/octo-org/octo-repo/issues/740)\n"
   );
-  assert.match(html, /<ul class="contains-task-list">\n/, "task list container class");
+  assert.match(html, /<ul class="contains-task-list" dir="auto">\n/, "task list container class");
   assert.doesNotMatch(html, /contains-task-list contains-task-list/, "duplicate task list class");
   assert.match(
     html,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { registerThemeCommands } from "./commands";
 import { registerMarkdownPreviewEvents } from "./events";
 import { updateMermaidThemeSync } from "./integrations/mermaid";
 import alerts from "./plugins/markdown-it-github-alerts";
+import directionality from "./plugins/markdown-it-github-directionality";
 import emoji from "./plugins/markdown-it-github-emoji";
 import footnotes from "./plugins/markdown-it-github-footnotes";
 import imageUrl from "./plugins/markdown-it-github-image-url";
@@ -33,6 +34,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<{
         .use(alerts)
         .use(emoji)
         .use(footnotes)
+        .use(directionality)
         .use(theme)
         .use(imageUrl);
     }

--- a/src/plugins/markdown-it-github-directionality.ts
+++ b/src/plugins/markdown-it-github-directionality.ts
@@ -1,0 +1,59 @@
+import type MarkdownIt from "markdown-it";
+import type { MarkdownToken } from "./shared";
+
+const automaticDirectionRules = [
+  "heading_open",
+  "paragraph_open",
+  "bullet_list_open",
+  "ordered_list_open"
+] as const;
+const codeRules = ["fence", "code_block"] as const;
+
+export default function markdownItGitHubDirectionality(md: MarkdownIt): MarkdownIt {
+  for (const ruleName of automaticDirectionRules) {
+    wrapRendererRule(md, ruleName, normalizeAutomaticDirection);
+  }
+  wrapRendererRule(md, "blockquote_open", (token) => {
+    if (token.tag === "div" && token.attrGet("class")?.split(/\s+/).includes("markdown-alert")) {
+      normalizeAutomaticDirection(token);
+    }
+  });
+  for (const ruleName of codeRules) {
+    wrapRendererRule(md, ruleName, (token) => removeAttribute(token, "dir"));
+  }
+
+  return md;
+}
+
+function wrapRendererRule(
+  md: MarkdownIt,
+  ruleName: string,
+  transform: (token: MarkdownToken) => void
+): void {
+  const defaultRender =
+    md.renderer.rules[ruleName] ??
+    ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options));
+
+  md.renderer.rules[ruleName] = (tokens, idx, options, env, self) => {
+    const token = tokens[idx];
+    if (token) {
+      transform(token);
+    }
+    return defaultRender(tokens, idx, options, env, self);
+  };
+}
+
+function normalizeAutomaticDirection(token: MarkdownToken): void {
+  const directions = token.attrGet("dir")?.split(/\s+/) ?? [];
+  const explicitDirection = directions.find(
+    (direction) => direction === "ltr" || direction === "rtl"
+  );
+  token.attrSet("dir", explicitDirection ?? "auto");
+}
+
+function removeAttribute(token: MarkdownToken, name: string): void {
+  const index = token.attrIndex(name);
+  if (index >= 0) {
+    token.attrs?.splice(index, 1);
+  }
+}

--- a/tests/fixtures/parity-baseline.json
+++ b/tests/fixtures/parity-baseline.json
@@ -971,6 +971,36 @@
         "kind": "exact"
       },
       "githubHtml": "<p dir=\"auto\"><strong>Allowed HTML</strong></p>\n<p dir=\"auto\">Filtered tags: &lt;title data-case=\"title\"&gt;title&lt;/title&gt; &lt;textarea&gt;textarea&lt;/textarea&gt; &lt;style&gt;style&lt;/style&gt; &lt;xmp&gt;xmp&lt;/xmp&gt; &lt;iframe&gt;iframe&lt;/iframe&gt; &lt;noembed&gt;noembed&lt;/noembed&gt; &lt;noframes&gt;noframes&lt;/noframes&gt; &lt;script&gt;script&lt;/script&gt; &lt;plaintext&gt;plaintext&lt;/plaintext&gt;.</p>"
+    },
+    "directionality-light": {
+      "markdownSha256": "6b0bf968ecc0b20e7df9fe6884d77448a2d9292ede51ec66d6006696bfccd410",
+      "inputSha256": "72478a5823ff991e3faa39890806c41e5e883f334c201888abee98834f53cce4",
+      "theme": "light",
+      "themeName": "light",
+      "linkUnderlines": true,
+      "reference": {
+        "kind": "markdown-api"
+      },
+      "htmlNormalization": "none",
+      "localComparison": {
+        "kind": "exact"
+      },
+      "githubHtml": "<h1 dir=\"auto\">مرحباً بالعالم</h1>\n<p dir=\"auto\">فقرة عربية لاختبار اتجاه النص.</p>\n<p dir=\"auto\">Mixed English العربية 123.</p>\n<ul dir=\"auto\">\n<li>عنصر عربي</li>\n<li>Mixed item العربية</li>\n</ul>\n<div class=\"markdown-alert markdown-alert-note\" dir=\"auto\"><p class=\"markdown-alert-title\" dir=\"auto\"><svg data-component=\"Octicon\" class=\"octicon octicon-info mr-2\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path d=\"M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z\"></path></svg>Note</p><p dir=\"auto\">تنبيه عربي with English.</p>\n</div>\n<p dir=\"auto\">Footnote reference العربية.<sup><a href=\"#user-content-fn-1-84ea154d956fda0471cef122b92a5e4d\" id=\"user-content-fnref-1-84ea154d956fda0471cef122b92a5e4d\" data-footnote-ref=\"\" aria-describedby=\"footnote-label\">1</a></sup></p>\n<p dir=\"auto\">Inline <code class=\"notranslate\">code العربية</code>.</p>\n<pre lang=\"text\" class=\"notranslate\"><code class=\"notranslate\">block العربية\n</code></pre>\n<p dir=\"rtl\">Explicit RTL العربية</p>\n<section data-footnotes=\"\" class=\"footnotes\"><h2 id=\"footnote-label\" class=\"sr-only\" dir=\"auto\">Footnotes</h2>\n<ol dir=\"auto\">\n<li id=\"user-content-fn-1-84ea154d956fda0471cef122b92a5e4d\">\n<p dir=\"auto\">ملاحظة هامشية mixed English. <a href=\"#user-content-fnref-1-84ea154d956fda0471cef122b92a5e4d\" data-footnote-backref=\"\" aria-label=\"Back to reference 1\" class=\"data-footnote-backref\">↩</a></p>\n</li>\n</ol>\n</section>"
+    },
+    "directionality-dark": {
+      "markdownSha256": "6b0bf968ecc0b20e7df9fe6884d77448a2d9292ede51ec66d6006696bfccd410",
+      "inputSha256": "72478a5823ff991e3faa39890806c41e5e883f334c201888abee98834f53cce4",
+      "theme": "dark",
+      "themeName": "dark",
+      "linkUnderlines": true,
+      "reference": {
+        "kind": "markdown-api"
+      },
+      "htmlNormalization": "none",
+      "localComparison": {
+        "kind": "exact"
+      },
+      "githubHtml": "<h1 dir=\"auto\">مرحباً بالعالم</h1>\n<p dir=\"auto\">فقرة عربية لاختبار اتجاه النص.</p>\n<p dir=\"auto\">Mixed English العربية 123.</p>\n<ul dir=\"auto\">\n<li>عنصر عربي</li>\n<li>Mixed item العربية</li>\n</ul>\n<div class=\"markdown-alert markdown-alert-note\" dir=\"auto\"><p class=\"markdown-alert-title\" dir=\"auto\"><svg data-component=\"Octicon\" class=\"octicon octicon-info mr-2\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path d=\"M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z\"></path></svg>Note</p><p dir=\"auto\">تنبيه عربي with English.</p>\n</div>\n<p dir=\"auto\">Footnote reference العربية.<sup><a href=\"#user-content-fn-1-84ea154d956fda0471cef122b92a5e4d\" id=\"user-content-fnref-1-84ea154d956fda0471cef122b92a5e4d\" data-footnote-ref=\"\" aria-describedby=\"footnote-label\">1</a></sup></p>\n<p dir=\"auto\">Inline <code class=\"notranslate\">code العربية</code>.</p>\n<pre lang=\"text\" class=\"notranslate\"><code class=\"notranslate\">block العربية\n</code></pre>\n<p dir=\"rtl\">Explicit RTL العربية</p>\n<section data-footnotes=\"\" class=\"footnotes\"><h2 id=\"footnote-label\" class=\"sr-only\" dir=\"auto\">Footnotes</h2>\n<ol dir=\"auto\">\n<li id=\"user-content-fn-1-84ea154d956fda0471cef122b92a5e4d\">\n<p dir=\"auto\">ملاحظة هامشية mixed English. <a href=\"#user-content-fnref-1-84ea154d956fda0471cef122b92a5e4d\" data-footnote-backref=\"\" aria-label=\"Back to reference 1\" class=\"data-footnote-backref\">↩</a></p>\n</li>\n</ol>\n</section>"
     }
   }
 }

--- a/tests/host/smoke.ts
+++ b/tests/host/smoke.ts
@@ -79,7 +79,35 @@ export async function run(): Promise<void> {
     "",
     "```html",
     "<style>fenced-tagfilter-literal</style>",
-    "```"
+    "```",
+    "",
+    "## rtl-host-heading مرحباً بالعالم",
+    "",
+    "rtl-host-paragraph فقرة عربية لاختبار اتجاه النص.",
+    "",
+    "rtl-host-mixed Mixed English العربية 123.",
+    "",
+    "- rtl-host-list-item عنصر عربي",
+    "- rtl-host-mixed-list Mixed item العربية",
+    "",
+    "> [!NOTE]",
+    "> rtl-host-alert تنبيه عربي with English.",
+    "",
+    "rtl-host-footnote-reference العربية.[^rtl]",
+    "",
+    "[^rtl]: rtl-host-footnote-definition ملاحظة هامشية mixed English.",
+    "",
+    "Inline direction code: `rtl-inline-code-direction العربية`.",
+    "",
+    "```text",
+    "rtl-block-code-direction العربية",
+    "```",
+    "",
+    "    rtl-indented-code-direction العربية",
+    "",
+    '<p dir="rtl" data-direction="explicit-rtl">rtl-explicit-direction العربية</p>',
+    "",
+    '<p dir="ltr" data-direction="explicit-ltr">ltr-explicit-direction English</p>'
   ].join("\n");
   const directHtml = api.extendMarkdownIt(new MarkdownIt({ html: true })).render(markdown);
   assertRenderedMarkdown(directHtml, "exported Markdown-it hook");
@@ -87,6 +115,7 @@ export async function run(): Promise<void> {
   const previewHtml = await vscode.commands.executeCommand<string>("markdown.api.render", markdown);
   assertRenderedMarkdown(previewHtml, "VS Code Markdown renderer contribution");
   assertTagfilter(previewHtml);
+  assertDirectionality(previewHtml);
 
   const previewStyles = extension.packageJSON.contributes?.["markdown.previewStyles"] as
     | string[]
@@ -140,6 +169,94 @@ function assertTagfilter(html: string | undefined): void {
     html.includes("<pre><code") && html.includes("fenced-tagfilter-literal"),
     "Fenced code keeps its block and raw tag text"
   );
+}
+
+function assertDirectionality(html: string | undefined): void {
+  assert(html, "VS Code Markdown renderer contribution returns HTML for directionality checks");
+  assert(
+    elementHasDirection(html, "h2", "auto", "rtl-host-heading مرحباً بالعالم"),
+    "RTL headings use automatic direction in final preview HTML"
+  );
+  assert(
+    elementHasDirection(html, "p", "auto", "rtl-host-paragraph فقرة عربية"),
+    "RTL paragraphs use automatic direction in final preview HTML"
+  );
+  assert(
+    elementHasDirection(html, "p", "auto", "rtl-host-mixed Mixed English العربية"),
+    "Mixed-direction paragraphs use automatic direction in final preview HTML"
+  );
+  assert(
+    elementHasDirection(html, "ul", "auto", "rtl-host-list-item عنصر عربي"),
+    "RTL lists use automatic direction in final preview HTML"
+  );
+  assert(
+    elementHasDirection(html, "div", "auto", "rtl-host-alert تنبيه عربي"),
+    "RTL alerts use automatic direction in final preview HTML"
+  );
+  assert(
+    elementHasDirection(html, "p", "auto", "rtl-host-footnote-reference العربية"),
+    "RTL footnote references use automatic direction in final preview HTML"
+  );
+  assert(
+    elementHasDirection(html, "p", "auto", "rtl-host-footnote-definition ملاحظة هامشية"),
+    "RTL footnote definitions use automatic direction in final preview HTML"
+  );
+  assert(
+    elementHasDirection(html, "p", "rtl", "rtl-explicit-direction العربية"),
+    "Explicit RTL direction remains unchanged"
+  );
+  assert(
+    elementHasDirection(html, "p", "ltr", "ltr-explicit-direction English"),
+    "Explicit LTR direction remains unchanged"
+  );
+
+  const inlineCode = html.match(/<code\b([^>]*)>rtl-inline-code-direction العربية<\/code>/);
+  assert(inlineCode && !/\bdir=/.test(inlineCode[1] ?? ""), "Inline code has no direction");
+  assert(
+    codeBlockHasNoDirection(html, "rtl-block-code-direction العربية"),
+    "Fenced code blocks have no direction"
+  );
+  assert(
+    codeBlockHasNoDirection(html, "rtl-indented-code-direction العربية"),
+    "Indented code blocks have no direction"
+  );
+}
+
+function codeBlockHasNoDirection(html: string, marker: string): boolean {
+  const markerIndex = html.indexOf(marker);
+  const preStart = html.lastIndexOf("<pre", markerIndex);
+  const codeStart = html.lastIndexOf("<code", markerIndex);
+  const preAttributes = html.slice(preStart, html.indexOf(">", preStart));
+  const codeAttributes = html.slice(codeStart, html.indexOf(">", codeStart));
+  return (
+    markerIndex >= 0 &&
+    preStart >= 0 &&
+    codeStart >= 0 &&
+    !/\bdir=/.test(preAttributes) &&
+    !/\bdir=/.test(codeAttributes)
+  );
+}
+
+function elementHasDirection(
+  html: string,
+  tag: string,
+  direction: "auto" | "ltr" | "rtl",
+  text: string
+): boolean {
+  let textIndex = html.indexOf(text);
+  while (textIndex >= 0) {
+    const openIndex = html.lastIndexOf(`<${tag}`, textIndex);
+    const openEnd = html.indexOf(">", openIndex);
+    const closeIndex = html.indexOf(`</${tag}>`, openEnd);
+    if (openIndex >= 0 && openEnd < textIndex && closeIndex > textIndex) {
+      const attributes = html.slice(openIndex + tag.length + 1, openEnd);
+      if (/^\s/.test(attributes) && new RegExp(`\\bdir="${direction}"`).test(attributes)) {
+        return true;
+      }
+    }
+    textIndex = html.indexOf(text, textIndex + text.length);
+  }
+  return false;
 }
 
 function assert(value: unknown, message: string): asserts value {

--- a/tests/plugins/directionality.test.ts
+++ b/tests/plugins/directionality.test.ts
@@ -1,0 +1,62 @@
+import MarkdownIt from "markdown-it";
+import { describe, expect, it } from "vitest";
+import alerts from "../../src/plugins/markdown-it-github-alerts";
+import directionality from "../../src/plugins/markdown-it-github-directionality";
+
+describe("markdown-it-github-directionality", () => {
+  it("adds automatic direction to text containers while preserving code and explicit HTML", () => {
+    const html = new MarkdownIt({ html: true })
+      .use(directionality)
+      .render(
+        [
+          "# مرحباً بالعالم",
+          "",
+          "فقرة عربية mixed English.",
+          "",
+          "- عنصر عربي",
+          "",
+          "1. Mixed item العربية",
+          "",
+          "Inline `code العربية`.",
+          "",
+          "```text",
+          "block العربية",
+          "```",
+          "",
+          "    indented العربية",
+          "",
+          '<p dir="rtl">explicit العربية</p>'
+        ].join("\n")
+      );
+
+    expect(html).toContain('<h1 dir="auto">مرحباً بالعالم</h1>');
+    expect(html).toContain('<p dir="auto">فقرة عربية mixed English.</p>');
+    expect(html).toContain('<ul dir="auto">');
+    expect(html).toContain('<ol dir="auto">');
+    expect(html).not.toMatch(/<(?:pre|code)\b[^>]*\bdir=/);
+    expect(html).toContain('<p dir="rtl">explicit العربية</p>');
+  });
+
+  it("normalizes host direction attributes and removes them from code blocks", () => {
+    const markdown = new MarkdownIt().use(alerts);
+    markdown.core.ruler.push("host-code-direction", (state) => {
+      for (const token of state.tokens) {
+        if (token.type === "fence" || token.type === "code_block") {
+          token.attrSet("dir", "auto");
+        } else if (token.type === "paragraph_open" || token.type === "blockquote_open") {
+          token.attrJoin("dir", "auto");
+        }
+      }
+    });
+    markdown.use(directionality);
+
+    const html = markdown.render(
+      "> [!NOTE]\n> alert العربية\n\n```text\nblock العربية\n```\n\n    indented العربية\n"
+    );
+
+    expect(html).toContain('<div class="markdown-alert markdown-alert-note" dir="auto">');
+    expect(html).toContain('<p dir="auto">alert العربية</p>');
+    expect(html).not.toContain('dir="auto auto"');
+    expect(html).not.toMatch(/<(?:pre|code)\b[^>]*\bdir=/);
+  });
+});

--- a/tests/plugins/integration.test.ts
+++ b/tests/plugins/integration.test.ts
@@ -28,6 +28,7 @@ vi.mock("vscode", () => ({
 }));
 
 import alerts from "../../src/plugins/markdown-it-github-alerts";
+import directionality from "../../src/plugins/markdown-it-github-directionality";
 import emoji from "../../src/plugins/markdown-it-github-emoji";
 import footnotes from "../../src/plugins/markdown-it-github-footnotes";
 import imageUrl from "../../src/plugins/markdown-it-github-image-url";
@@ -44,6 +45,7 @@ function createChain(): MarkdownIt {
     .use(alerts)
     .use(emoji)
     .use(footnotes)
+    .use(directionality)
     .use(theme)
     .use(imageUrl);
 }
@@ -102,7 +104,7 @@ describe("plugin chain integration", () => {
     expect(html).toContain('class="vscode-github-markdown"');
     // The theme div opens before the heading and closes at the very end
     const divOpen = html.indexOf("vscode-github-markdown");
-    const h1Pos = html.indexOf("<h1>");
+    const h1Pos = html.indexOf("<h1 ");
     expect(divOpen).toBeLessThan(h1Pos);
   });
 

--- a/tests/scripts/parity/cases.test.ts
+++ b/tests/scripts/parity/cases.test.ts
@@ -6,6 +6,7 @@ describe("visual parity cases", () => {
     const features = [
       "formatting",
       "tagfilter",
+      "directionality",
       "lists",
       "alerts",
       "emoji",


### PR DESCRIPTION
## 变更

- 为标题、段落和列表补齐与 GitHub 一致的 `dir="auto"`。
- 归一 Alerts 的自动方向，保留显式 `ltr`/`rtl`，并移除代码跨度与代码块上的错误方向属性。
- 增加语义、Host 和双向文本视觉对齐覆盖，并同步中英文文档及 v4.2.0 发布说明。

## 验证

- `nub run test`（202 项通过）
- VS Code 1.74.0 桌面 Host、稳定版桌面 Host、稳定版 Web Host
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nub scripts/verify/index.ts`
- `pnpm run verify:parity`（directionality 明暗主题均 0px 差异）
- `nub run package`

Closes #1136