### PR TITLE
feat(mermaid): synchronize built-in and external themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+### Mermaid
+
+- Mermaid theme synchronization now works with VS Code's built-in renderer on 1.121 or later as well as the external `markdown-mermaid` extension. Disabling synchronization or deactivating this extension restores only settings it still owns, preserving newer Mermaid theme choices.
+
 ## [v4.2.0] - 2026-07-15
 
 v4.2.0 makes raw HTML, strikethrough syntax, and bidirectional text behave more like GitHub while preserving allowed HTML, literal Markdown syntax, code direction, and explicit direction settings.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This project focuses on three practical outcomes:
 
 - Align the rendering, spacing, and visual details of GitHub Markdown instead of inventing a separate lookalike theme
 - Keep local preview and expected GitHub output as close as possible so documentation work needs less trial and error
-- Keep `markdown-mermaid` diagrams on a matching light or dark theme when Mermaid theme sync is enabled
+- Keep diagrams from VS Code's built-in Mermaid renderer or `markdown-mermaid` on a matching light or dark theme when Mermaid theme sync is enabled
 
 ## Features
 
@@ -97,7 +97,7 @@ Switch themes anytime via VS Code commands (Quick Pick) — no need to open sett
 
 ### Mermaid Diagrams
 
-When `githubMarkdown.mermaid.syncTheme` is enabled and `markdown-mermaid` is installed, the extension updates both of that extension's light and dark theme settings. System mode maps the selected GitHub light and dark themes independently; single mode applies one matching Mermaid theme to both slots. Disabling sync restores the previous global Mermaid values. This extension does not ship a Mermaid renderer or add a Mermaid dependency.
+On VS Code 1.121 or later, Mermaid theme sync works with the built-in `vscode.mermaid-markdown-features` extension. On older supported releases, install the external `bierner.markdown-mermaid` extension. When either renderer is available and `githubMarkdown.mermaid.syncTheme` is enabled, this extension updates their shared `markdown-mermaid` light and dark theme settings. System mode maps the selected GitHub light and dark themes independently; single mode applies one matching Mermaid theme to both slots. Disabling sync or deactivating this extension restores only the values it last applied, so newer Mermaid theme choices remain intact. This extension does not ship a Mermaid renderer or add a Mermaid runtime dependency.
 
 ### Desktop and Web
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,7 +55,7 @@ VS Code 自带的 Markdown Preview 更偏通用渲染，而开发者真正关心
 
 - 对齐 GitHub Markdown 的渲染结果、留白和排版细节，而不是另起一套看起来相似但结果不同的主题
 - 尽量让本地预览和 GitHub 上的预期效果保持一致，让文档编写过程更可预期、更省来回验证成本
-- 启用 Mermaid 主题同步时，让 `markdown-mermaid` 图表跟随匹配的亮色或暗色主题
+- 启用 Mermaid 主题同步时，让 VS Code 内置 Mermaid 渲染器或 `markdown-mermaid` 图表跟随匹配的亮色或暗色主题
 
 ## 特性
 
@@ -97,7 +97,7 @@ VS Code 语法高亮，以及 GitHub 为 Mermaid、GeoJSON、STL 和数学公式
 
 ### Mermaid 图表
 
-启用 `githubMarkdown.mermaid.syncTheme` 且已安装 `markdown-mermaid` 时，扩展会同时更新该扩展的亮色和暗色主题设置。跟随系统模式会分别映射所选的 GitHub 亮色与暗色主题；单主题模式会为两种预览配色应用同一个匹配主题。关闭同步后，扩展会恢复此前的 Mermaid 全局设置。本扩展不内置 Mermaid 渲染器，也不引入 Mermaid 运行时依赖。
+在 VS Code 1.121 及以上版本中，Mermaid 主题同步可直接配合内置的 `vscode.mermaid-markdown-features` 扩展；在更早的受支持版本中，请安装外置的 `bierner.markdown-mermaid` 扩展。任一渲染器可用且已启用 `githubMarkdown.mermaid.syncTheme` 时，本扩展会更新它们共用的 `markdown-mermaid` 亮色和暗色主题设置。跟随系统模式会分别映射所选的 GitHub 亮色与暗色主题；单主题模式会为两个槽位应用同一个匹配主题。关闭同步或停用本扩展时，只会恢复仍由本扩展最后写入的值，因此不会覆盖同步期间产生的新 Mermaid 主题选择。本扩展不内置 Mermaid 渲染器，也不引入 Mermaid 运行时依赖。
 
 ### 桌面端与 Web
 

--- a/package.nls.json
+++ b/package.nls.json
@@ -28,5 +28,5 @@
 
   "configuration.accessibility.linkUnderlines.description": "Show underlines on links in text blocks, matching GitHub's default accessibility setting.",
 
-  "configuration.mermaid.syncTheme.description": "Synchronize the markdown-mermaid light and dark themes with GitHub Markdown, restoring the previous settings when disabled."
+  "configuration.mermaid.syncTheme.description": "Synchronize the light and dark themes used by VS Code's built-in Mermaid renderer or markdown-mermaid with GitHub Markdown. Disabling synchronization restores previous values without replacing newer Mermaid choices."
 }

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -28,5 +28,5 @@
 
   "configuration.accessibility.linkUnderlines.description": "显示文本块中链接的下划线，与 GitHub 的默认无障碍设置保持一致。",
 
-  "configuration.mermaid.syncTheme.description": "将 markdown-mermaid 的亮色和暗色主题与 GitHub Markdown 同步，并在关闭同步时恢复原设置。"
+  "configuration.mermaid.syncTheme.description": "将 VS Code 内置 Mermaid 渲染器或 markdown-mermaid 使用的亮色和暗色主题与 GitHub Markdown 同步；关闭同步时恢复原值，但不覆盖更新的 Mermaid 选择。"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import vscode from "vscode";
 import type MarkdownIt from "markdown-it";
 import { registerThemeCommands } from "./commands";
 import { registerMarkdownPreviewEvents } from "./events";
-import { updateMermaidThemeSync } from "./integrations/mermaid";
+import { restoreMermaidThemeSync, updateMermaidThemeSync } from "./integrations/mermaid";
 import alerts from "./plugins/markdown-it-github-alerts";
 import directionality from "./plugins/markdown-it-github-directionality";
 import emoji from "./plugins/markdown-it-github-emoji";
@@ -13,9 +13,12 @@ import tagfilter from "./plugins/markdown-it-github-tagfilter";
 import taskLists from "./plugins/markdown-it-github-task-lists";
 import theme from "./plugins/markdown-it-github-theme";
 
+let activeMemento: vscode.Memento | undefined;
+
 export async function activate(context: vscode.ExtensionContext): Promise<{
   extendMarkdownIt(md: MarkdownIt): MarkdownIt;
 }> {
+  activeMemento = context.globalState;
   context.subscriptions.push(...registerThemeCommands());
   context.subscriptions.push(registerMarkdownPreviewEvents(context.globalState));
 
@@ -39,4 +42,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<{
         .use(imageUrl);
     }
   };
+}
+
+export async function deactivate(): Promise<void> {
+  const memento = activeMemento;
+  activeMemento = undefined;
+  if (!memento) {
+    return;
+  }
+
+  try {
+    await restoreMermaidThemeSync(memento);
+  } catch (error) {
+    console.error("[github-markdown] Failed to restore Mermaid theme on deactivation:", error);
+  }
 }

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -26,10 +26,17 @@ export type MermaidTheme = (typeof themes)[number];
 type MermaidThemeSnapshot = {
   light: MermaidTheme | undefined;
   dark: MermaidTheme | undefined;
+  applied?: {
+    light: MermaidTheme;
+    dark: MermaidTheme;
+  };
 };
 
 const snapshotKey = "githubMarkdown.mermaid.originalGlobalThemes";
-const mermaidExtensionId = "bierner.markdown-mermaid";
+const mermaidExtensionIds = [
+  "vscode.mermaid-markdown-features",
+  "bierner.markdown-mermaid"
+] as const;
 const MERMAID_LIGHT_THEME: MermaidTheme = "default";
 const MERMAID_DARK_THEME: MermaidTheme = "dark";
 
@@ -38,26 +45,54 @@ export function getMermaidSyncTheme(): boolean {
 }
 
 export async function updateMermaidThemeSync(memento: vscode.Memento): Promise<void> {
-  if (!vscode.extensions.getExtension(mermaidExtensionId)) {
-    return;
-  }
-
   const configuration = getOriginMermaidThemeConfiguration();
-  if (!hasMermaidThemeConfiguration(configuration)) {
-    return;
-  }
 
   if (!getMermaidSyncTheme()) {
-    await restoreMermaidThemes(memento, configuration);
+    await restoreMermaidThemeSync(memento, configuration);
     return;
   }
 
-  await preserveMermaidThemes(memento, configuration);
+  if (!hasMermaidExtension() || !hasMermaidThemeConfiguration(configuration)) {
+    return;
+  }
+
+  const snapshot = await preserveMermaidThemes(memento, configuration);
   const [light, dark] = resolveMermaidThemes();
   await Promise.all([
     updateMermaidTheme(configuration, originSection.light, light),
     updateMermaidTheme(configuration, originSection.dark, dark)
   ]);
+  await memento.update(snapshotKey, {
+    ...snapshot,
+    applied: { light, dark }
+  } satisfies MermaidThemeSnapshot);
+}
+
+export async function restoreMermaidThemeSync(
+  memento: vscode.Memento,
+  configuration = getOriginMermaidThemeConfiguration()
+): Promise<void> {
+  const snapshot = memento.get<MermaidThemeSnapshot>(snapshotKey);
+  if (!snapshot || !hasMermaidThemeConfiguration(configuration)) {
+    return;
+  }
+
+  const updates: Promise<void>[] = [];
+  if (
+    snapshot.applied &&
+    getGlobalMermaidTheme(configuration, originSection.light) === snapshot.applied.light
+  ) {
+    updates.push(updateMermaidTheme(configuration, originSection.light, snapshot.light));
+  }
+  if (
+    snapshot.applied &&
+    getGlobalMermaidTheme(configuration, originSection.dark) === snapshot.applied.dark
+  ) {
+    updates.push(updateMermaidTheme(configuration, originSection.dark, snapshot.dark));
+  }
+
+  await Promise.all(updates);
+  await memento.update(snapshotKey, undefined);
 }
 
 function resolveMermaidThemes(): readonly [MermaidTheme, MermaidTheme] {
@@ -76,31 +111,22 @@ function resolveMermaidTheme(markdownTheme: Theme): MermaidTheme {
 async function preserveMermaidThemes(
   memento: vscode.Memento,
   configuration: vscode.WorkspaceConfiguration
-): Promise<void> {
-  if (memento.get<MermaidThemeSnapshot>(snapshotKey)) {
-    return;
+): Promise<MermaidThemeSnapshot> {
+  const snapshot = memento.get<MermaidThemeSnapshot>(snapshotKey);
+  if (snapshot) {
+    return snapshot;
   }
 
-  await memento.update(snapshotKey, {
-    light: configuration.inspect<MermaidTheme>(originSection.light)?.globalValue,
-    dark: configuration.inspect<MermaidTheme>(originSection.dark)?.globalValue
-  } satisfies MermaidThemeSnapshot);
+  const newSnapshot = {
+    light: getGlobalMermaidTheme(configuration, originSection.light),
+    dark: getGlobalMermaidTheme(configuration, originSection.dark)
+  } satisfies MermaidThemeSnapshot;
+  await memento.update(snapshotKey, newSnapshot);
+  return newSnapshot;
 }
 
-async function restoreMermaidThemes(
-  memento: vscode.Memento,
-  configuration: vscode.WorkspaceConfiguration
-): Promise<void> {
-  const snapshot = memento.get<MermaidThemeSnapshot>(snapshotKey);
-  if (!snapshot) {
-    return;
-  }
-
-  await Promise.all([
-    updateMermaidTheme(configuration, originSection.light, snapshot.light),
-    updateMermaidTheme(configuration, originSection.dark, snapshot.dark)
-  ]);
-  await memento.update(snapshotKey, undefined);
+function hasMermaidExtension(): boolean {
+  return mermaidExtensionIds.some((id) => vscode.extensions.getExtension(id) !== undefined);
 }
 
 function getOriginMermaidThemeConfiguration(): vscode.WorkspaceConfiguration {
@@ -112,6 +138,13 @@ function hasMermaidThemeConfiguration(configuration: vscode.WorkspaceConfigurati
     configuration.inspect(originSection.light) !== undefined &&
     configuration.inspect(originSection.dark) !== undefined
   );
+}
+
+function getGlobalMermaidTheme(
+  configuration: vscode.WorkspaceConfiguration,
+  key: typeof originSection.light | typeof originSection.dark
+): MermaidTheme | undefined {
+  return configuration.inspect<MermaidTheme>(key)?.globalValue;
 }
 
 async function updateMermaidTheme(

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -21,7 +21,7 @@ vi.mock("vscode", () => ({
   default: {
     ConfigurationTarget: { Global: 1 },
     extensions: {
-      getExtension: () => ({})
+      getExtension: (id: string) => (id === "vscode.mermaid-markdown-features" ? {} : undefined)
     },
     commands: {
       registerCommand: (id: string, handler: () => Promise<void>) => {
@@ -73,7 +73,7 @@ vi.mock("vscode", () => ({
   }
 }));
 
-import { activate } from "../src/extension";
+import { activate, deactivate } from "../src/extension";
 
 function createContext(): vscode.ExtensionContext {
   return {
@@ -138,6 +138,19 @@ describe("extension lifecycle", () => {
       { key: "darkModeTheme", value: "forest", target: 1 }
     ]);
     expect(harness.executeCalls).toEqual(["markdown.preview.refresh"]);
+  });
+
+  it("restores Mermaid settings when the extension is deactivated", async () => {
+    const context = createContext();
+    await activate(context);
+    harness.mermaidUpdates.length = 0;
+
+    await deactivate();
+
+    expect(harness.mermaidUpdates).toEqual([
+      { key: "lightModeTheme", value: "neutral", target: 1 },
+      { key: "darkModeTheme", value: "forest", target: 1 }
+    ]);
   });
 
   it("updates a theme through a registered command while treating cancellation as a no-op", async () => {

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -14,7 +14,7 @@ let mermaidGlobalConfig: Record<string, string | undefined> = {
   darkModeTheme: "forest"
 };
 let mermaidConfigurationRegistered = true;
-let mermaidExtensionInstalled = true;
+let mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features"]);
 
 const updateCalls: { key: string; value: string | undefined; target: number }[] = [];
 
@@ -22,7 +22,7 @@ vi.mock("vscode", () => ({
   default: {
     ConfigurationTarget: { Global: 1 },
     extensions: {
-      getExtension: () => (mermaidExtensionInstalled ? {} : undefined)
+      getExtension: (id: string) => (mermaidExtensionIds.has(id) ? {} : undefined)
     },
     workspace: {
       getConfiguration: (namespace?: string) => {
@@ -64,7 +64,7 @@ describe("Mermaid theme synchronization", () => {
       darkModeTheme: "forest"
     };
     mermaidConfigurationRegistered = true;
-    mermaidExtensionInstalled = true;
+    mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features"]);
   });
 
   it("configures both Mermaid slots from the system-mode light and dark themes", async () => {
@@ -93,6 +93,15 @@ describe("Mermaid theme synchronization", () => {
     ]);
   });
 
+  it("also supports the legacy external Mermaid extension", async () => {
+    const memento = createTestMemento();
+    mermaidExtensionIds = new Set(["bierner.markdown-mermaid"]);
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toHaveLength(2);
+  });
+
   it("restores the user's global Mermaid settings when synchronization is disabled", async () => {
     const memento = createTestMemento();
 
@@ -111,6 +120,23 @@ describe("Mermaid theme synchronization", () => {
     ]);
   });
 
+  it("does not overwrite Mermaid choices made while synchronization was active", async () => {
+    const memento = createTestMemento();
+
+    await updateMermaidThemeSync(memento);
+    mermaidGlobalConfig["lightModeTheme"] = "base";
+
+    markdownConfig["mermaid.syncTheme"] = false;
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "darkModeTheme", value: "forest", target: 1 }]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "forest"
+    });
+  });
+
   it("does not modify Mermaid settings when synchronization starts disabled", async () => {
     const memento = createTestMemento();
     markdownConfig["mermaid.syncTheme"] = false;
@@ -122,7 +148,7 @@ describe("Mermaid theme synchronization", () => {
 
   it("does not modify settings when the Mermaid extension is not installed", async () => {
     const memento = createTestMemento();
-    mermaidExtensionInstalled = false;
+    mermaidExtensionIds.clear();
 
     await updateMermaidThemeSync(memento);
 


### PR DESCRIPTION
## Summary

- support both VS Code's built-in `vscode.mermaid-markdown-features` extension and the legacy external `bierner.markdown-mermaid` extension
- restore only Mermaid theme values still owned by this extension when synchronization is disabled or the extension is deactivated
- preserve newer user choices and update the English/Chinese documentation, configuration descriptions, and changelog

## Validation

- `nub run test` — 36 files, 205 tests passed on the latest base
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nub run build`
- VS Code desktop host smoke tests on 1.74.0 and stable
- stable VS Code Web host smoke test
- `nub run package`
- `lychee --offline README.md README.zh-CN.md CHANGELOG.md`

The latest-base local build would require installing the newly pinned pnpm 11.13.1, so that repeat is left to CI; the build, package, and host checks passed before the dependency-only rebase.

Closes #1137