### PR TITLE
fix(host): wait for Mermaid palette transitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
 
       - uses: jdx/mise-action@v4
 
-      - name: Install nub
-        run: npm install --global @nubjs/nub
-
       - run: pnpm install --frozen-lockfile
 
       - name: Cache Chromium
@@ -92,9 +89,6 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: jdx/mise-action@v4
-
-      - name: Install nub
-        run: npm install --global @nubjs/nub
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/drift-drill.yml
+++ b/.github/workflows/drift-drill.yml
@@ -15,9 +15,6 @@ jobs:
 
       - uses: jdx/mise-action@v4
 
-      - name: Install nub
-        run: npm install --global @nubjs/nub
-
       - run: pnpm install --frozen-lockfile
 
       - name: Run simulated upstream drift recovery drill

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -27,12 +27,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ matrix.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: jdx/mise-action@v4
 
-      - name: Install nub
-        run: npm install --global @nubjs/nub
+      # Compare both refs with the toolchain declared by the pull request.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ matrix.ref }}
 
       - run: pnpm install --frozen-lockfile
 
@@ -61,9 +63,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: jdx/mise-action@v4
-
-      - name: Install nub
-        run: npm install --global @nubjs/nub
 
       - name: Download baseline VSIX
         uses: actions/download-artifact@v8

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           ref: ${{ matrix.ref }}
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --no-runtime
 
       - name: Build
         run: nub run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,9 +54,6 @@ jobs:
 
       - uses: jdx/mise-action@v4
 
-      - name: Install nub
-        run: npm install --global @nubjs/nub
-
       - run: pnpm install --frozen-lockfile
 
       - name: Audit production dependencies

--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -23,9 +23,6 @@ jobs:
 
       - uses: jdx/mise-action@v4
 
-      - name: Install nub
-        run: npm install --global @nubjs/nub
-
       - run: pnpm install --frozen-lockfile
 
       - name: Cache Chromium

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
 node = "24.19.0"
-pnpm = "11.20.0"
+"npm:pnpm" = "11.20.0"
+"npm:@nubjs/nub" = "0.7.1"

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": ">=24.18.0",
+      "version": "24.19.0",
       "onFail": "download"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,8 +250,8 @@ importers:
         specifier: 14.3.0
         version: 14.3.0
       node:
-        specifier: runtime:>=24.18.0
-        version: runtime:26.5.1
+        specifier: runtime:24.19.0
+        version: runtime:24.19.0
       oxfmt:
         specifier: 0.62.0
         version: 0.62.0
@@ -2525,7 +2525,7 @@ packages:
     resolution: {integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==}
     engines: {node: '>=20'}
 
-  node@runtime:26.5.1:
+  node@runtime:24.19.0:
     resolution:
       type: variations
       variants:
@@ -2533,9 +2533,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-C6/oFrF7yu4oXnnjJbekTupgXRLYGyyqeM3crfXRtfY=
+            integrity: sha256-9ONcExZd5ogMqiVYwKpIyoitpH/iI0vtB9Ztu4CkfI0=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-aix-ppc64.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-aix-ppc64.tar.gz
           targets:
             - cpu: ppc64
               os: aix
@@ -2543,9 +2543,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-9Dh98LRlVlFtGavy8taAZIGsg2iqf52Wuv7UIqVqHQE=
+            integrity: sha256-gpS3qpsDmXSBwGur8eiycMhZNY8n2lehFQmv5TesOB0=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-darwin-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-darwin-arm64.tar.gz
           targets:
             - cpu: arm64
               os: darwin
@@ -2553,9 +2553,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-B31ck2ho2rGdIfd/HnHOE2l+gLPoajmdyrI4kCouv5M=
+            integrity: sha256-0bXpmdsVjGL+j3JnpEdrA12L2TsaYFusJKPw3RZuMxY=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-darwin-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-darwin-x64.tar.gz
           targets:
             - cpu: x64
               os: darwin
@@ -2563,9 +2563,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-IRlLv0HBjZ7Cd1RcTRTM6Fl9V6nZ9JTDI9gSGiXeM+g=
+            integrity: sha256-0oyKW/CoCPDtQ0odzoxUrpjwNxwL2GrFirxhP3PmZD8=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-arm64.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -2573,9 +2573,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-z1GN0ncup+UEba9KS6njSPzgHiuXQfMrohtLvYe4368=
+            integrity: sha256-sxqMTLxYn5FS8y/bQxhGl1nhZViltdk7f/L7KHsBPbI=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-ppc64le.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-ppc64le.tar.gz
           targets:
             - cpu: ppc64le
               os: linux
@@ -2583,9 +2583,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-r1pY/KDD/BMMamSb1sKfSwABRQVet6NkveGJq98VFvU=
+            integrity: sha256-s6tqQ5KCjbn9TtloOY1VGIKSvMFYGVQtU74LEQDjMvw=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-s390x.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-s390x.tar.gz
           targets:
             - cpu: s390x
               os: linux
@@ -2593,9 +2593,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-KwfwnCGNRzomRCv/WpAVH1P3t8CiO60kTtosJjA6K6c=
+            integrity: sha256-9iXZfNcH30/5YlSRb7xf8BTwnAnv/loeDKj21BqHidQ=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-x64.tar.gz
           targets:
             - cpu: x64
               os: linux
@@ -2603,10 +2603,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-Rn9CUiii/cyDozD184sSS1tDtC9QM9eEi05Hyb7MNvk=
-            prefix: node-v26.5.1-win-arm64
+            integrity: sha256-hQL0pQtFjUzDjtjyABVWws0jnUZJIPdAF5Jsyx4cFX8=
+            prefix: node-v24.19.0-win-arm64
             type: binary
-            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-win-arm64.zip
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-arm64.zip
           targets:
             - cpu: arm64
               os: win32
@@ -2614,14 +2614,36 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-xDLJlrlcv3Vo8ToPuzdSbehKJ+OlxSDDvhXwWpoWghI=
-            prefix: node-v26.5.1-win-x64
+            integrity: sha256-V/cas2UueX2ErN3HnIHMn/HG3bKhl0zbg/AP7pv/THM=
+            prefix: node-v24.19.0-win-x64
             type: binary
-            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-win-x64.zip
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-x64.zip
           targets:
             - cpu: x64
               os: win32
-    version: 26.5.1
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-IIJOTTWUj65bM33M70eBOwTYmVMS9Z33OG8iVtn5q34=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-arm64-musl.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-xgIjeG3xSl0j4iDruOYDGPUyJkCmL5Dm2eVNOhjaUy4=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-x64-musl.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+    version: 24.19.0
     hasBin: true
 
   normalize-package-data@6.0.2:
@@ -5529,7 +5551,7 @@ snapshots:
       '@types/sarif': 2.1.7
       fs-extra: 11.3.6
 
-  node@runtime:26.5.1: {}
+  node@runtime:24.19.0: {}
 
   normalize-package-data@6.0.2:
     dependencies:

--- a/scripts/host/preview.ts
+++ b/scripts/host/preview.ts
@@ -44,11 +44,19 @@ async function assertThemeRendering(page: Page): Promise<void> {
 
   let lightPalette: MermaidPalette | undefined;
   let darkPalette: MermaidPalette | undefined;
+  let previousMode: ThemeExpectation["mode"] | undefined;
+  let previousPalette: MermaidPalette | undefined;
   for (const [label, expectation] of singleCases) {
     await selectQuickPick(page, "GitHub Markdown: Change Single Theme", label);
-    const palette = await waitForThemedPreview(page, expectation);
+    const palette = await waitForThemedPreview(
+      page,
+      expectation,
+      previousMode && previousMode !== expectation.mode ? previousPalette : undefined
+    );
     if (label === "Light") lightPalette = palette;
     if (label === "Dark dimmed") darkPalette = palette;
+    previousMode = expectation.mode;
+    previousPalette = palette;
   }
   assert(
     JSON.stringify(lightPalette) !== JSON.stringify(darkPalette),


### PR DESCRIPTION
## 变更

- 在单主题预览回归中记录上一次 Mermaid palette 和主题模式
- light 与 dark 之间切换时，等待 Mermaid palette 真正变化后再继续
- 同属 light 的主题变体不强制 palette 变化，避免错误等待

## 根因

Markdown 主题属性会先于 Mermaid SVG 的异步重渲染完成。原测试只等待主题属性匹配，可能读取到上一次渲染的 palette，导致 `Single mode switches Mermaid between light and dark palettes` 间歇失败。

该失败曾在不同分支和 VS Code 宿主任务中重复出现，与触发失败的 Renovate 依赖升级无关。

## 验证

- `nubx oxfmt --check scripts/host/preview.ts`
- `nubx oxlint scripts/host/preview.ts`
- `nubx oxlint --type-aware scripts/host/preview.ts`
- `nub run test`（47 个测试文件、292 个测试）
- `nub run test:host:desktop:preview`
- `nub run test:host:web:preview`

未更新 CHANGELOG：这是内部回归测试稳定性修复，不改变扩展用户可观察行为。