### PR TITLE
fix: improve footnote parity and Mermaid rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This file records notable changes that people can observe or act on when using t
 
 ### Markdown preview
 
+- Footnote references now recognize single-word definitions and labels containing inline punctuation instead of rendering them as ordinary links or literal Markdown, including references nested inside Markdown links.
+
+- Empty footnote definitions now keep a valid return target, and indented code blocks inside footnotes retain their code formatting.
+
+- Footnote definitions inside list items now resolve correctly, and adjacent continuation lines stay in the same paragraph instead of being split.
+
 - Footnote labels now match definitions without regard to letter case and keep the first duplicate definition, matching GitHub instead of leaving references unresolved or showing later duplicate text.
 
 - Footnotes now render inside a single theme container, preventing nested preview styles from altering their layout and appearance.

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -81,6 +81,18 @@ async function updateMermaidThemeSyncNow(memento: vscode.Memento): Promise<void>
 
   const failure = [lightResult, darkResult].find((result) => result.status === "rejected");
   if (failure?.status === "rejected") {
+    try {
+      await restoreMermaidThemeSyncNow(memento, configuration);
+    } catch (restoreError) {
+      const failureMessage =
+        failure.reason instanceof Error ? failure.reason.message : String(failure.reason);
+      const restoreFailures =
+        restoreError instanceof AggregateError ? restoreError.errors : [restoreError];
+      throw new AggregateError(
+        [failure.reason, ...restoreFailures],
+        `${failureMessage}; failed to restore the original Mermaid themes`
+      );
+    }
     throw failure.reason;
   }
 }
@@ -115,7 +127,13 @@ async function restoreMermaidThemeSyncNow(
     updates.push(updateMermaidTheme(configuration, originSection.dark, snapshot.dark));
   }
 
-  await Promise.all(updates);
+  const restoreResults = await Promise.allSettled(updates);
+  const restoreFailures = restoreResults
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  if (restoreFailures.length > 0) {
+    throw new AggregateError(restoreFailures, "Failed to restore the original Mermaid themes");
+  }
   await memento.update(snapshotKey, undefined);
 }
 

--- a/src/plugins/markdown-it-github-footnotes.ts
+++ b/src/plugins/markdown-it-github-footnotes.ts
@@ -1,5 +1,6 @@
 import { l10n } from "vscode";
 import type MarkdownIt from "markdown-it";
+import type StateBlock from "markdown-it/lib/rules_block/state_block.mjs";
 import { caseFold } from "unicode-case-folding";
 import type { MarkdownToken, MarkdownState } from "./shared";
 
@@ -17,19 +18,13 @@ type FootnoteGraph = {
   references: FootnoteReference[];
 };
 
-type FootnoteState = MarkdownState & {
-  src: string;
-};
-
 type FragmentRenderer = (tokens: MarkdownToken[]) => string;
-
-type ParsedFootnoteDefinition = {
-  label: string;
-  definition: string;
-};
 
 const footnoteDefinitionLinePattern = /^\[\^([^\]\n]+)\]:[ \t]*(.*)$/;
 const footnoteReferencePattern = /\[\^([^\]\n]+)\]/g;
+const footnoteDefinitionsKey = "githubMarkdownFootnoteDefinitions";
+const footnoteHardbreakLabelsKey = "githubMarkdownFootnoteHardbreakLabels";
+const nestedFootnoteParseKey = "githubMarkdownNestedFootnoteParse";
 const footnoteOrderKey = "githubMarkdownFootnoteOrder";
 const footnoteReferencesKey = "githubMarkdownFootnoteReferences";
 
@@ -37,14 +32,41 @@ export default function markdownItGitHubFootnotes(md: MarkdownIt): MarkdownIt {
   const render = md.renderer.render.bind(md.renderer);
   const renderFragment: FragmentRenderer = (tokens) => render(tokens, md.options, {});
 
+  md.block.ruler.before(
+    "reference",
+    "github-markdown-footnote-definition",
+    footnoteDefinitionBlock,
+    { alt: ["paragraph", "reference"] }
+  );
+
+  md.inline.ruler.before("escape", "github-markdown-footnote-reference", (state, silent) => {
+    if (silent) {
+      return false;
+    }
+
+    const match = state.src.slice(state.pos).match(/^\[\^([^\]\n]+)\]/);
+    const fullMatch = match?.[0];
+    const label = normalizeFootnoteLabel(match?.[1] ?? "");
+    if (!fullMatch || !label || !footnoteDefinitions(state).has(label)) {
+      return false;
+    }
+
+    const token = state.push("text", "", 0);
+    token.content = fullMatch;
+    state.pos += fullMatch.length;
+    return true;
+  });
+
   md.core.ruler.after("inline", "github-markdown-footnotes", (state) => {
-    const markdownState = state as unknown as FootnoteState;
-    const footnotes = collectFootnotes(markdownState.tokens, markdownState.src);
-    markdownState.tokens = footnotes.tokens;
+    if (state.env[nestedFootnoteParseKey] === true) {
+      return;
+    }
 
-    const definitionTokens = applyFootnoteReferences(markdownState, footnotes.definitions, md);
+    const markdownState = state as unknown as MarkdownState;
+    const definitions = footnoteDefinitions(markdownState);
+    const definitionTokens = applyFootnoteReferences(markdownState, definitions, md);
 
-    if (footnotes.definitions.size > 0) {
+    if (definitions.size > 0) {
       appendFootnoteSection(markdownState, definitionTokens, renderFragment);
     }
   });
@@ -52,132 +74,75 @@ export default function markdownItGitHubFootnotes(md: MarkdownIt): MarkdownIt {
   return md;
 }
 
-function collectFootnotes(
-  tokens: MarkdownToken[],
-  source: string
-): {
-  definitions: Map<string, string>;
-  tokens: MarkdownToken[];
-} {
-  const definitions = new Map<string, string>();
-  const output: MarkdownToken[] = [];
-  const sourceLines = source.split("\n");
-
-  for (let index = 0; index < tokens.length; index += 1) {
-    const paragraphOpen = tokens[index];
-    const inline = tokens[index + 1];
-    const paragraphClose = tokens[index + 2];
-
-    if (
-      paragraphOpen?.type === "paragraph_open" &&
-      inline?.type === "inline" &&
-      paragraphClose?.type === "paragraph_close"
-    ) {
-      const parsedDefinitions = parseFootnoteDefinitions(inline.content);
-      if (parsedDefinitions) {
-        let definitionEnd = paragraphOpen.map?.[1];
-        if (definitionEnd !== undefined) {
-          const continuation = collectFootnoteContinuation(sourceLines, definitionEnd);
-          const lastDefinition = parsedDefinitions.at(-1);
-          if (continuation && lastDefinition) {
-            lastDefinition.definition = normalizeFootnoteDefinition(
-              `${lastDefinition.definition}\n\n${continuation.markdown}`
-            );
-            definitionEnd = continuation.endLine;
-          }
-        }
-
-        for (const { label, definition } of parsedDefinitions) {
-          if (!definitions.has(label)) {
-            definitions.set(label, definition);
-          }
-        }
-
-        index += 2;
-        while (definitionEnd !== undefined) {
-          const nextTokenStart = tokens[index + 1]?.map?.[0];
-          if (nextTokenStart === undefined || nextTokenStart >= definitionEnd) {
-            break;
-          }
-          index += 1;
-        }
-        continue;
-      }
-    }
-
-    const token = tokens[index];
-    if (token) {
-      output.push(token);
-    }
+function footnoteDefinitionBlock(
+  state: StateBlock,
+  startLine: number,
+  endLine: number,
+  silent: boolean
+): boolean {
+  if ((state.sCount[startLine] ?? 0) - state.blkIndent >= 4) {
+    return false;
   }
 
-  return {
-    definitions,
-    tokens: output
-  };
-}
+  const lineStart = (state.bMarks[startLine] ?? 0) + (state.tShift[startLine] ?? 0);
+  const lineEnd = state.eMarks[startLine] ?? lineStart;
+  const match = state.src.slice(lineStart, lineEnd).match(footnoteDefinitionLinePattern);
+  if (!match) {
+    return false;
+  }
+  if (silent) {
+    return true;
+  }
 
-function collectFootnoteContinuation(
-  sourceLines: string[],
-  startLine: number
-): { markdown: string; endLine: number } | undefined {
-  const markdownLines: string[] = [];
+  let definition = match[2] ?? "";
+  const hasInlineDefinition = definition.length > 0;
+  let scanLine = startLine + 1;
+  let definitionEnd = scanLine;
   let pendingBlankLines = 0;
-  let lineIndex = startLine;
+  const continuationLines: string[] = [];
 
-  for (; lineIndex < sourceLines.length; lineIndex += 1) {
-    const line = sourceLines[lineIndex] ?? "";
-    if (/^[ \t]*$/.test(line)) {
+  for (; scanLine < endLine; scanLine += 1) {
+    if (state.isEmpty(scanLine)) {
       pendingBlankLines += 1;
       continue;
     }
-
-    const continuation = line.match(/^(?: {4}|\t)(.*)$/);
-    if (!continuation) {
+    if ((state.sCount[scanLine] ?? 0) - state.blkIndent < 4) {
       break;
     }
 
-    markdownLines.push(...Array.from({ length: pendingBlankLines }, () => ""));
-    markdownLines.push(continuation[1] ?? "");
+    continuationLines.push(...Array.from({ length: pendingBlankLines }, () => ""));
+    continuationLines.push(state.getLines(scanLine, scanLine + 1, state.blkIndent + 4, false));
     pendingBlankLines = 0;
+    definitionEnd = scanLine + 1;
   }
 
-  if (markdownLines.length === 0) {
-    return undefined;
+  if (continuationLines.length > 0) {
+    definition = `${definition}\n${continuationLines.join("\n")}`;
   }
 
-  return {
-    markdown: markdownLines.join("\n"),
-    endLine: lineIndex
-  };
+  const label = normalizeFootnoteLabel(match[1] ?? "");
+  const definitions = footnoteDefinitions(state);
+  if (label && !definitions.has(label)) {
+    definitions.set(label, normalizeFootnoteDefinition(definition));
+    if (hasInlineDefinition && continuationLines.length > 0) {
+      const hardbreakLabels = footnoteHardbreakLabels(state);
+      hardbreakLabels.add(label);
+      state.env[footnoteHardbreakLabelsKey] = hardbreakLabels;
+    }
+  }
+  state.env[footnoteDefinitionsKey] = definitions;
+  state.line = definitionEnd;
+  return true;
 }
 
-function parseFootnoteDefinitions(content: string): ParsedFootnoteDefinition[] | undefined {
-  const definitions: ParsedFootnoteDefinition[] = [];
-  let currentLabel: string | undefined;
-  let currentLines: string[] = [];
+function footnoteDefinitions(state: { env: Record<string, unknown> }): Map<string, string> {
+  const definitions = state.env[footnoteDefinitionsKey];
+  return definitions instanceof Map ? definitions : new Map();
+}
 
-  const commit = () => {
-    if (!currentLabel) return;
-    definitions.push({
-      label: currentLabel,
-      definition: normalizeFootnoteDefinition(currentLines.join("\n"))
-    });
-  };
-
-  for (const line of content.split("\n")) {
-    const match = line.match(footnoteDefinitionLinePattern);
-    if (match) {
-      commit();
-      currentLabel = normalizeFootnoteLabel(match[1] ?? "");
-      currentLines = [match[2] ?? ""];
-      continue;
-    }
-    if (!currentLabel) return undefined;
-    currentLines.push(line);
-  }
-  commit();
-  return definitions.length > 0 ? definitions : undefined;
+function footnoteHardbreakLabels(state: { env: Record<string, unknown> }): Set<string> {
+  const labels = state.env[footnoteHardbreakLabelsKey];
+  return labels instanceof Set ? labels : new Set();
 }
 
 function applyFootnoteReferences(
@@ -203,11 +168,17 @@ function applyFootnoteReferences(
   for (let index = 0; index < graph.order.length; index += 1) {
     const label = graph.order[index];
     const definition = label ? definitions.get(label) : undefined;
-    if (!label || !definition) {
+    if (!label || definition === undefined) {
       continue;
     }
 
-    const tokens = md.parse(definition, {});
+    const tokens = md.parse(definition, {
+      [footnoteDefinitionsKey]: definitions,
+      [nestedFootnoteParseKey]: true
+    });
+    if (footnoteHardbreakLabels(state).has(label)) {
+      promoteSoftbreaks(tokens);
+    }
     applyFootnoteReferencesToTokens(tokens, state, graph);
     definitionTokens.set(label, tokens);
   }
@@ -228,7 +199,23 @@ function applyFootnoteReferencesToTokens(
     }
 
     const nextChildren: MarkdownToken[] = [];
+    let linkDepth = 0;
+    let deferredLinkReferences: MarkdownToken[] = [];
     for (const child of token.children) {
+      if (child.type === "link_open") {
+        linkDepth += 1;
+        nextChildren.push(child);
+        continue;
+      }
+      if (child.type === "link_close") {
+        nextChildren.push(child);
+        linkDepth = Math.max(0, linkDepth - 1);
+        if (linkDepth === 0 && deferredLinkReferences.length > 0) {
+          nextChildren.push(...deferredLinkReferences);
+          deferredLinkReferences = [];
+        }
+        continue;
+      }
       if (child.type !== "text") {
         nextChildren.push(child);
         continue;
@@ -263,10 +250,15 @@ function applyFootnoteReferencesToTokens(
         graph.references.push({ label, number, referenceCount });
 
         const htmlToken = new state.Token("html_inline", "", 0);
-        htmlToken.content = `<sup class="footnote-ref"><a href="#user-content-fn-${number}" id="${footnoteReferenceId(
-          number,
-          referenceCount
-        )}" data-footnote-ref="" aria-describedby="footnote-label">${number}</a></sup>`;
+        const anchor = renderFootnoteReferenceAnchor(number, referenceCount);
+        if (linkDepth > 0) {
+          htmlToken.content = "<sup></sup>";
+          const deferredReference = new state.Token("html_inline", "", 0);
+          deferredReference.content = anchor;
+          deferredLinkReferences.push(deferredReference);
+        } else {
+          htmlToken.content = `<sup class="footnote-ref">${anchor}</sup>`;
+        }
         nextChildren.push(htmlToken);
 
         lastIndex = matchIndex + fullMatch.length;
@@ -284,8 +276,23 @@ function applyFootnoteReferencesToTokens(
         nextChildren.push(textToken);
       }
     }
+    nextChildren.push(...deferredLinkReferences);
 
     token.children = nextChildren;
+  }
+}
+
+function promoteSoftbreaks(tokens: MarkdownToken[]): void {
+  for (const token of tokens) {
+    if (token.type !== "inline" || !token.children) {
+      continue;
+    }
+    for (const child of token.children) {
+      if (child.type === "softbreak") {
+        child.type = "hardbreak";
+        child.tag = "br";
+      }
+    }
   }
 }
 
@@ -338,10 +345,7 @@ ${content}
 }
 
 function normalizeFootnoteDefinition(definition: string): string {
-  return definition
-    .replace(/^\n/, "")
-    .replace(/\n[ \t]{4}/g, "\n")
-    .trim();
+  return definition.replace(/^\n+/, "").trimEnd();
 }
 
 function normalizeFootnoteLabel(label: string): string {
@@ -406,6 +410,13 @@ function renderBackref(number: number, referenceCount: number): string {
     number,
     referenceCount
   )}" data-footnote-backref="" aria-label="${l10n.t("Back to reference {0}{1}", number, suffix)}" class="data-footnote-backref">↩${marker}</a>`;
+}
+
+function renderFootnoteReferenceAnchor(number: number, referenceCount: number): string {
+  return `<a href="#user-content-fn-${number}" id="${footnoteReferenceId(
+    number,
+    referenceCount
+  )}" data-footnote-ref="" aria-describedby="footnote-label">${number}</a>`;
 }
 
 function footnoteReferenceId(number: number, referenceCount: number): string {

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -261,8 +261,14 @@ describe("extension lifecycle", () => {
     expect(harness.executeCalls).toEqual(["markdown.preview.refresh"]);
     expect(console.error).toHaveBeenCalledWith(
       "[github-markdown] Failed to sync Mermaid theme:",
-      harness.mermaidUpdateError
+      expect.any(AggregateError)
     );
+    const loggedError = vi.mocked(console.error).mock.calls[0]?.[1];
+    expect((loggedError as AggregateError).errors).toEqual([
+      harness.mermaidUpdateError,
+      harness.mermaidUpdateError,
+      harness.mermaidUpdateError
+    ]);
   });
 
   it("contains preview refresh failures inside the configuration listener", async () => {
@@ -313,8 +319,13 @@ describe("extension lifecycle", () => {
     await expect(deactivate()).resolves.toBeUndefined();
     expect(console.error).toHaveBeenCalledWith(
       "[github-markdown] Failed to restore Mermaid theme on deactivation:",
-      harness.mermaidUpdateError
+      expect.any(AggregateError)
     );
+    const loggedError = vi.mocked(console.error).mock.calls[0]?.[1];
+    expect((loggedError as AggregateError).errors).toEqual([
+      harness.mermaidUpdateError,
+      harness.mermaidUpdateError
+    ]);
   });
 
   it("treats theme command cancellation as a no-op", async () => {

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -19,6 +19,8 @@ let mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features"]);
 const updateCalls: { key: string; value: string | undefined; target: number }[] = [];
 let updateFailures = new Set<string>();
 let updateGates = new Map<string, Promise<void>>();
+let updateFailureCalls = new Set<number>();
+let updateGateCalls = new Map<number, Promise<void>>();
 
 vi.mock("vscode", () => ({
   default: {
@@ -36,10 +38,11 @@ vi.mock("vscode", () => ({
                 : undefined,
             update: async (key: string, value: string | undefined, target: number) => {
               updateCalls.push({ key, value, target });
-              if (updateFailures.has(key)) {
+              const callNumber = updateCalls.length;
+              if (updateFailures.has(key) || updateFailureCalls.has(callNumber)) {
                 throw new Error(`Failed to update ${key}`);
               }
-              const updateGate = updateGates.get(key);
+              const updateGate = updateGateCalls.get(callNumber) ?? updateGates.get(key);
               if (updateGate) {
                 await updateGate;
               }
@@ -76,6 +79,8 @@ describe("Mermaid theme synchronization", () => {
     mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features"]);
     updateFailures = new Set();
     updateGates = new Map();
+    updateFailureCalls = new Set();
+    updateGateCalls = new Map();
   });
 
   it("configures both Mermaid slots from the system-mode light and dark themes", async () => {
@@ -238,7 +243,37 @@ describe("Mermaid theme synchronization", () => {
     });
   });
 
-  it("restores a setting changed before another theme update fails", async () => {
+  it.each([
+    ["darkModeTheme", "lightModeTheme"],
+    ["lightModeTheme", "darkModeTheme"]
+  ] as const)(
+    "restores %s after the other theme update succeeds",
+    async (failedKey, appliedKey) => {
+      const memento = createTestMemento();
+      let releaseAppliedUpdate = () => {};
+      updateGates.set(
+        appliedKey,
+        new Promise<void>((resolve) => {
+          releaseAppliedUpdate = resolve;
+        })
+      );
+      updateFailures.add(failedKey);
+
+      const synchronization = expect(updateMermaidThemeSync(memento)).rejects.toThrow(
+        `Failed to update ${failedKey}`
+      );
+      await vi.waitFor(() => expect(updateCalls).toHaveLength(2));
+      releaseAppliedUpdate();
+      await synchronization;
+
+      expect(mermaidGlobalConfig).toEqual({
+        lightModeTheme: "neutral",
+        darkModeTheme: "forest"
+      });
+    }
+  );
+
+  it("reports update and rollback failures while keeping the snapshot retryable", async () => {
     const memento = createTestMemento();
     let releaseLightUpdate = () => {};
     updateGates.set(
@@ -249,12 +284,21 @@ describe("Mermaid theme synchronization", () => {
     );
     updateFailures.add("darkModeTheme");
 
-    const synchronization = expect(updateMermaidThemeSync(memento)).rejects.toThrow(
-      "Failed to update darkModeTheme"
-    );
+    const synchronization = updateMermaidThemeSync(memento).catch((error: unknown) => error);
     await vi.waitFor(() => expect(updateCalls).toHaveLength(2));
+    updateFailures.add("lightModeTheme");
     releaseLightUpdate();
-    await synchronization;
+
+    const error = await synchronization;
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([
+      expect.objectContaining({ message: "Failed to update darkModeTheme" }),
+      expect.objectContaining({ message: "Failed to update lightModeTheme" })
+    ]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "default",
+      darkModeTheme: "forest"
+    });
 
     updateFailures.clear();
     updateGates.clear();
@@ -264,6 +308,43 @@ describe("Mermaid theme synchronization", () => {
     expect(mermaidGlobalConfig).toEqual({
       lightModeTheme: "neutral",
       darkModeTheme: "forest"
+    });
+  });
+
+  it("waits for every rollback before running the next synchronization", async () => {
+    const memento = createTestMemento();
+    await updateMermaidThemeSync(memento);
+
+    markdownConfig["theme.mode"] = "vscode";
+    let releaseDarkRollback = () => {};
+    updateFailureCalls.add(4);
+    updateFailureCalls.add(5);
+    updateGateCalls.set(
+      6,
+      new Promise<void>((resolve) => {
+        releaseDarkRollback = resolve;
+      })
+    );
+
+    const failedSynchronization = expect(updateMermaidThemeSync(memento)).rejects.toBeInstanceOf(
+      AggregateError
+    );
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(6));
+
+    markdownConfig["theme.mode"] = "single";
+    markdownConfig["theme.single"] = "light";
+    const latestSynchronization = updateMermaidThemeSync(memento);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(updateCalls).toHaveLength(6);
+
+    releaseDarkRollback();
+    await failedSynchronization;
+    await latestSynchronization;
+
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "default",
+      darkModeTheme: "default"
     });
   });
 

--- a/tests/plugins/footnotes.test.ts
+++ b/tests/plugins/footnotes.test.ts
@@ -32,6 +32,24 @@ describe("markdown-it-github-footnotes", () => {
     expect(html).toContain("My reference.");
   });
 
+  it("keeps single-word footnote definitions out of Markdown link references", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render("Text[^a].\n\n[^a]: body");
+    const footnote = html.match(/<li id="user-content-fn-1">[\s\S]*?<\/li>/)?.[0];
+
+    expect(html).toContain("data-footnote-ref");
+    expect(footnote).toContain("body");
+    expect(html).not.toContain('href="body"');
+  });
+
+  it("renders an empty footnote definition with its backreference", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render("Text[^a].\n\n[^a]:");
+
+    expect(html).toContain('<li id="user-content-fn-1">');
+    expect(html).toContain("data-footnote-backref");
+  });
+
   it("matches footnote labels without regard to case", () => {
     const md = new MarkdownIt().use(githubFootnotes);
     const html = md.render("Text[^foo].\n\n[^Foo]: Case-insensitive reference.");
@@ -49,6 +67,38 @@ describe("markdown-it-github-footnotes", () => {
 
     expect(html).toContain("Unicode case-folded reference.");
     expect(html).not.toContain("[^straße]");
+  });
+
+  it("recognizes a footnote label that contains inline punctuation", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render("Text[^a*b*].\n\n[^a*b*]: Punctuation label.");
+    const footnote = html.match(/<li id="user-content-fn-1">[\s\S]*?<\/li>/)?.[0];
+
+    expect(html).toContain("data-footnote-ref");
+    expect(footnote).toContain("Punctuation label.");
+    expect(html).not.toContain("[^a");
+  });
+
+  it("keeps a footnote reference inside a Markdown link label", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render("[link[^a]](https://example.com)\n\n[^a]: note body");
+
+    expect(html).toContain(
+      '<a href="https://example.com">link<sup></sup></a><a href="#user-content-fn-1" id="user-content-fnref-1" data-footnote-ref="" aria-describedby="footnote-label">1</a>'
+    );
+    expect(html).toContain("note body");
+    expect(html).not.toContain("[link");
+  });
+
+  it("recognizes an inline-punctuation label referenced by another footnote", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render(
+      "Text[^outer].\n\n[^outer]: Nested[^a*b*].\n\n[^a*b*]: Punctuation label."
+    );
+
+    expect(html).toContain('href="#user-content-fn-2"');
+    expect(html).toContain("Punctuation label.");
+    expect(html).not.toContain("[^a");
   });
 
   it("renders multiple footnotes with correct numbering", () => {
@@ -92,6 +142,17 @@ describe("markdown-it-github-footnotes", () => {
     expect(html).not.toContain("[^second]:");
   });
 
+  it("recognizes a footnote definition inside a list item", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render("Body[^a].\n\n- item\n  [^a]: list body\n");
+    const footnote = html.match(/<li id="user-content-fn-1">[\s\S]*?<\/li>/)?.[0];
+
+    expect(html).toContain("data-footnote-ref");
+    expect(html).toContain("<ul>\n<li>item</li>\n</ul>");
+    expect(footnote).toContain("list body");
+    expect(html).not.toContain("[^a]:");
+  });
+
   it("keeps the first duplicate footnote definition", () => {
     const md = new MarkdownIt().use(githubFootnotes);
     const html = md.render(
@@ -105,11 +166,11 @@ describe("markdown-it-github-footnotes", () => {
   it("renders multiple references to same footnote with backrefs", () => {
     const md = new MarkdownIt().use(githubFootnotes);
     const html = md.render("First[^1]. Second[^1].\n\n[^1]: Shared ref.");
-    // Two references to the same footnote
-    const referenceCount = (html.match(/fnref-1/g) ?? []).length;
-    expect(referenceCount).toBeGreaterThanOrEqual(2);
-    // Backreference with sup
+
+    expect(html).toContain('id="user-content-fnref-1"');
+    expect(html).toContain('id="user-content-fnref-1-2"');
     expect(html).toContain("data-footnote-backref");
+    expect(html).toContain("<sup>2</sup>");
   });
 
   it("renders inline markup in footnote definition", () => {
@@ -123,6 +184,33 @@ describe("markdown-it-github-footnotes", () => {
     const html = md.render("Text[^1].\n\n[^1]:\n    Line 1.\n    Line 2.");
     expect(html).toContain("Line 1.");
     expect(html).toContain("Line 2.");
+  });
+
+  it("keeps an adjacent continuation line in the same footnote paragraph", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render("Body[^a].\n\n[^a]: first line\n    second line\n");
+    const footnote = html.match(/<li id="user-content-fn-1">[\s\S]*?<\/li>/)?.[0] ?? "";
+
+    expect(footnote).toContain("first line<br>\nsecond line");
+    expect(footnote.match(/<p dir="auto">/g)).toHaveLength(1);
+  });
+
+  it("preserves soft breaks when a footnote starts on a continuation line", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render("Body[^a].\n\n[^a]:\n    first line\n    second line\n");
+    const footnote = html.match(/<li id="user-content-fn-1">[\s\S]*?<\/li>/)?.[0] ?? "";
+
+    expect(footnote).toContain("first line\nsecond line");
+    expect(footnote).not.toContain("<br>");
+  });
+
+  it("preserves indented code blocks inside a footnote", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render("Text[^1].\n\n[^1]:\n        const value = 1;");
+    const footnote = html.match(/<li id="user-content-fn-1">[\s\S]*?<\/li>/)?.[0];
+
+    expect(footnote).toContain("<pre><code>const value = 1;");
+    expect(footnote).not.toContain("<p>const value = 1;");
   });
 
   it("keeps indented paragraphs inside the footnote", () => {
@@ -160,5 +248,14 @@ describe("markdown-it-github-footnotes", () => {
     expect(html).not.toContain("data-footnote-ref");
     expect(html).not.toContain('class="footnotes"');
     expect(html).not.toContain("My reference.");
+  });
+
+  it("does not collect footnote definitions from fenced code", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render("Text[^a].\n\n```markdown\n[^a]: body\n```");
+
+    expect(html).toContain("[^a]: body");
+    expect(html).not.toContain("data-footnote-ref");
+    expect(html).not.toContain('class="footnotes"');
   });
 });


### PR DESCRIPTION
## Summary

- parse footnote definitions and references through dedicated Markdown-it rules so GitHub-compatible labels, nested references, list-item definitions, empty definitions, continuation lines, and indented code render correctly
- keep footnote references nested in Markdown links valid without creating nested anchors
- wait for every Mermaid theme rollback, preserve all update and rollback failures, and keep the original-theme snapshot available for a later retry
- add regression coverage and document the user-visible footnote fixes under Unreleased

## Why

The previous footnote implementation recovered definitions from the raw source after block parsing, so Markdown-it could consume some footnote syntax as ordinary link references or lose its block context before the plugin handled it. Mermaid rollback used `Promise.all`, which could reject before the other rollback finished and let the next queued synchronization run against partially restored settings.

## Impact

Markdown preview now follows GitHub more closely for complex footnotes. Mermaid theme synchronization is also safer when one or more configuration writes fail: successful writes are rolled back before a later synchronization begins, and all failures remain visible for diagnosis and retry.

## Validation

- `nub run test` — 287 tests passed
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check CHANGELOG.md src/integrations/mermaid.ts src/plugins/markdown-it-github-footnotes.ts tests/extension.test.ts tests/integrations/mermaid.test.ts tests/plugins/footnotes.test.ts`
- `git diff --check`