### PR TITLE
fix(theme): preserve high-contrast themes in Single mode

### DIFF
--- a/src/extension.preview.css
+++ b/src/extension.preview.css
@@ -248,7 +248,8 @@ body,
 
 body.vscode-high-contrast,
 body.vscode-high-contrast-light {
-  .vscode-github-markdown {
+  .vscode-github-markdown[data-color-mode="auto"],
+  .vscode-github-markdown[data-color-mode="vscode"] {
     --bgColor-default: var(--vscode-editor-background) !important;
     --fgColor-default: var(--vscode-editor-foreground) !important;
     --fgColor-accent: var(--vscode-textLink-foreground) !important;

--- a/tests/host/smoke.ts
+++ b/tests/host/smoke.ts
@@ -120,7 +120,7 @@ export async function run(): Promise<void> {
   // VS Code 1.74 does not apply workbench.colorTheme writes from extension-host tests.
   // Stable desktop and web hosts cover the live light, dark, and high-contrast signals.
   if (!vscode.version.startsWith("1.74.")) {
-    await assertPreviewColorThemeSignals();
+    await assertPreviewColorThemeSignals(markdown);
   }
 
   const previewStyles = extension.packageJSON.contributes?.["markdown.previewStyles"] as
@@ -145,7 +145,9 @@ async function assertVsCodeThemeMode(markdown: string): Promise<void> {
   }
 }
 
-async function assertPreviewColorThemeSignals(): Promise<void> {
+async function assertPreviewColorThemeSignals(markdown: string): Promise<void> {
+  const githubMarkdown = vscode.workspace.getConfiguration("githubMarkdown");
+  const originalGlobalMode = githubMarkdown.inspect<string>("theme.mode")?.globalValue;
   const workbench = vscode.workspace.getConfiguration("workbench");
   const originalGlobalTheme = workbench.inspect<string>("colorTheme")?.globalValue;
   const cases = [
@@ -155,12 +157,23 @@ async function assertPreviewColorThemeSignals(): Promise<void> {
   ] as const;
 
   try {
+    await githubMarkdown.update("theme.mode", "system", vscode.ConfigurationTarget.Global);
     for (const [theme, expectedKind] of cases) {
       await workbench.update("colorTheme", theme, vscode.ConfigurationTarget.Global);
       await waitForColorThemeKind(expectedKind);
+      const html = await vscode.commands.executeCommand<string>("markdown.api.render", markdown);
+      assert(
+        html?.includes('data-color-mode="auto"'),
+        `System mode remains active after switching to ${theme}`
+      );
     }
   } finally {
     await workbench.update("colorTheme", originalGlobalTheme, vscode.ConfigurationTarget.Global);
+    await githubMarkdown.update(
+      "theme.mode",
+      originalGlobalMode,
+      vscode.ConfigurationTarget.Global
+    );
   }
 }
 

--- a/tests/preview-css.test.ts
+++ b/tests/preview-css.test.ts
@@ -1,9 +1,31 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { readGithubCssAssets } from "../scripts/build/github-css";
 
 const previewCss = readFileSync(new URL("../src/extension.preview.css", import.meta.url), "utf8");
 
 describe("preview theme CSS", () => {
+  it("defines every color token consumed by the shared GitHub CSS", async () => {
+    const assets = await readGithubCssAssets();
+    const sharedCss = assets.find(({ fileName }) => fileName === "github-markdown.css")?.content;
+    expect(sharedCss).toBeDefined();
+
+    const vscodeModeCss = extractCssBlock(
+      previewCss,
+      '.vscode-github-markdown[data-color-mode="vscode"]'
+    );
+    const consumedTokens = new Set(
+      [...sharedCss!.matchAll(/var\(\s*(--[\w-]+)/g)]
+        .map((match) => match[1]!)
+        .filter(isGitHubColorToken)
+    );
+    const definedTokens = new Set(
+      [...vscodeModeCss.matchAll(/(--[\w-]+)\s*:/g)].map((match) => match[1]!)
+    );
+
+    expect([...consumedTokens].filter((token) => !definedTokens.has(token)).sort()).toEqual([]);
+  });
+
   it("maps VS Code mode to active workbench colors", () => {
     expect(previewCss).toContain('.vscode-github-markdown[data-color-mode="vscode"]');
 
@@ -30,4 +52,35 @@ describe("preview theme CSS", () => {
     expect(previewCss).toContain("--fgColor-accent: var(--vscode-textLink-foreground) !important");
     expect(previewCss).toContain("outline: 2px solid var(--vscode-focusBorder) !important");
   });
+
+  it("does not override Single mode in high-contrast themes", () => {
+    const highContrastCss = extractCssBlock(previewCss, "body.vscode-high-contrast,");
+
+    expect(highContrastCss).toContain('.vscode-github-markdown[data-color-mode="auto"]');
+    expect(highContrastCss).toContain('.vscode-github-markdown[data-color-mode="vscode"]');
+    expect(highContrastCss).not.toContain('.vscode-github-markdown[data-color-mode="light"]');
+    expect(highContrastCss).not.toContain('.vscode-github-markdown[data-color-mode="dark"]');
+  });
 });
+
+function isGitHubColorToken(token: string): boolean {
+  return /^--(?:bgColor|borderColor|color-|fgColor|focus-|selection-)/.test(token);
+}
+
+function extractCssBlock(css: string, selector: string): string {
+  const selectorStart = css.indexOf(selector);
+  const blockStart = css.indexOf("{", selectorStart);
+  if (selectorStart < 0 || blockStart < 0) {
+    throw new Error(`CSS selector not found: ${selector}`);
+  }
+
+  let depth = 0;
+  for (let index = blockStart; index < css.length; index += 1) {
+    if (css[index] === "{") depth += 1;
+    if (css[index] !== "}") continue;
+    depth -= 1;
+    if (depth === 0) return css.slice(blockStart + 1, index);
+  }
+
+  throw new Error(`CSS block is not closed: ${selector}`);
+}


### PR DESCRIPTION
## 变更

- 将高对比度颜色覆盖限制在 System（`auto`）和 VS Code 模式，避免改变 Single 的固定 GitHub 主题
- 自动比较共享 GitHub CSS 消费的颜色 token 与 VS Code 模式定义，防止后续漏映射
- 在稳定版桌面/Web 宿主中验证 System 模式跨亮、暗和高对比度切换后仍保持 `auto`

这是 #1157 的最小后续修复；#1138 和 #1156 已由 #1157 关闭，本 PR 保持两者要求的 Single/System 兼容契约。

## 验证

- `nub run build`
- `nub run test`（37 files / 212 tests）
- `nub scripts/verify/index.ts`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nub run test:host:desktop`（VS Code 1.129.0）
- `nub run test:host:web`
- `VSCODE_TEST_VERSION=1.74.0 nub run test:host:desktop`
- `nub run verify:parity`
- `nub run package`
