### PR TITLE
test(host): stabilize Quick Input interactions

### DIFF
--- a/scripts/host/preview.ts
+++ b/scripts/host/preview.ts
@@ -88,13 +88,14 @@ async function openFile(page: Page, fileName: string): Promise<void> {
 }
 
 async function runCommand(page: Page, command: string): Promise<void> {
+  const quickInput = page.locator(".quick-input-widget:visible");
+  // The shortcut toggles an open Quick Input, so wait for the previous picker to close first.
+  await quickInput.waitFor({ state: "hidden" });
   await page.keyboard.press(`${primaryModifier}+Shift+P`);
-  const input = page.locator(".quick-input-widget input:visible");
+  const input = quickInput.locator("input");
   await input.waitFor({ state: "visible" });
   await input.fill(`>${command}`);
-  const result = page
-    .locator(".quick-input-widget:visible .monaco-list-row")
-    .filter({ hasText: command });
+  const result = quickInput.locator(".monaco-list-row").filter({ hasText: command });
   await result.first().waitFor({ state: "visible" });
   await result.first().click();
 }


### PR DESCRIPTION
## 变更

- 在宿主预览测试再次打开命令面板前，等待已有 Quick Input 完全关闭
- 复用可见 Quick Input 定位器查找输入框和命令结果

## 根因

GitHub Actions 的 `Host smoke (desktop-stable)` 在连续切换主题时，前一个 Quick Input 尚在关闭，下一次命令面板快捷键会把它反向切换为关闭状态，最终在 `.quick-input-widget input:visible` 上等待超时。

失败作业：https://github.com/lzm0x219/vscode-github-markdown/actions/runs/29592989750/job/87926440861

## 影响

提高桌面与 Web 最终 Markdown 预览回归的稳定性，不改变扩展运行时行为。

## 验证

- `nub run test:host:desktop:preview` 连续通过 3 次（VS Code 1.129.0）
- `nub run test:host:web:preview`
- `nub run test`（37 个文件，212 项测试）
- `nubx oxlint --type-aware scripts/host/preview.ts`
- `nubx oxfmt --check scripts/host/preview.ts`
- `git diff --check`