### PR TITLE
test(host): fix Web host Quick Input positioning

### DIFF
--- a/scripts/host/preview.ts
+++ b/scripts/host/preview.ts
@@ -89,10 +89,12 @@ async function openFile(page: Page, fileName: string): Promise<void> {
 
 async function runCommand(page: Page, command: string): Promise<void> {
   await page.keyboard.press(`${primaryModifier}+Shift+P`);
-  const input = page.locator(".quick-input-widget input");
+  const input = page.locator(".quick-input-widget input:visible");
   await input.waitFor({ state: "visible" });
   await input.fill(`>${command}`);
-  const result = page.locator(".quick-input-widget .monaco-list-row").filter({ hasText: command });
+  const result = page
+    .locator(".quick-input-widget:visible .monaco-list-row")
+    .filter({ hasText: command });
   await result.first().waitFor({ state: "visible" });
   await result.first().click();
 }
@@ -100,7 +102,7 @@ async function runCommand(page: Page, command: string): Promise<void> {
 async function selectQuickPick(page: Page, command: string, option: string): Promise<void> {
   await runCommand(page, command);
   const result = page
-    .locator(".quick-input-widget .monaco-list-row")
+    .locator(".quick-input-widget:visible .monaco-list-row")
     .getByText(option, { exact: true });
   await result.first().waitFor({ state: "visible" });
   await result.first().click();


### PR DESCRIPTION
## Summary

- restrict command-palette input lookup to the currently visible VS Code Quick Input
- restrict command and option results to the visible Quick Input widget
- prevent stale hidden Web workbench inputs from consuming Playwright actions

## Root cause

The Web final-preview regression used `.quick-input-widget input`, while VS Code Web retained a hidden Quick Input alongside the active one. Playwright resolved the stale hidden input and timed out after 30 seconds while attempting to run `Preferences: Color Theme`.

Failing job: https://github.com/lzm0x219/vscode-github-markdown/actions/runs/29586373849/job/87904270603

## Impact

This stabilizes the real-host theme regression without changing extension runtime behavior.

## Validation

- format and lint checks
- type-aware lint
- 37 Vitest files / 212 tests
- Web final Markdown preview regression
- desktop final Markdown preview regression