### PR TITLE
fix(theme): respect workspace configuration scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file records notable changes that people can observe or act on when using t
 ### Themes and appearance
 
 - Theme and theme-mode Quick Picks now display Chinese labels in Simplified Chinese VS Code, and confirmation messages no longer mix Chinese text with English theme names.
+- Theme Quick Picks now update existing workspace-level theme settings, so confirmed selections take effect instead of being hidden by a workspace override.
 
 ## [v4.4.2] - 2026-08-02
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,4 @@
-import { l10n } from "vscode";
+import vscode, { l10n } from "vscode";
 import { getConfiguration } from "./configuration";
 
 export type ThemeMode = "single" | "system" | "vscode";
@@ -56,12 +56,25 @@ export const section = {
   dark: "theme.dark"
 } as const;
 
+async function updateThemeConfiguration<T>(
+  key: (typeof section)[keyof typeof section],
+  value: T
+): Promise<void> {
+  const configuration = getConfiguration();
+  // Theme settings use window scope, so an unscoped configuration cannot write WorkspaceFolder.
+  const target =
+    configuration.inspect<T>(key)?.workspaceValue === undefined
+      ? vscode.ConfigurationTarget.Global
+      : vscode.ConfigurationTarget.Workspace;
+  await configuration.update(key, value, target);
+}
+
 export function getThemeMode(): ThemeMode {
   return getConfiguration().get(section.mode, "system");
 }
 
 export async function setThemeMode(mode: ThemeMode): Promise<void> {
-  await getConfiguration().update(section.mode, mode, true);
+  await updateThemeConfiguration(section.mode, mode);
 }
 
 export function getSingleTheme(): Theme {
@@ -69,7 +82,7 @@ export function getSingleTheme(): Theme {
 }
 
 export async function setSingleTheme(theme: Theme): Promise<void> {
-  await getConfiguration().update(section.single, theme, true);
+  await updateThemeConfiguration(section.single, theme);
 }
 
 export function getLightTheme(): Theme {
@@ -77,7 +90,7 @@ export function getLightTheme(): Theme {
 }
 
 export async function setLightTheme(theme: Theme): Promise<void> {
-  await getConfiguration().update(section.light, theme, true);
+  await updateThemeConfiguration(section.light, theme);
 }
 
 export function getDarkTheme(): Theme {
@@ -85,7 +98,7 @@ export function getDarkTheme(): Theme {
 }
 
 export async function setDarkTheme(theme: Theme): Promise<void> {
-  await getConfiguration().update(section.dark, theme, true);
+  await updateThemeConfiguration(section.dark, theme);
 }
 
 export function getThemeColorMode(): ThemeColorMode {

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -1,4 +1,4 @@
-import type vscode from "vscode";
+import vscode from "vscode";
 import MarkdownIt from "markdown-it";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestMemento } from "./helpers/memento";
@@ -16,6 +16,7 @@ const harness = vi.hoisted(() => ({
   informationMessages: [] as string[],
   localizedMessages: {} as Record<string, string>,
   markdownConfig: {} as Record<string, string | boolean>,
+  markdownWorkspaceConfig: {} as Record<string, string | boolean>,
   mermaidGlobalConfig: {} as Record<string, string | undefined>,
   mermaidUpdateError: undefined as Error | undefined,
   mermaidUpdates: [] as { key: string; value: string | undefined; target: number }[],
@@ -29,7 +30,7 @@ const harness = vi.hoisted(() => ({
 
 vi.mock("vscode", () => ({
   default: {
-    ConfigurationTarget: { Global: 1 },
+    ConfigurationTarget: { Global: 1, Workspace: 2 },
     extensions: {
       getExtension: (id: string) => (id === "vscode.mermaid-markdown-features" ? {} : undefined)
     },
@@ -43,6 +44,7 @@ vi.mock("vscode", () => ({
         if (harness.executeError) {
           throw harness.executeError;
         }
+        await harness.commandHandlers.get(id)?.();
       }
     },
     window: {
@@ -79,13 +81,24 @@ vi.mock("vscode", () => ({
         }
         return {
           get: (key: string, defaultValue?: unknown) =>
-            key in harness.markdownConfig ? harness.markdownConfig[key] : defaultValue,
+            key in harness.markdownWorkspaceConfig
+              ? harness.markdownWorkspaceConfig[key]
+              : key in harness.markdownConfig
+                ? harness.markdownConfig[key]
+                : defaultValue,
+          inspect: (key: string) => ({
+            key: `githubMarkdown.${key}`,
+            globalValue: harness.markdownConfig[key],
+            workspaceValue: harness.markdownWorkspaceConfig[key]
+          }),
           update: async (key: string, value: unknown, target: unknown) => {
             harness.githubUpdates.push({ key, value, target });
             if (harness.githubUpdateError) {
               throw harness.githubUpdateError;
             }
-            harness.markdownConfig[key] = value as string | boolean;
+            const targetConfig =
+              target === 2 ? harness.markdownWorkspaceConfig : harness.markdownConfig;
+            targetConfig[key] = value as string | boolean;
           }
         };
       },
@@ -197,6 +210,7 @@ describe("extension lifecycle", () => {
       "theme.dark": "dark",
       "mermaid.syncTheme": true
     };
+    harness.markdownWorkspaceConfig = {};
     harness.mermaidGlobalConfig = {
       lightModeTheme: "neutral",
       darkModeTheme: "forest"
@@ -342,9 +356,8 @@ describe("extension lifecycle", () => {
   it("treats theme command cancellation as a no-op", async () => {
     const context = createContext();
     await activate(context);
-    const command = harness.commandHandlers.get("vscode-github-markdown.changeThemeMode");
 
-    await command?.();
+    await vscode.commands.executeCommand("vscode-github-markdown.changeThemeMode");
 
     expect(harness.githubUpdates).toEqual([]);
     expect(harness.informationMessages).toEqual([]);
@@ -363,15 +376,45 @@ describe("extension lifecycle", () => {
       const context = createContext();
       await activate(context);
       harness.quickPickResult = newSelection;
-      const command = harness.commandHandlers.get(commandId);
 
-      await command?.();
+      await vscode.commands.executeCommand(commandId);
 
+      const configuration = vscode.workspace.getConfiguration("githubMarkdown");
       expect(harness.quickPickCalls).toEqual([{ items: quickPickItems, options: { placeHolder } }]);
-      expect(harness.githubUpdates).toEqual([
-        { key: configurationKey, value: newSelection.value, target: true }
-      ]);
+      expect(configuration.get(configurationKey)).toBe(newSelection.value);
+      expect(configuration.inspect(configurationKey)).toEqual(
+        expect.objectContaining({
+          globalValue: newSelection.value,
+          workspaceValue: undefined
+        })
+      );
       expect(harness.informationMessages).toEqual([successMessage]);
+    }
+  );
+
+  it.each(themeCommandCases)(
+    "updates an existing workspace override through $commandId",
+    async ({ commandId, currentSelection, newSelection, configurationKey, successMessage }) => {
+      const originalGlobalValue = harness.markdownConfig[configurationKey];
+      harness.markdownWorkspaceConfig[configurationKey] = currentSelection.value;
+      const context = createContext();
+      await activate(context);
+      harness.quickPickResult = newSelection;
+
+      await vscode.commands.executeCommand(commandId);
+
+      const configuration = vscode.workspace.getConfiguration("githubMarkdown");
+      expect({
+        effectiveValue: configuration.get(configurationKey),
+        globalValue: configuration.inspect(configurationKey)?.globalValue,
+        workspaceValue: configuration.inspect(configurationKey)?.workspaceValue,
+        informationMessages: harness.informationMessages
+      }).toEqual({
+        effectiveValue: newSelection.value,
+        globalValue: originalGlobalValue,
+        workspaceValue: newSelection.value,
+        informationMessages: [successMessage]
+      });
     }
   );
 
@@ -384,9 +427,8 @@ describe("extension lifecycle", () => {
     const context = createContext();
     await activate(context);
     harness.quickPickValue = "dark_dimmed";
-    const command = harness.commandHandlers.get("vscode-github-markdown.changeSingleTheme");
 
-    await command?.();
+    await vscode.commands.executeCommand("vscode-github-markdown.changeSingleTheme");
 
     expect(harness.informationMessages).toEqual(["固定主题已切换为 柔和暗色。"]);
     expect(harness.quickPickCalls).toEqual([
@@ -404,9 +446,8 @@ describe("extension lifecycle", () => {
       const context = createContext();
       await activate(context);
       harness.quickPickResult = currentSelection;
-      const command = harness.commandHandlers.get(commandId);
 
-      await command?.();
+      await vscode.commands.executeCommand(commandId);
 
       expect(harness.githubUpdates).toEqual([]);
       expect(harness.informationMessages).toEqual([]);
@@ -416,11 +457,12 @@ describe("extension lifecycle", () => {
   it("reports a theme configuration update failure without changing the active value", async () => {
     const context = createContext();
     await activate(context);
-    const command = harness.commandHandlers.get("vscode-github-markdown.changeThemeMode");
     harness.quickPickResult = { label: "Single theme", value: "single" };
     harness.githubUpdateError = new Error("Configuration update failed");
 
-    await expect(command?.()).resolves.toBeUndefined();
+    await expect(
+      vscode.commands.executeCommand("vscode-github-markdown.changeThemeMode")
+    ).resolves.toBeUndefined();
 
     expect(harness.markdownConfig["theme.mode"]).toBe("system");
     expect(harness.informationMessages).toEqual([]);


### PR DESCRIPTION
## 概要

- 主题 Quick Pick 在设置已有 workspace override 时，改为更新 Workspace target
- 没有 workspace override 时继续写入 Global，保持原有用户级设置行为
- 四个主题命令通过同一个配置更新路径获得一致行为
- 在 `[Unreleased] / Themes and appearance` 记录用户可观察的修复结果

## 根因

四个主题 setter 都调用 `WorkspaceConfiguration.update(..., true)`。布尔值 `true` 等价于 `ConfigurationTarget.Global`。

当工作区已经为对应主题设置提供 `workspaceValue` 时，Workspace 的优先级高于 Global。命令虽然成功更新 Global 并显示确认消息，但 `WorkspaceConfiguration.get()` 仍返回旧的 workspace override，因此当前预览主题没有变化。

## 修复策略

共享更新路径先通过 `inspect(key)` 检查现有作用域：

- 已有 `workspaceValue`：更新 `ConfigurationTarget.Workspace`
- 否则：更新 `ConfigurationTarget.Global`

这些主题设置使用默认的 `window` scope，且配置对象没有资源 URI。VS Code API 明确禁止这种 configuration 写入 WorkspaceFolder，因此实现不会根据 `workspaceFolderValue` 选择不可写 target，也不会创建新的 workspace override。

## TDD：red → green

公共 seam 是：

`activate()` 注册命令 → `vscode.commands.executeCommand()` → Quick Pick → `WorkspaceConfiguration.get()/inspect()` 与用户可见消息。

Red：

- 四个主题命令全部失败，`4 failed / 295 passed`
- 收到成功消息，但有效值和 `workspaceValue` 仍是旧值
- 新值被错误写入 `globalValue`

Green：

- 四个命令都更新已有 workspace override
- 有效值立即变为 Quick Pick 选择
- 原 `globalValue` 保持不变
- 无 workspace override 的现有 Global 行为继续通过
- 定向测试 `23 passed`，全量测试 `299 passed`

## 验证

- `pnpm install --frozen-lockfile`
- `nubx vitest run tests/extension.test.ts`
- `nub run test`
- `nub run test:coverage`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nubx tsc --noEmit`
- `nub run build`
- pre-commit hook：format、lint、299 tests 全部通过

## Scope

未修改 Mermaid 同步逻辑或配置作用域。