### PR TITLE
fix: align Markdown edge cases with GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ This file records notable changes that people can observe or act on when using t
 
 ### Markdown preview
 
-- Footnote references now resolve for single-word definitions, labels with punctuation or case differences, and references inside Markdown links. References from other footnotes also receive GitHub-matching numbering and return links.
+- Automatic links containing text such as `:rocket:` now stay intact instead of producing nested links.
+- Footnote references now resolve for single-word definitions, labels with punctuation or case differences, and references inside Markdown links. References from other footnotes also receive GitHub-matching numbering and return links, and reference-style links inside definitions use targets from the main document.
 - Duplicate footnote labels now use the first definition, and empty definitions retain a valid return target.
-- Footnote definitions in list items now resolve correctly. Continuation lines, indented code blocks, and multiple paragraphs stay inside the footnote without losing formatting or introducing nested theme styles.
+- Footnote definitions in list items now resolve correctly. Continuation lines, indented code blocks, and multiple paragraphs stay inside the footnote without losing formatting or introducing nested theme styles. Return links appear after trailing code and quoted blocks.
+- Task list markers now require whitespace after the checkbox, so entries such as `[x]text` remain ordinary list text as they do on GitHub.
+- Alert markers inside list items now remain ordinary blockquotes, matching GitHub, which renders alerts only at the top level.
 - Raw HTML images now rewrite quoted and unquoted project-root `src` paths without changing `data-src` attributes or protocol-relative URLs.
 
 ## [v4.4.1] - 2026-07-26

--- a/src/plugins/markdown-it-github-alerts.ts
+++ b/src/plugins/markdown-it-github-alerts.ts
@@ -50,7 +50,7 @@ function octicon(name: string, path: string): string {
 function applyAlerts(state: MarkdownState) {
   for (let index = 0; index < state.tokens.length - 2; index += 1) {
     const blockquoteOpen = state.tokens[index];
-    if (blockquoteOpen?.type !== "blockquote_open") {
+    if (blockquoteOpen?.type !== "blockquote_open" || blockquoteOpen.level !== 0) {
       continue;
     }
 

--- a/src/plugins/markdown-it-github-emoji.ts
+++ b/src/plugins/markdown-it-github-emoji.ts
@@ -7,7 +7,7 @@ const EMOJI_IMAGE_SIZE = "20";
 const wrappedUnicodeEmojiAliases = new Set(["warning"]);
 
 export default function markdownItGitHubEmoji(md: MarkdownIt): MarkdownIt {
-  md.core.ruler.after("inline", "github-markdown-emoji", (state) => {
+  md.core.ruler.after("linkify", "github-markdown-emoji", (state) => {
     applyEmojiShortcodes(state as unknown as MarkdownState, md);
   });
 
@@ -21,8 +21,19 @@ function applyEmojiShortcodes(state: MarkdownState, md: MarkdownIt) {
     }
 
     const nextChildren: MarkdownToken[] = [];
+    let automaticLinkDepth = 0;
     for (const child of token.children) {
-      if (child.type !== "text" || !child.content.includes(":")) {
+      if (child.type === "link_open" && child.markup === "linkify") {
+        automaticLinkDepth += 1;
+        nextChildren.push(child);
+        continue;
+      }
+      if (child.type === "link_close" && child.markup === "linkify") {
+        nextChildren.push(child);
+        automaticLinkDepth = Math.max(0, automaticLinkDepth - 1);
+        continue;
+      }
+      if (automaticLinkDepth > 0 || child.type !== "text" || !child.content.includes(":")) {
         nextChildren.push(child);
         continue;
       }

--- a/src/plugins/markdown-it-github-footnotes.ts
+++ b/src/plugins/markdown-it-github-footnotes.ts
@@ -18,7 +18,7 @@ type FootnoteGraph = {
   references: FootnoteReference[];
 };
 
-type FragmentRenderer = (tokens: MarkdownToken[]) => string;
+type FragmentRenderer = (tokens: MarkdownToken[], env: Record<string, unknown>) => string;
 
 const footnoteDefinitionLinePattern = /^\[\^([^\]\n]+)\]:[ \t]*(.*)$/;
 const footnoteReferencePattern = /\[\^([^\]\n]+)\]/g;
@@ -30,7 +30,7 @@ const footnoteReferencesKey = "githubMarkdownFootnoteReferences";
 
 export default function markdownItGitHubFootnotes(md: MarkdownIt): MarkdownIt {
   const render = md.renderer.render.bind(md.renderer);
-  const renderFragment: FragmentRenderer = (tokens) => render(tokens, md.options, {});
+  const renderFragment: FragmentRenderer = (tokens, env) => render(tokens, md.options, env);
 
   md.block.ruler.before(
     "reference",
@@ -172,10 +172,7 @@ function applyFootnoteReferences(
       continue;
     }
 
-    const tokens = md.parse(definition, {
-      [footnoteDefinitionsKey]: definitions,
-      [nestedFootnoteParseKey]: true
-    });
+    const tokens = parseFootnoteDefinition(md, definition, state.env);
     if (footnoteHardbreakLabels(state).has(label)) {
       promoteSoftbreaks(tokens);
     }
@@ -186,6 +183,26 @@ function applyFootnoteReferences(
   state.env[footnoteOrderKey] = graph.order;
   state.env[footnoteReferencesKey] = graph.references;
   return definitionTokens;
+}
+
+function parseFootnoteDefinition(
+  md: MarkdownIt,
+  definition: string,
+  env: Record<string, unknown>
+): MarkdownToken[] {
+  const hadNestedParseFlag = Object.hasOwn(env, nestedFootnoteParseKey);
+  const previousNestedParseFlag = env[nestedFootnoteParseKey];
+  env[nestedFootnoteParseKey] = true;
+
+  try {
+    return md.parse(definition, env);
+  } finally {
+    if (hadNestedParseFlag) {
+      env[nestedFootnoteParseKey] = previousNestedParseFlag;
+    } else {
+      delete env[nestedFootnoteParseKey];
+    }
+  }
 }
 
 function applyFootnoteReferencesToTokens(
@@ -369,16 +386,18 @@ function renderFootnoteDefinition(
     }
   }
 
-  if (lastInline?.children) {
+  const trailingParagraphInline =
+    tokens.at(-1)?.type === "paragraph_close" ? lastInline : undefined;
+  if (trailingParagraphInline?.children) {
     const separator = new state.Token("text", "", 0);
     separator.content = " ";
     const backref = new state.Token("html_inline", "", 0);
     backref.content = backrefs;
-    lastInline.children.push(separator, backref);
+    trailingParagraphInline.children.push(separator, backref);
   }
 
-  const content = renderFragment(tokens).trimEnd();
-  return lastInline ? content : `${content}\n<p dir="auto">${backrefs}</p>`;
+  const content = renderFragment(tokens, state.env).trimEnd();
+  return trailingParagraphInline ? content : `${content}\n${backrefs}`;
 }
 
 function footnoteReferences(state: MarkdownState): FootnoteReference[] {

--- a/src/plugins/markdown-it-github-task-lists.ts
+++ b/src/plugins/markdown-it-github-task-lists.ts
@@ -2,7 +2,7 @@ import { l10n } from "vscode";
 import type MarkdownIt from "markdown-it";
 import type { MarkdownToken, MarkdownState } from "./shared";
 
-const taskListMarkerPattern = /^[ \t]*\[( |x|X)\][ \t]*/;
+const taskListMarkerPattern = /^[ \t]*\[( |x|X)\][ \t]+/;
 
 export default function markdownItGitHubTaskLists(md: MarkdownIt): MarkdownIt {
   md.core.ruler.after("inline", "github-markdown-task-lists", (state) => {

--- a/tests/plugins/alerts.test.ts
+++ b/tests/plugins/alerts.test.ts
@@ -64,6 +64,15 @@ describe("markdown-it-github-alerts", () => {
     expect(html).not.toContain("markdown-alert");
   });
 
+  it("does not render alerts inside list items", () => {
+    const md = new MarkdownIt().use(githubAlerts);
+    const html = md.render("- > [!NOTE]\n  > List quote.");
+
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("[!NOTE]");
+    expect(html).not.toContain("markdown-alert");
+  });
+
   it("removes blockquote wrapper from alert output", () => {
     const md = new MarkdownIt().use(githubAlerts);
     const html = md.render("> [!NOTE]\n> Content.");

--- a/tests/plugins/emoji.test.ts
+++ b/tests/plugins/emoji.test.ts
@@ -54,4 +54,14 @@ describe("markdown-it-github-emoji", () => {
     const html = md.render(":warning:");
     expect(html).toContain('<g-emoji class="g-emoji" alias="warning">⚠️</g-emoji>');
   });
+
+  it("does not rewrite shortcodes inside automatic links", () => {
+    const md = new MarkdownIt({ linkify: true }).use(githubEmoji);
+    const html = md.render("https://example.com/:rocket:");
+
+    expect(html.match(/<a\b/g)).toHaveLength(1);
+    expect(html).toContain('href="https://example.com/:rocket:"');
+    expect(html).toContain("https://example.com/:rocket:");
+    expect(html).not.toContain("🚀");
+  });
 });

--- a/tests/plugins/footnotes.test.ts
+++ b/tests/plugins/footnotes.test.ts
@@ -179,6 +179,14 @@ describe("markdown-it-github-footnotes", () => {
     expect(html).toContain("<strong>bold</strong>");
   });
 
+  it("resolves document link references inside footnote definitions", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render("Text[^1].\n\n[ref]: https://example.com\n\n[^1]: [link][ref]");
+    const footnote = html.match(/<li id="user-content-fn-1">[\s\S]*?<\/li>/)?.[0];
+
+    expect(footnote).toContain('<a href="https://example.com">link</a>');
+  });
+
   it("normalizes multiline footnote definitions", () => {
     const md = new MarkdownIt().use(githubFootnotes);
     const html = md.render("Text[^1].\n\n[^1]:\n    Line 1.\n    Line 2.");
@@ -211,6 +219,16 @@ describe("markdown-it-github-footnotes", () => {
 
     expect(footnote).toContain("<pre><code>const value = 1;");
     expect(footnote).not.toContain("<p>const value = 1;");
+  });
+
+  it("places the backreference after a trailing code block", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render(
+      "Text[^1].\n\n[^1]: Paragraph.\n\n    ```\n    const value = 1;\n    ```"
+    );
+    const footnote = html.match(/<li id="user-content-fn-1">[\s\S]*?<\/li>/)?.[0] ?? "";
+
+    expect(footnote.indexOf("data-footnote-backref")).toBeGreaterThan(footnote.indexOf("</pre>"));
   });
 
   it("keeps indented paragraphs inside the footnote", () => {

--- a/tests/plugins/task-lists.test.ts
+++ b/tests/plugins/task-lists.test.ts
@@ -52,6 +52,14 @@ describe("markdown-it-github-task-lists", () => {
     expect(html).toContain('<a href="https://github.com/octo-org/octo-repo/issues/739">#739</a>');
   });
 
+  it("requires whitespace after the task list marker", () => {
+    const md = new MarkdownIt().use(githubTaskLists);
+    const html = md.render("- [x]oops");
+
+    expect(html).not.toContain("task-list-item-checkbox");
+    expect(html).toContain("[x]oops");
+  });
+
   it("adds contains-task-list exactly once to the task list", () => {
     const md = new MarkdownIt().use(githubTaskLists);
     const html = md.render("- Parent\n  - [x] A\n  - [ ] B");


### PR DESCRIPTION
## Summary

- Preserve emoji shortcode text inside automatic links.
- Reuse the document parsing context for footnote links and place return links after trailing blocks.
- Match GitHub's task-list whitespace and top-level alert behavior.

## Root cause

Emoji conversion ran before automatic links were finalized. Footnote fragments discarded the document environment and attached return links to the last inline token, even when another block followed. Task-list and alert detection also accepted syntax that GitHub leaves unchanged.

## Validation

- `nub run test` (292 tests)
- `nub run test:coverage`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx tsc --noEmit`
- `nubx oxfmt --check .`
- `nub run build`
- `nub run verify:parity`
- `nub scripts/verify/index.ts`
- `nub run test:host:desktop`
- `nub run test:host:web`
- `nub run package`