### PR TITLE
fix(release): audit first package without self-baseline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,6 +127,41 @@ jobs:
       - name: Package
         run: nub run package
 
+      - name: Download previous published VSIX baseline
+        id: package_baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          baseline_directory="artifacts/packages/baseline"
+          baseline_tag="$(
+            gh release list \
+              --exclude-drafts \
+              --exclude-pre-releases \
+              --limit 100 \
+              --json tagName,publishedAt \
+              --repo "$GITHUB_REPOSITORY" \
+              | jq -r --arg current "$GITHUB_REF_NAME" \
+                'map(select(.tagName != $current)) | max_by(.publishedAt).tagName // empty'
+          )"
+
+          if [[ -z "$baseline_tag" ]]; then
+            echo "::notice::No previous published stable VSIX exists; applying absolute package checks only"
+            exit 0
+          fi
+
+          mkdir -p "$baseline_directory"
+          gh release download "$baseline_tag" \
+            --pattern '*.vsix' \
+            --dir "$baseline_directory" \
+            --repo "$GITHUB_REPOSITORY"
+          baseline="$(find "$baseline_directory" -maxdepth 1 -type f -name '*.vsix' -print -quit)"
+          if [[ -z "$baseline" ]]; then
+            echo "::error::Release $baseline_tag has no VSIX asset"
+            exit 1
+          fi
+          echo "path=$baseline" >> "$GITHUB_OUTPUT"
+          echo "tag=$baseline_tag" >> "$GITHUB_OUTPUT"
+
       - name: Verify VSIX contents and size
         run: |
           archive="$(find . -maxdepth 1 -type f -name '*.vsix' -print -quit)"
@@ -134,8 +169,12 @@ jobs:
             echo "::error::No VSIX archive was produced"
             exit 1
           fi
+          baseline="${{ steps.package_baseline.outputs.path }}"
+          if [[ -z "$baseline" ]]; then
+            baseline="$archive"
+          fi
           nub scripts/package-audit/index.ts \
-            "$archive" \
+            "$baseline" \
             "$archive" \
             artifacts/package-size/release.json
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -170,13 +170,17 @@ jobs:
             exit 1
           fi
           baseline="${{ steps.package_baseline.outputs.path }}"
-          if [[ -z "$baseline" ]]; then
-            baseline="$archive"
+          if [[ -n "$baseline" ]]; then
+            nub scripts/package-audit/index.ts \
+              "$baseline" \
+              "$archive" \
+              artifacts/package-size/release.json
+          else
+            nub scripts/package-audit/index.ts \
+              --current-only \
+              "$archive" \
+              artifacts/package-size/release.json
           fi
-          nub scripts/package-audit/index.ts \
-            "$baseline" \
-            "$archive" \
-            artifacts/package-size/release.json
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v7

--- a/scripts/package-audit/audit.ts
+++ b/scripts/package-audit/audit.ts
@@ -10,15 +10,24 @@ export type PackageEntryIncrease = {
   deltaBytes: number;
 };
 
-export type PackageAuditReport = {
+type PackageAuditReportBase = {
   conclusion: "pass" | "fail";
-  baseline: PackageSnapshot;
   current: PackageSnapshot;
+  violations: PackageAuditViolation[];
+};
+
+export type PackageComparisonAuditReport = PackageAuditReportBase & {
+  baseline: PackageSnapshot;
   archiveDeltaBytes: number;
   archiveDeltaRatio: number;
   largestEntryIncreases: PackageEntryIncrease[];
-  violations: PackageAuditViolation[];
 };
+
+export type CurrentPackageAuditReport = PackageAuditReportBase & {
+  mode: "current-only";
+};
+
+export type PackageAuditReport = PackageComparisonAuditReport | CurrentPackageAuditReport;
 
 export type PackageAuditViolation =
   | {
@@ -42,7 +51,7 @@ const forbiddenPackageFiles = new Set([
 export function auditPackageComparison(
   baseline: PackageSnapshot,
   current: PackageSnapshot
-): PackageAuditReport {
+): PackageComparisonAuditReport {
   const archiveDeltaBytes = current.archiveBytes - baseline.archiveBytes;
   const archiveDeltaRatio =
     baseline.archiveBytes === 0 ? 0 : archiveDeltaBytes / baseline.archiveBytes;
@@ -56,14 +65,7 @@ export function auditPackageComparison(
       (left, right) => right.deltaBytes - left.deltaBytes || left.path.localeCompare(right.path)
     )
     .slice(0, 10);
-  const violations: PackageAuditViolation[] = [];
-  if (current.archiveBytes > maximumPackageBytes) {
-    violations.push({
-      rule: "maximum-size",
-      actual: current.archiveBytes,
-      limit: maximumPackageBytes
-    });
-  }
+  const violations = auditMaximumPackageSize(current);
   if (archiveDeltaBytes > maximumPackageIncreaseBytes) {
     violations.push({
       rule: "maximum-increase-bytes",
@@ -78,12 +80,7 @@ export function auditPackageComparison(
       limit: maximumPackageIncreaseRatio
     });
   }
-  for (const path of Object.keys(current.entries).sort()) {
-    if (path.startsWith("extension/.serena/") || forbiddenPackageFiles.has(path)) {
-      violations.push({ rule: "forbidden-file", path });
-    }
-  }
-
+  violations.push(...auditForbiddenPackageFiles(current));
   return {
     conclusion: violations.length === 0 ? "pass" : "fail",
     baseline,
@@ -93,4 +90,35 @@ export function auditPackageComparison(
     largestEntryIncreases,
     violations
   };
+}
+
+export function auditCurrentPackage(current: PackageSnapshot): CurrentPackageAuditReport {
+  const violations = auditCurrentPackageViolations(current);
+  return {
+    mode: "current-only",
+    conclusion: violations.length === 0 ? "pass" : "fail",
+    current,
+    violations
+  };
+}
+
+function auditCurrentPackageViolations(current: PackageSnapshot): PackageAuditViolation[] {
+  return [...auditMaximumPackageSize(current), ...auditForbiddenPackageFiles(current)];
+}
+
+function auditMaximumPackageSize(current: PackageSnapshot): PackageAuditViolation[] {
+  if (current.archiveBytes > maximumPackageBytes) {
+    return [{ rule: "maximum-size", actual: current.archiveBytes, limit: maximumPackageBytes }];
+  }
+  return [];
+}
+
+function auditForbiddenPackageFiles(current: PackageSnapshot): PackageAuditViolation[] {
+  const violations: PackageAuditViolation[] = [];
+  for (const path of Object.keys(current.entries).sort()) {
+    if (path.startsWith("extension/.serena/") || forbiddenPackageFiles.has(path)) {
+      violations.push({ rule: "forbidden-file", path });
+    }
+  }
+  return violations;
 }

--- a/scripts/package-audit/cli.ts
+++ b/scripts/package-audit/cli.ts
@@ -1,11 +1,16 @@
 import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { readPackageSnapshot } from "./archive";
-import { auditPackageComparison, type PackageSnapshot } from "./audit";
+import {
+  auditCurrentPackage,
+  auditPackageComparison,
+  type PackageAuditReport,
+  type PackageSnapshot
+} from "./audit";
 import { renderPackageAuditReport } from "./report";
 
 type PackageAuditOptions = {
-  baselinePath: string;
+  baselinePath?: string;
   currentPath: string;
   outputPath: string;
   summaryPath?: string;
@@ -21,11 +26,16 @@ export class PackageAuditError extends Error {
 
 export async function runPackageAudit(options: PackageAuditOptions): Promise<void> {
   const readSnapshot = options.readSnapshot ?? readPackageSnapshot;
-  const [baseline, current] = await Promise.all([
-    readSnapshot(options.baselinePath),
-    readSnapshot(options.currentPath)
-  ]);
-  const report = auditPackageComparison(baseline, current);
+  let report: PackageAuditReport;
+  if (options.baselinePath) {
+    const [baseline, current] = await Promise.all([
+      readSnapshot(options.baselinePath),
+      readSnapshot(options.currentPath)
+    ]);
+    report = auditPackageComparison(baseline, current);
+  } else {
+    report = auditCurrentPackage(await readSnapshot(options.currentPath));
+  }
   const markdown = renderPackageAuditReport(report);
 
   await mkdir(dirname(options.outputPath), { recursive: true });

--- a/scripts/package-audit/index.ts
+++ b/scripts/package-audit/index.ts
@@ -1,15 +1,33 @@
 import { runPackageAudit } from "./cli";
 
-const [baselinePath, currentPath, outputPath] = process.argv.slice(2);
-if (!baselinePath || !currentPath || !outputPath) {
-  throw new Error(
-    "Usage: nub scripts/package-audit/index.ts <baseline.vsix> <current.vsix> <report.json>"
-  );
+const args = process.argv.slice(2);
+const summaryPath = process.env["GITHUB_STEP_SUMMARY"];
+
+if (args[0] === "--current-only") {
+  const [, currentPath, outputPath, ...extra] = args;
+  if (!currentPath || !outputPath || extra.length > 0) throw new Error(usage());
+  await runPackageAudit({
+    currentPath,
+    outputPath,
+    ...(summaryPath ? { summaryPath } : {})
+  });
+} else {
+  const [baselinePath, currentPath, outputPath, ...extra] = args;
+  if (!baselinePath || !currentPath || !outputPath || extra.length > 0) {
+    throw new Error(usage());
+  }
+  await runPackageAudit({
+    baselinePath,
+    currentPath,
+    outputPath,
+    ...(summaryPath ? { summaryPath } : {})
+  });
 }
 
-await runPackageAudit({
-  baselinePath,
-  currentPath,
-  outputPath,
-  ...(process.env["GITHUB_STEP_SUMMARY"] ? { summaryPath: process.env["GITHUB_STEP_SUMMARY"] } : {})
-});
+function usage(): string {
+  return [
+    "Usage:",
+    "  nub scripts/package-audit/index.ts <baseline.vsix> <current.vsix> <report.json>",
+    "  nub scripts/package-audit/index.ts --current-only <current.vsix> <report.json>"
+  ].join("\n");
+}

--- a/scripts/package-audit/report.ts
+++ b/scripts/package-audit/report.ts
@@ -9,11 +9,21 @@ export function renderPackageAuditReport(report: PackageAuditReport): string {
     `Conclusion: **${report.conclusion.toUpperCase()}**`,
     "",
     "| Package | Size |",
-    "| --- | ---: |",
-    `| Baseline | ${formatBytes(report.baseline.archiveBytes)} |`,
-    `| Current | ${formatBytes(report.current.archiveBytes)} |`,
-    `| Change | ${formatSignedBytes(report.archiveDeltaBytes)} (${formatSignedPercent(report.archiveDeltaRatio)}) |`
+    "| --- | ---: |"
   ];
+  if ("baseline" in report) {
+    lines.push(
+      `| Baseline | ${formatBytes(report.baseline.archiveBytes)} |`,
+      `| Current | ${formatBytes(report.current.archiveBytes)} |`,
+      `| Change | ${formatSignedBytes(report.archiveDeltaBytes)} (${formatSignedPercent(report.archiveDeltaRatio)}) |`
+    );
+  } else {
+    lines.push(
+      "| Baseline | Not available |",
+      `| Current | ${formatBytes(report.current.archiveBytes)} |`,
+      "| Change | Not evaluated |"
+    );
+  }
 
   if (report.violations.length > 0) {
     lines.push(
@@ -23,6 +33,8 @@ export function renderPackageAuditReport(report: PackageAuditReport): string {
       ...report.violations.map((violation) => `- ${renderViolation(violation)}`)
     );
   }
+
+  if (!("baseline" in report)) return `${lines.join("\n")}\n`;
 
   lines.push("", "## Largest file increases", "", "| File | Baseline | Current | Change |");
   lines.push("| --- | ---: | ---: | ---: |");

--- a/tests/scripts/package-audit/cli.test.ts
+++ b/tests/scripts/package-audit/cli.test.ts
@@ -61,4 +61,40 @@ describe("runPackageAudit", () => {
     });
     expect(await readFile(summaryPath, "utf8")).toContain("Conclusion: **FAIL**");
   });
+
+  it("enforces absolute checks without inventing a historical baseline", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "package-audit-"));
+    temporaryDirectories.push(directory);
+    const outputPath = join(directory, "report.json");
+    const summaryPath = join(directory, "summary.md");
+    const readPaths: unknown[] = [];
+
+    await expect(
+      runPackageAudit({
+        currentPath: "current",
+        outputPath,
+        summaryPath,
+        readSnapshot: async (path) => {
+          readPaths.push(path);
+          return {
+            archiveBytes: 524_289,
+            entries: { "extension/release-CHANGELOG.txt": 526 }
+          };
+        }
+      })
+    ).rejects.toBeInstanceOf(PackageAuditError);
+
+    expect(readPaths).toEqual(["current"]);
+    const report = JSON.parse(await readFile(outputPath, "utf8"));
+    expect(report).toMatchObject({
+      mode: "current-only",
+      conclusion: "fail",
+      violations: [
+        { rule: "maximum-size", actual: 524_289, limit: 524_288 },
+        { rule: "forbidden-file", path: "extension/release-CHANGELOG.txt" }
+      ]
+    });
+    expect(report).not.toHaveProperty("baseline");
+    expect(await readFile(summaryPath, "utf8")).toContain("| Baseline | Not available |");
+  });
 });

--- a/tests/scripts/package-audit/publish-workflow.test.ts
+++ b/tests/scripts/package-audit/publish-workflow.test.ts
@@ -19,4 +19,15 @@ describe("publish package audit", () => {
     expect(auditStep).toContain('"$archive" \\\n');
     expect(auditStep).not.toContain('"$archive" \\\n            "$archive"');
   });
+
+  it("runs an explicit current-only audit for the first stable release", () => {
+    const auditStep = workflow.slice(
+      workflow.indexOf("Verify VSIX contents and size"),
+      workflow.indexOf("Upload VSIX artifact")
+    );
+
+    expect(auditStep).not.toContain('baseline="$archive"');
+    expect(auditStep).toContain('if [[ -n "$baseline" ]]');
+    expect(auditStep).toContain("--current-only");
+  });
 });

--- a/tests/scripts/package-audit/publish-workflow.test.ts
+++ b/tests/scripts/package-audit/publish-workflow.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  new URL("../../../.github/workflows/publish.yml", import.meta.url),
+  "utf8"
+);
+
+describe("publish package audit", () => {
+  it("compares the release VSIX with the previous published stable release", () => {
+    expect(workflow).toContain("Download previous published VSIX baseline");
+    expect(workflow).toContain("--exclude-drafts");
+    expect(workflow).toContain("--exclude-pre-releases");
+    expect(workflow).toContain("select(.tagName != $current)");
+    expect(workflow).toContain('gh release download "$baseline_tag"');
+
+    const auditStep = workflow.slice(workflow.indexOf("Verify VSIX contents and size"));
+    expect(auditStep).toContain('"$baseline" \\\n');
+    expect(auditStep).toContain('"$archive" \\\n');
+    expect(auditStep).not.toContain('"$archive" \\\n            "$archive"');
+  });
+});


### PR DESCRIPTION
## 修改内容

- 发布前从 GitHub Releases 选择不同于当前 tag 的最新稳定版本。
- 排除 draft 和 prerelease，并下载历史 VSIX 作为体积与内容比较基线。
- 首个稳定版本没有历史基线时，改走显式 `--current-only` 审计，只执行绝对大小和 forbidden-file 检查；不再把当前 VSIX 伪装成自己的 baseline。
- JSON 与 job summary 会明确标记 historical baseline 不可用，历史 comparison 路径保持不变。

## 根因

原工作流最初把当前生成的 `$archive` 连续传入 package audit 两次，使增长门禁恒为零。第一版修复虽然下载了上一稳定版本，却在首发 fallback 中执行 `baseline="$archive"`，仍让同一文件同时充当 baseline/current，也与 PR 声明的审计边界矛盾。

## TDD 证据

- 初始 Red：旧工作流缺少 previous published VSIX baseline，`1 failed / 295 passed`。
- 复审 Red（CLI seam）：current-only 用例观察到读取路径为 `[undefined, "current"]`，并生成与 current 相同的伪 baseline；定向结果 `1 failed / 2 passed`。
- 复审 Red（workflow seam）：契约测试稳定命中 `baseline="$archive"`；定向结果 `1 failed / 1 passed`。
- Green：CLI 仅读取 current，报告不含 baseline，仍拦截 maximum-size 与 forbidden-file；工作流在有历史 baseline 时比较两份不同 VSIX，无历史 baseline 时调用 `--current-only`。
- package-audit 定向测试：5 files / 12 tests passed。
- 全量测试：48 files / 298 tests passed。

## 验证

- `nub run test`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nubx tsc --noEmit`
- Ruby YAML parse
- `nub run build`
- `nub run package`
- 对真实的 87,723 B VSIX 执行 `nub scripts/package-audit/index.ts --current-only ...`：PASS，summary 显示 `Baseline | Not available` 与 `Change | Not evaluated`。
- pre-commit hook：format、lint、298 tests 全部通过。

`CHANGELOG.md` 按 admission rules 有意省略：这是发布门禁修复，不改变扩展用户行为。
