### PR TITLE
feat(parity): add three-way parity reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "update:parity:offline": "nub scripts/parity/index.ts sync",
     "verify:parity": "nub scripts/parity/index.ts check",
     "verify:parity:remote": "nub scripts/parity/index.ts remote",
+    "verify:parity:report": "nub scripts/parity/index.ts report",
     "probe:drift": "nub scripts/drift/index.ts",
     "i18n-export": "nubx vscode-l10n-dev export --outDir ./l10n ./src",
     "test": "vitest run",

--- a/scripts/drift/probe.ts
+++ b/scripts/drift/probe.ts
@@ -94,6 +94,15 @@ export async function createDriftReport(options: DriftProbeOptions): Promise<Dri
 
 export function classifyProbeError(stage: ProbeStage, error: unknown): DriftConclusion {
   if (error instanceof GithubCssSnapshotContractError) return "extraction_failure";
+  const threeWayConclusion = threeWayReportConclusion(error);
+  if (
+    threeWayConclusion === "upstream-drift" ||
+    threeWayConclusion === "upstream-drift-with-user-impact"
+  ) {
+    return "drift_detected";
+  }
+  if (threeWayConclusion === "extract-failure") return "extraction_failure";
+  if (threeWayConclusion === "render-failure") return "render_failure";
   const message = errorMessage(error);
   if (/fetch failed|timed out|econn|enotfound|eai_again|aborterror/i.test(message)) {
     return "network_failure";
@@ -191,4 +200,19 @@ function failureDetails(
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function threeWayReportConclusion(error: unknown): string | undefined {
+  if (
+    typeof error !== "object" ||
+    error === null ||
+    !("report" in error) ||
+    typeof error.report !== "object" ||
+    error.report === null ||
+    !("conclusion" in error.report) ||
+    typeof error.report.conclusion !== "string"
+  ) {
+    return undefined;
+  }
+  return error.report.conclusion;
 }

--- a/scripts/drift/run.ts
+++ b/scripts/drift/run.ts
@@ -19,7 +19,7 @@ export async function runDriftProbe(): Promise<void> {
       const { snapshot } = await createReferenceCssSnapshot(fixtureCommit);
       return snapshot;
     },
-    verifyRemoteParity: () => runParityCommand("remote")
+    verifyRemoteParity: () => runParityCommand("report")
   });
   const directory = join(project.root, "artifacts", "drift");
   const markdown = renderDriftReport(report);

--- a/scripts/parity/browser.ts
+++ b/scripts/parity/browser.ts
@@ -18,6 +18,8 @@ export type ScreenshotRequest = {
   theme: "light" | "dark";
   themeName: GithubTheme;
   linkUnderlines: boolean;
+  viewport?: { width: number; height: number };
+  interaction?: "default" | "focus" | "hover";
 };
 
 const viewport = { width: 1024, height: 720 };
@@ -27,18 +29,20 @@ export const visualRenderConfiguration = JSON.stringify({
   javaScriptEnabled: false,
   capture: "markdown-container"
 });
-const commonCss = `
+function commonCss(width: number): string {
+  return `
   :root { --vscode-editor-font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
   html, body { margin: 0; background: transparent; }
   .vscode-github-markdown {
     box-sizing: border-box;
-    width: ${viewport.width}px;
+    width: ${width}px;
     height: auto !important;
     min-height: 0 !important;
     margin: 0 !important;
     padding: 36px !important;
   }
 `;
+}
 const githubPageCss = `
   .vscode-github-markdown a { text-decoration: underline; }
   .vscode-github-markdown[data-link-underlines="false"] a { text-decoration: none; }
@@ -96,12 +100,31 @@ export async function captureScreenshots(
       return route.abort();
     });
     const screenshots: Record<string, Buffer> = {};
-    for (const { id, html, css, theme, themeName, linkUnderlines } of requests) {
+    for (const {
+      id,
+      html,
+      css,
+      theme,
+      themeName,
+      linkUnderlines,
+      viewport: requestViewport = viewport,
+      interaction = "default"
+    } of requests) {
+      await page.setViewportSize(requestViewport);
       await page.emulateMedia({ colorScheme: theme });
-      const safeCss = `${css}\n${commonCss}`.replace(/<\/style/gi, "<\\/style");
+      const safeCss = `${css}\n${commonCss(requestViewport.width)}`.replace(
+        /<\/style/gi,
+        "<\\/style"
+      );
       await page.setContent(
         `<style>${safeCss}</style><main class="vscode-github-markdown" data-color-mode="${theme}" data-light-theme="${theme === "light" ? themeName : "light"}" data-dark-theme="${theme === "dark" ? themeName : "dark"}" data-link-underlines="${linkUnderlines}">${html}</main>`
       );
+      const interactive = page
+        .locator(".vscode-github-markdown")
+        .locator("a, button, input, summary")
+        .first();
+      if (interaction === "focus" && (await interactive.count())) await interactive.focus();
+      if (interaction === "hover" && (await interactive.count())) await interactive.hover();
       screenshots[id] = await page.locator(".vscode-github-markdown").screenshot({
         animations: "disabled"
       });

--- a/scripts/parity/cli.ts
+++ b/scripts/parity/cli.ts
@@ -25,6 +25,11 @@ import { renderGitHubMarkdown, renderGitHubRepositoryFile, resolveGitHubRef } fr
 import { stripPlatformWrapperMarkup, stripSyntaxTokenMarkup } from "./html";
 import { renderLocalMarkdown } from "./local";
 import { artifactNames, screenshotKeys } from "./names";
+import {
+  collectThreeWayReport,
+  renderThreeWayReport,
+  ThreeWayParityReportError
+} from "./three-way";
 import { compareScreenshots } from "./visual";
 
 type CaseReport = {
@@ -69,10 +74,11 @@ export async function runParityCommand(command = process.argv[2] ?? "check"): Pr
   if (command === "refresh") return refreshBaseline();
   if (command === "snapshot") return refreshCssSnapshot();
   if (command === "sync") return syncBaseline();
+  if (command === "report") return runThreeWayParityReport();
   if (command === "remote") return checkVisualParity("github");
   if (command === "check") return checkVisualParity("local");
   throw new Error(
-    `Unknown parity command: ${command}. Expected check, remote, refresh, snapshot, or sync.`
+    `Unknown parity command: ${command}. Expected check, remote, report, refresh, snapshot, or sync.`
   );
 }
 
@@ -176,6 +182,46 @@ async function checkVisualParity(actualSource: "github" | "local"): Promise<void
   }
   if (reports.some(({ passed }) => !passed)) {
     throw new Error(`Visual parity exceeded its limits. See ${artifactDirectory}`);
+  }
+}
+
+async function runThreeWayParityReport(): Promise<void> {
+  const artifactDirectory = join(project.root, "artifacts", "parity");
+  await mkdir(artifactDirectory, { recursive: true });
+  const report = await collectThreeWayReport(parityCases, {
+    fetchCurrentGithub: async () =>
+      renderAllGitHubCases(await resolveRepositoryReferences(parityCases)),
+    extractInputs: async () => {
+      await buildCss();
+      const [baseline, committedReferenceCss, currentGithubCss, currentExtensionCss] =
+        await Promise.all([
+          readBaseline(),
+          readFile(project.paths.parityReferenceCss, "utf8"),
+          createReferenceCss(),
+          readLocalCss()
+        ]);
+      validateBaseline(baseline, parityCases, committedReferenceCss, visualRenderConfiguration);
+      return {
+        baseline,
+        committedReferenceCss,
+        currentGithubCss,
+        currentExtensionCss
+      };
+    },
+    render: captureScreenshots,
+    compare: compareScreenshots,
+    writeArtifact: (name, content) => writeFile(join(artifactDirectory, name), content)
+  });
+  await Promise.all([
+    writeFile(
+      join(artifactDirectory, "three-way-report.json"),
+      `${JSON.stringify(report, null, 2)}\n`
+    ),
+    writeFile(join(artifactDirectory, "three-way-report.md"), renderThreeWayReport(report))
+  ]);
+  console.log(`Three-way Markdown parity: ${report.conclusion}`);
+  if (report.conclusion !== "pass") {
+    throw new ThreeWayParityReportError(report, artifactDirectory);
   }
 }
 

--- a/scripts/parity/three-way.ts
+++ b/scripts/parity/three-way.ts
@@ -1,0 +1,430 @@
+import type { Buffer } from "node:buffer";
+import type { GithubTheme } from "../build/github-css";
+import type { VisualBaseline } from "./baseline";
+import type { ScreenshotRequest } from "./browser";
+import type { VisualParityCase } from "./cases";
+import type { ScreenshotComparison } from "./visual";
+import { stripPlatformWrapperMarkup, stripSyntaxTokenMarkup } from "./html";
+import { renderLocalMarkdown } from "./local";
+
+export type ThreeWayStage = "fetch" | "extract" | "render" | "compare";
+export type ThreeWayComparison =
+  | "baseline-github-vs-current-github"
+  | "current-extension-vs-current-github"
+  | "current-extension-vs-committed-baseline";
+
+type StageResult = {
+  status: "pending" | "pass" | "fail";
+  error?: { name: string; message: string };
+};
+
+type ComparisonPolicy =
+  | { kind: "exact"; owner: string; limits: ComparisonLimits }
+  | {
+      kind: "integration-boundary";
+      scope: "separate-fixture";
+      owner: string;
+      reason: string;
+      reviewCondition: string;
+      limits: ComparisonLimits;
+    };
+
+type ComparisonLimits = { pixels: number; pixelRatio: number; areaPixels: number };
+
+export type ThreeWayCaseReport = {
+  id: string;
+  sourceCaseId: string;
+  viewport: "wide" | "narrow";
+  interaction: "default" | "focus" | "hover";
+  passed: boolean;
+  width: number;
+  height: number;
+  diffPixels: number;
+  diffPixelRatio: number;
+  largestDiffAreaPixels: number;
+  policy: ComparisonPolicy;
+  artifacts: { expected: string; actual: string; diff: string };
+};
+
+export type ThreeWayReport = {
+  schemaVersion: 1;
+  generatedAt: string;
+  conclusion:
+    | "pass"
+    | "upstream-drift"
+    | "upstream-drift-with-user-impact"
+    | "extension-regression"
+    | "multiple-differences"
+    | `${ThreeWayStage}-failure`;
+  stages: Record<ThreeWayStage, StageResult>;
+  metadata?: {
+    baselineGeneratedAt: string;
+    baselineChromiumVersion: string;
+    chromiumVersion: string;
+  };
+  comparisons: Record<ThreeWayComparison, ThreeWayCaseReport[]>;
+};
+
+export class ThreeWayParityReportError extends Error {
+  constructor(
+    readonly report: ThreeWayReport,
+    artifactDirectory: string
+  ) {
+    const failedStage = (["fetch", "extract", "render", "compare"] as const).find(
+      (stage) => report.stages[stage].status === "fail"
+    );
+    const details = failedStage
+      ? `: ${report.stages[failedStage].error?.message ?? "unknown error"}`
+      : "";
+    super(
+      `Three-way Markdown parity concluded ${report.conclusion}${details}. See ${artifactDirectory}`
+    );
+    this.name = "ThreeWayParityReportError";
+  }
+}
+
+type ExtractedInputs = {
+  baseline: VisualBaseline;
+  committedReferenceCss: string;
+  currentGithubCss: string;
+  currentExtensionCss: string;
+};
+
+export type ThreeWayDependencies = {
+  fetchCurrentGithub: () => Promise<Record<string, string>>;
+  extractInputs: () => Promise<ExtractedInputs>;
+  render: (
+    requests: readonly ScreenshotRequest[]
+  ) => Promise<{ chromiumVersion: string; screenshots: Record<string, Buffer> }>;
+  compare: (expected: Buffer, actual: Buffer) => ScreenshotComparison;
+  writeArtifact: (name: string, content: Buffer) => Promise<void>;
+};
+
+type ReportVariant = {
+  id: string;
+  source: VisualParityCase;
+  viewport: "wide" | "narrow";
+  dimensions: { width: number; height: number };
+  interaction: "default" | "focus" | "hover";
+};
+
+const comparisons: readonly ThreeWayComparison[] = [
+  "baseline-github-vs-current-github",
+  "current-extension-vs-current-github",
+  "current-extension-vs-committed-baseline"
+];
+
+export async function collectThreeWayReport(
+  cases: readonly VisualParityCase[],
+  dependencies: ThreeWayDependencies,
+  generatedAt = new Date().toISOString()
+): Promise<ThreeWayReport> {
+  const report = emptyReport(generatedAt);
+  let currentGithub: Record<string, string>;
+  try {
+    currentGithub = await dependencies.fetchCurrentGithub();
+    report.stages.fetch = { status: "pass" };
+  } catch (error) {
+    return failStage(report, "fetch", error);
+  }
+
+  let inputs: ExtractedInputs;
+  try {
+    inputs = await dependencies.extractInputs();
+    report.stages.extract = { status: "pass" };
+  } catch (error) {
+    return failStage(report, "extract", error);
+  }
+
+  const variants = createReportVariants(cases);
+  let rendered: Awaited<ReturnType<ThreeWayDependencies["render"]>>;
+  try {
+    rendered = await dependencies.render(
+      variants.flatMap((variant) =>
+        screenshotRequests(variant, inputs, currentGithub[variant.source.id])
+      )
+    );
+    await Promise.all(
+      variants.flatMap((variant) =>
+        subjects.map(async (subject) => {
+          const key = screenshotKey(variant.id, subject);
+          const screenshot = rendered.screenshots[key];
+          if (!screenshot) throw new Error(`Missing rendered screenshot: ${key}`);
+          await dependencies.writeArtifact(`${key}.png`, screenshot);
+        })
+      )
+    );
+    report.stages.render = { status: "pass" };
+  } catch (error) {
+    return failStage(report, "render", error);
+  }
+
+  try {
+    for (const variant of variants) {
+      for (const comparison of comparisons) {
+        const [expectedSubject, actualSubject] = comparisonSubjects(comparison);
+        const expected = rendered.screenshots[screenshotKey(variant.id, expectedSubject)];
+        const actual = rendered.screenshots[screenshotKey(variant.id, actualSubject)];
+        if (!expected || !actual) {
+          throw new Error(`Missing screenshots for ${variant.id} ${comparison}`);
+        }
+        const result = dependencies.compare(expected, actual);
+        const policy = comparisonPolicy(variant.source, comparison);
+        const artifacts = {
+          expected: `${screenshotKey(variant.id, expectedSubject)}.png`,
+          actual: `${screenshotKey(variant.id, actualSubject)}.png`,
+          diff: `${variant.id}-${comparison}-diff.png`
+        };
+        await dependencies.writeArtifact(artifacts.diff, result.diff);
+        report.comparisons[comparison].push({
+          id: variant.id,
+          sourceCaseId: variant.source.id,
+          viewport: variant.viewport,
+          interaction: variant.interaction,
+          passed: withinLimits(result, policy.limits),
+          width: result.width,
+          height: result.height,
+          diffPixels: result.diffPixels,
+          diffPixelRatio: result.diffPixelRatio,
+          largestDiffAreaPixels: result.largestDiffAreaPixels,
+          policy,
+          artifacts
+        });
+      }
+    }
+    report.stages.compare = { status: "pass" };
+  } catch (error) {
+    return failStage(report, "compare", error);
+  }
+
+  report.metadata = {
+    baselineGeneratedAt: inputs.baseline.generatedAt,
+    baselineChromiumVersion: inputs.baseline.chromiumVersion,
+    chromiumVersion: rendered.chromiumVersion
+  };
+  report.conclusion = comparisonConclusion(report.comparisons);
+  return report;
+}
+
+export function renderThreeWayReport(report: ThreeWayReport): string {
+  const lines = [
+    "# Three-way Markdown parity",
+    "",
+    `Conclusion: \`${report.conclusion}\``,
+    "",
+    "## Stages",
+    "",
+    "| Stage | Status | Error |",
+    "| --- | --- | --- |",
+    ...(["fetch", "extract", "render", "compare"] as const).map((stage) => {
+      const result = report.stages[stage];
+      return `| ${stage} | ${result.status} | ${escapeTable(result.error?.message ?? "")} |`;
+    })
+  ];
+  for (const comparison of comparisons) {
+    lines.push(
+      "",
+      `## ${comparison}`,
+      "",
+      "| Case | Result | Viewport | Interaction | Pixels | Ratio | Largest area | Policy | Owner | Artifacts |",
+      "| --- | --- | --- | --- | ---: | ---: | ---: | --- | --- | --- |",
+      ...report.comparisons[comparison].map((item) => {
+        const limits = item.policy.limits;
+        const policy =
+          item.policy.kind === "exact"
+            ? "exact"
+            : `boundary: ${item.policy.reason}; review: ${item.policy.reviewCondition}`;
+        return `| ${item.id} | ${item.passed ? "Pass" : "Fail"} | ${item.viewport} | ${item.interaction} | ${item.diffPixels}/${limits.pixels} | ${(item.diffPixelRatio * 100).toFixed(4)}%/${(limits.pixelRatio * 100).toFixed(4)}% | ${item.largestDiffAreaPixels}/${limits.areaPixels} | ${escapeTable(policy)} | ${escapeTable(item.policy.owner)} | [expected](${item.artifacts.expected}) · [actual](${item.artifacts.actual}) · [diff](${item.artifacts.diff}) |`;
+      })
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export function createReportVariants(cases: readonly VisualParityCase[]): readonly ReportVariant[] {
+  const byId = new Map(cases.map((parityCase) => [parityCase.id, parityCase]));
+  const narrowFocus = byId.get("stress-light");
+  const narrowHover = byId.get("stress-dark");
+  if (!narrowFocus || !narrowHover) {
+    throw new Error("Parity report matrix requires light and dark stress cases");
+  }
+  return [
+    ...cases.map((source) => ({
+      id: source.id,
+      source,
+      viewport: "wide" as const,
+      dimensions: { width: 1024, height: 720 },
+      interaction: "default" as const
+    })),
+    {
+      id: "stress-light-narrow-focus",
+      source: narrowFocus,
+      viewport: "narrow",
+      dimensions: { width: 420, height: 720 },
+      interaction: "focus"
+    },
+    {
+      id: "stress-dark-narrow-hover",
+      source: narrowHover,
+      viewport: "narrow",
+      dimensions: { width: 420, height: 720 },
+      interaction: "hover"
+    }
+  ];
+}
+
+function emptyReport(generatedAt: string): ThreeWayReport {
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    conclusion: "pass",
+    stages: {
+      fetch: { status: "pending" },
+      extract: { status: "pending" },
+      render: { status: "pending" },
+      compare: { status: "pending" }
+    },
+    comparisons: {
+      "baseline-github-vs-current-github": [],
+      "current-extension-vs-current-github": [],
+      "current-extension-vs-committed-baseline": []
+    }
+  };
+}
+
+function failStage(report: ThreeWayReport, stage: ThreeWayStage, error: unknown): ThreeWayReport {
+  report.stages[stage] = {
+    status: "fail",
+    error: {
+      name: error instanceof Error ? error.name : "UnknownError",
+      message: error instanceof Error ? error.message : String(error)
+    }
+  };
+  report.conclusion = `${stage}-failure`;
+  return report;
+}
+
+const subjects = ["baseline-github", "current-github", "current-extension"] as const;
+type Subject = (typeof subjects)[number];
+
+function screenshotRequests(
+  variant: ReportVariant,
+  inputs: ExtractedInputs,
+  currentGithubHtml: string | undefined
+): ScreenshotRequest[] {
+  const baselineHtml = inputs.baseline.cases[variant.source.id]?.githubHtml;
+  if (!baselineHtml) throw new Error(`Missing baseline GitHub HTML for ${variant.source.id}`);
+  if (!currentGithubHtml) throw new Error(`Missing current GitHub HTML for ${variant.source.id}`);
+  const common = {
+    theme: variant.source.theme,
+    themeName: variant.source.themeName as GithubTheme,
+    linkUnderlines: variant.source.linkUnderlines,
+    viewport: variant.dimensions,
+    interaction: variant.interaction
+  };
+  return [
+    {
+      ...common,
+      id: screenshotKey(variant.id, "baseline-github"),
+      html: normalize(baselineHtml, variant.source.htmlNormalization),
+      css: inputs.committedReferenceCss
+    },
+    {
+      ...common,
+      id: screenshotKey(variant.id, "current-github"),
+      html: normalize(currentGithubHtml, variant.source.htmlNormalization),
+      css: inputs.currentGithubCss
+    },
+    {
+      ...common,
+      id: screenshotKey(variant.id, "current-extension"),
+      html: normalize(
+        renderLocalMarkdown(variant.source.markdown),
+        variant.source.htmlNormalization
+      ),
+      css: inputs.currentExtensionCss
+    }
+  ];
+}
+
+function normalize(html: string, mode: VisualParityCase["htmlNormalization"]): string {
+  const withoutWrappers = stripPlatformWrapperMarkup(html);
+  return mode === "syntax-tokens" ? stripSyntaxTokenMarkup(withoutWrappers) : withoutWrappers;
+}
+
+function screenshotKey(id: string, subject: Subject): string {
+  return `${id}-${subject}`;
+}
+
+function comparisonSubjects(comparison: ThreeWayComparison): readonly [Subject, Subject] {
+  if (comparison === "baseline-github-vs-current-github") {
+    return ["baseline-github", "current-github"];
+  }
+  if (comparison === "current-extension-vs-current-github") {
+    return ["current-github", "current-extension"];
+  }
+  return ["baseline-github", "current-extension"];
+}
+
+function comparisonPolicy(
+  parityCase: VisualParityCase,
+  comparison: ThreeWayComparison
+): ComparisonPolicy {
+  const exact = { pixels: 0, pixelRatio: 0, areaPixels: 0 };
+  if (comparison === "baseline-github-vs-current-github") {
+    return { kind: "exact", owner: "GitHub", limits: exact };
+  }
+  if (parityCase.localComparison.kind === "exact") {
+    return { kind: "exact", owner: "extension", limits: exact };
+  }
+  const limits = {
+    pixels: parityCase.maxDiffPixels,
+    pixelRatio: parityCase.maxDiffPixelRatio,
+    areaPixels: parityCase.maxDiffAreaPixels
+  };
+  if (parityCase.id.includes("host-highlighting")) {
+    return {
+      kind: "integration-boundary",
+      scope: "separate-fixture",
+      owner: "VS Code Markdown host",
+      reason: parityCase.localComparison.reason,
+      reviewCondition: "Review when VS Code token markup or bundled syntax highlighting changes.",
+      limits
+    };
+  }
+  return {
+    kind: "integration-boundary",
+    scope: "separate-fixture",
+    owner: "GitHub client renderers and companion extensions",
+    reason: parityCase.localComparison.reason,
+    reviewCondition: "Review when Mermaid, math, GeoJSON, STL, or companion rendering changes.",
+    limits
+  };
+}
+
+function withinLimits(comparison: ScreenshotComparison, limits: ComparisonLimits): boolean {
+  return (
+    comparison.diffPixels <= limits.pixels &&
+    comparison.diffPixelRatio <= limits.pixelRatio &&
+    comparison.largestDiffAreaPixels <= limits.areaPixels
+  );
+}
+
+function comparisonConclusion(
+  results: ThreeWayReport["comparisons"]
+): ThreeWayReport["conclusion"] {
+  const upstream = results["baseline-github-vs-current-github"].some(({ passed }) => !passed);
+  const userImpact = results["current-extension-vs-current-github"].some(({ passed }) => !passed);
+  const regression = results["current-extension-vs-committed-baseline"].some(
+    ({ passed }) => !passed
+  );
+  if (!upstream && !userImpact && !regression) return "pass";
+  if (upstream && userImpact && !regression) return "upstream-drift-with-user-impact";
+  if (upstream && !regression) return "upstream-drift";
+  if (!upstream && regression) return "extension-regression";
+  return "multiple-differences";
+}
+
+function escapeTable(value: string): string {
+  return value.replaceAll("|", "\\|").replaceAll("\n", " ");
+}

--- a/tests/scripts/drift/probe.test.ts
+++ b/tests/scripts/drift/probe.test.ts
@@ -87,4 +87,16 @@ describe("upstream drift probe", () => {
   ] as const)("classifies %s as %s", (message, conclusion) => {
     expect(classifyProbeError("compare", new Error(message))).toBe(conclusion);
   });
+
+  it("preserves three-way drift and stage conclusions", () => {
+    const upstream = Object.assign(new Error("Three-way report failed"), {
+      report: { conclusion: "upstream-drift-with-user-impact" }
+    });
+    const extraction = Object.assign(new Error("Three-way report failed"), {
+      report: { conclusion: "extract-failure" }
+    });
+
+    expect(classifyProbeError("compare", upstream)).toBe("drift_detected");
+    expect(classifyProbeError("compare", extraction)).toBe("extraction_failure");
+  });
 });

--- a/tests/scripts/parity/three-way.test.ts
+++ b/tests/scripts/parity/three-way.test.ts
@@ -1,0 +1,256 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it, vi } from "vitest";
+import type { VisualBaseline } from "../../../scripts/parity/baseline";
+import type { ScreenshotComparison } from "../../../scripts/parity/visual";
+import { parityCases } from "../../../scripts/parity/cases";
+import {
+  collectThreeWayReport,
+  createReportVariants,
+  type ThreeWayDependencies
+} from "../../../scripts/parity/three-way";
+
+vi.mock("vscode", () => ({ l10n: { t: (message: string) => message } }));
+
+const selectedCases = parityCases.filter(({ id }) => id === "stress-light" || id === "stress-dark");
+const baseline: VisualBaseline = {
+  version: 2,
+  generatedAt: "2026-07-26T00:00:00.000Z",
+  chromiumVersion: "test",
+  rendererSha256: "a".repeat(64),
+  referenceCssSha256: "b".repeat(64),
+  cases: Object.fromEntries(
+    selectedCases.map((parityCase) => [
+      parityCase.id,
+      {
+        markdownSha256: "a".repeat(64),
+        inputSha256: "b".repeat(64),
+        theme: parityCase.theme,
+        themeName: parityCase.themeName,
+        linkUnderlines: parityCase.linkUnderlines,
+        reference: parityCase.reference,
+        htmlNormalization: parityCase.htmlNormalization,
+        localComparison: parityCase.localComparison,
+        githubHtml: `<p>${parityCase.id} baseline</p>`
+      }
+    ])
+  )
+};
+
+describe("three-way parity report", () => {
+  it("covers nine themes with focused narrow and wide variants without a cartesian product", () => {
+    const variants = createReportVariants(parityCases);
+    const themes = new Set(
+      variants
+        .filter(
+          ({ id }) =>
+            id === "formatting-light" || id === "formatting-dark" || id.startsWith("theme-")
+        )
+        .map(({ source }) => source.themeName)
+    );
+
+    expect(themes.size).toBe(9);
+    expect(
+      variants
+        .filter(({ viewport }) => viewport === "narrow")
+        .map(({ id, interaction }) => ({ id, interaction }))
+    ).toEqual([
+      { id: "stress-light-narrow-focus", interaction: "focus" },
+      { id: "stress-dark-narrow-hover", interaction: "hover" }
+    ]);
+    expect(variants.filter(({ viewport }) => viewport === "wide")).toHaveLength(parityCases.length);
+  });
+
+  it("reports all three comparisons independently", async () => {
+    const report = await collectThreeWayReport(
+      selectedCases,
+      dependencies(() => comparison(0))
+    );
+
+    expect(report.conclusion).toBe("pass");
+    expect(report.stages).toEqual({
+      fetch: { status: "pass" },
+      extract: { status: "pass" },
+      render: { status: "pass" },
+      compare: { status: "pass" }
+    });
+    expect(Object.values(report.comparisons).map((results) => results.length)).toEqual([4, 4, 4]);
+    expect(
+      report.comparisons["current-extension-vs-current-github"].every(
+        ({ policy }) => policy.kind === "exact" && policy.owner === "extension"
+      )
+    ).toBe(true);
+  });
+
+  it("distinguishes upstream drift with user impact from an extension regression", async () => {
+    const upstream = await collectThreeWayReport(
+      selectedCases,
+      dependencies((expected, actual) => {
+        const pair = `${expected.toString()}|${actual.toString()}`;
+        return comparison(
+          pair.includes("baseline-github|") && pair.includes("current-extension") ? 0 : 1
+        );
+      })
+    );
+    const regression = await collectThreeWayReport(
+      selectedCases,
+      dependencies((expected, actual) =>
+        comparison(
+          expected.toString().includes("baseline-github") &&
+            actual.toString().includes("current-github")
+            ? 0
+            : 1
+        )
+      )
+    );
+
+    expect(upstream.conclusion).toBe("upstream-drift-with-user-impact");
+    expect(regression.conclusion).toBe("extension-regression");
+  });
+
+  it("records HTTP fetch and extraction failures before later stages run", async () => {
+    const fetchFailure = await collectThreeWayReport(selectedCases, {
+      ...dependencies(() => comparison(0)),
+      fetchCurrentGithub: async () => {
+        throw new Error("GitHub Markdown API returned 503");
+      }
+    });
+    const extractFailure = await collectThreeWayReport(selectedCases, {
+      ...dependencies(() => comparison(0)),
+      extractInputs: async () => {
+        throw new Error("CSS extractor contract failed");
+      }
+    });
+
+    expect(fetchFailure).toMatchObject({
+      conclusion: "fetch-failure",
+      stages: {
+        fetch: { status: "fail", error: { message: "GitHub Markdown API returned 503" } },
+        extract: { status: "pending" }
+      }
+    });
+    expect(extractFailure).toMatchObject({
+      conclusion: "extract-failure",
+      stages: {
+        fetch: { status: "pass" },
+        extract: { status: "fail", error: { message: "CSS extractor contract failed" } },
+        render: { status: "pending" }
+      }
+    });
+  });
+
+  it("records render and compare failures while retaining available image artifacts", async () => {
+    const renderFailure = await collectThreeWayReport(selectedCases, {
+      ...dependencies(() => comparison(0)),
+      render: async () => {
+        throw new Error("Playwright browser failed");
+      }
+    });
+    const written: string[] = [];
+    const compareFailure = await collectThreeWayReport(selectedCases, {
+      ...dependencies(() => {
+        throw new Error("pixel comparison failed");
+      }),
+      writeArtifact: async (name) => {
+        written.push(name);
+      }
+    });
+
+    expect(renderFailure).toMatchObject({
+      conclusion: "render-failure",
+      stages: { render: { status: "fail" }, compare: { status: "pending" } }
+    });
+    expect(compareFailure).toMatchObject({
+      conclusion: "compare-failure",
+      stages: { render: { status: "pass" }, compare: { status: "fail" } }
+    });
+    expect(written.filter((name) => !name.includes("-diff.png"))).toHaveLength(12);
+  });
+
+  it("keeps extension-owned regions exact and documents isolated boundary ownership", async () => {
+    const boundaryCase = parityCases.find(({ id }) => id === "corpus-11-light")!;
+    const cases = [...selectedCases, boundaryCase];
+    const report = await collectThreeWayReport(
+      cases,
+      dependencies(() => comparison(0), cases)
+    );
+    const boundary = report.comparisons["current-extension-vs-current-github"].find(
+      ({ id }) => id === boundaryCase.id
+    );
+
+    expect(boundary?.policy).toMatchObject({
+      kind: "integration-boundary",
+      scope: "separate-fixture",
+      owner: "GitHub client renderers and companion extensions"
+    });
+    expect(
+      report.comparisons["current-extension-vs-current-github"]
+        .filter(({ sourceCaseId }) => sourceCaseId.startsWith("stress-"))
+        .every(
+          ({ policy }) =>
+            policy.kind === "exact" &&
+            policy.limits.pixels === 0 &&
+            policy.limits.pixelRatio === 0 &&
+            policy.limits.areaPixels === 0
+        )
+    ).toBe(true);
+  });
+});
+
+function dependencies(
+  compare: ThreeWayDependencies["compare"],
+  cases = selectedCases
+): ThreeWayDependencies {
+  return {
+    fetchCurrentGithub: async () =>
+      Object.fromEntries(
+        cases.map((parityCase) => [parityCase.id, `<p>${parityCase.id} current GitHub</p>`])
+      ),
+    extractInputs: async () => ({
+      baseline: cases === selectedCases ? baseline : baselineFor(cases),
+      committedReferenceCss: "baseline css",
+      currentGithubCss: "current GitHub css",
+      currentExtensionCss: "current extension css"
+    }),
+    render: async (requests) => ({
+      chromiumVersion: "test",
+      screenshots: Object.fromEntries(
+        requests.map(({ id }) => [id, Buffer.from(id.replace(/^.*?(baseline|current)/, "$1"))])
+      )
+    }),
+    compare,
+    writeArtifact: async () => {}
+  };
+}
+
+function baselineFor(cases: typeof parityCases): VisualBaseline {
+  return {
+    ...baseline,
+    cases: Object.fromEntries(
+      cases.map((parityCase) => [
+        parityCase.id,
+        {
+          markdownSha256: "a".repeat(64),
+          inputSha256: "b".repeat(64),
+          theme: parityCase.theme,
+          themeName: parityCase.themeName,
+          linkUnderlines: parityCase.linkUnderlines,
+          reference: parityCase.reference,
+          htmlNormalization: parityCase.htmlNormalization,
+          localComparison: parityCase.localComparison,
+          githubHtml: `<p>${parityCase.id} baseline</p>`
+        }
+      ])
+    )
+  };
+}
+
+function comparison(diffPixels: number): ScreenshotComparison {
+  return {
+    width: 1,
+    height: 1,
+    diffPixels,
+    diffPixelRatio: diffPixels,
+    largestDiffAreaPixels: diffPixels,
+    diff: Buffer.from("diff")
+  };
+}


### PR DESCRIPTION
## Summary

- add an independent three-way parity report for baseline GitHub vs current GitHub, current extension vs current GitHub, and current extension vs the committed baseline
- classify fetch, extract, render, and compare failures while retaining JSON, Markdown, and available image artifacts
- enforce exact-zero extension-owned comparisons and record explicit ownership/review policy for host-client boundary fixtures
- cover the high-value theme matrix with targeted narrow viewport and focus/hover variants
- make the daily drift probe consume the structured report and distinguish upstream drift, local regression, and stage failures

## Why

Issue #1142 requires an auditable report that separates upstream GitHub changes from extension regressions without hiding failures behind a single comparison result.

## Impact

This is internal parity and drift-detection tooling. It does not change extension runtime behavior or user-facing documentation.

## Validation

- `pnpm exec tsc --noEmit`
- targeted parity and drift tests: 22 passed
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nub run test`: 228 passed
- `nub run build`
- `pnpm run verify:parity:report`: live GitHub fetch and extraction passed; the run produced a structured `render-failure` report because the local Playwright Chromium executable is not installed. Per the local no-download constraint, browser installation was intentionally not performed, so end-to-end image comparison remains for an environment with the configured browser.

Closes #1142