### PR TITLE
docs: prepare v4.4.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+## [v4.4.2] - 2026-08-02
+
+v4.4.2 keeps Mermaid theme synchronization consistent during rapid changes and failed updates. Markdown preview now matches GitHub more closely for footnotes, project-root images, task lists, alerts, and automatic links.
+
 ### Mermaid
 
 - Mermaid theme synchronization now processes rapid changes in order and rolls back partial updates. The latest theme wins, and disabling synchronization or a failed update restores previous settings.
@@ -131,6 +135,7 @@ v4 is a new extension rather than an in-place update of `lzm0x219.vscode-markdow
 - v4 supports VS Code 1.74 or later and continues to enhance the built-in Markdown preview instead of opening a separate preview editor.
 - Commands and settings are available in English and Simplified Chinese according to the VS Code display language.
 
+[v4.4.2]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.1...v4.4.2
 [v4.4.1]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.0...v4.4.1
 [v4.4.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.3.0...v4.4.0
 [v4.3.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.2.0...v4.3.0
@@ -138,4 +143,4 @@ v4 is a new extension rather than an in-place update of `lzm0x219.vscode-markdow
 [v4.1.1]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.1.0...v4.1.1
 [v4.1.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.0.0...v4.1.0
 [v4.0.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v3.1.0...v4.0.0
-[Unreleased]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.1...HEAD
+[Unreleased]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.2...HEAD


### PR DESCRIPTION
## Summary

- Promote the current Unreleased entries into v4.4.2, dated 2026-08-02.
- Add a concise user-facing release summary.
- Update the comparison links and leave a new empty Unreleased section.

## Impact

The changelog is ready for the v4.4.2 release. It covers the Mermaid theme synchronization fixes and the latest GitHub Markdown preview parity improvements. The version bump remains owned by the existing release-please PR.

## Validation

- `nubx oxfmt --check CHANGELOG.md`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nub run test:coverage` (47 test files, 292 tests)
- `nub scripts/verify/index.ts`
- `nub run verify:parity`
- `nub run build`
- `nub run package`
- VSIX package-size audit
- `pnpm audit --prod --audit-level high`