### PR TITLE
ci: restrict workflow permissions explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "17 3 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 变更

- 为 CI 工作流显式设置 `contents: read`
- 将 `GITHUB_TOKEN` 权限限制为当前检出和远程 Markdown 校验实际所需的最小范围

## 原因

仓库级默认权限已经收紧为只读；工作流内继续显式声明权限，可以让安全边界随代码版本化，并避免未来仓库设置变化时权限被意外放大。

## 影响

不改变 CI 的构建、测试或产物上传行为。若未来增加自动提交、PR 评论或发布操作，应在对应 job 中单独申请最小写权限。

## 验证

- `nubx oxfmt --check .github/workflows/ci.yml`
- Ruby YAML 解析
- `git diff --check`