### PR TITLE
fix(mermaid): preserve workspace theme overrides

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,7 +39,9 @@ Theme metadata written by `src/plugins/markdown-it-github-theme.ts` selects eith
 
 Mermaid rendering belongs to the separate `markdown-mermaid` extension. If its configuration keys exist and `githubMarkdown.mermaid.syncTheme` is enabled, this extension maps the selected GitHub themes to both `markdown-mermaid.lightModeTheme` and `markdown-mermaid.darkModeTheme`.
 
-Before the first update, the original global values are stored in extension global state. Disabling synchronization restores those values and removes the snapshot. If `markdown-mermaid` is absent, synchronization is a no-op. No Mermaid runtime is bundled.
+Each Mermaid slot uses the Workspace target when that setting has an explicit workspace override; otherwise it uses Global. Original values and the last applied values are stored per target in extension global state, with Workspace records keyed by the current workspace identity. Stopping synchronization or deactivating the extension restores every still-owned Global record and the current workspace's still-owned Workspace records. A user change releases the affected record, so restoration does not overwrite the newer choice.
+
+Apply and restore intent is persisted before configuration writes. Pending records are reconciled after an interrupted transition, and released records preserve user takeovers across later workspace changes. Concurrent extension hosts cannot update shared Global settings atomically, so the latest observed host write wins until another host observes a user takeover. If `markdown-mermaid` is absent, synchronization is a no-op. No Mermaid runtime is bundled.
 
 ## Verification Boundaries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+### Mermaid
+
+- Mermaid theme synchronization now respects workspace-level Mermaid theme settings, restores their original values when synchronization stops, and leaves global themes and newer user choices unchanged.
+
 ### Themes and appearance
 
 - Theme and theme-mode Quick Picks now display Chinese labels in Simplified Chinese VS Code, and confirmation messages no longer mix Chinese text with English theme names.

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -34,8 +34,6 @@ type SlotState = {
   applied?: MermaidTheme;
   owner?: string;
   releasedBy?: string;
-  releasedValue?: MermaidTheme | undefined;
-  releasedValueCaptured?: true;
   pending?: Pending;
 };
 type LegacySnapshot = {
@@ -50,7 +48,6 @@ type SlotContext = {
   key: SlotKey;
   target: Target;
   stateKey: string;
-  revision: string | undefined;
   state: SlotState | undefined;
 };
 type Transaction = SlotContext & {
@@ -73,16 +70,6 @@ const mermaidExtensionIds = [
   "bierner.markdown-mermaid"
 ] as const;
 let operationQueue: Promise<void> = Promise.resolve();
-let revisionCounter = 0;
-
-class ConcurrentStateError extends Error {
-  constructor(
-    readonly key: string,
-    readonly persistedState: SlotState | undefined
-  ) {
-    super("Mermaid theme state changed in another extension host");
-  }
-}
 
 export function getMermaidSyncTheme(): boolean {
   return getConfiguration().get<boolean>(section.syncTheme, true);
@@ -189,21 +176,20 @@ async function prepareApply(
   if (state?.pending?.kind === "apply") {
     reconciled = true;
     if (previousValue === state.pending.desired) state.applied = state.pending.desired;
-    else if (previousValue !== state.pending.previous)
-      state = release(state, identity, previousValue);
+    else if (previousValue !== state.pending.previous) state = release(state, identity);
     if (state.pending?.kind === "apply") delete state.pending;
   } else if (state?.pending?.kind === "restore") {
     reconciled = true;
     if (previousValue === state.pending.desired) state = undefined;
     else if (previousValue === state.pending.previous) delete state.pending;
-    else state = release(state, identity, previousValue);
+    else state = release(state, identity);
   }
   if (state?.releasedBy !== undefined) {
     if (reconciled) await saveContext(memento, context, state);
     return undefined;
   }
   if (state?.applied !== undefined && previousValue !== state.applied) {
-    await saveContext(memento, context, release(state, identity, previousValue));
+    await saveContext(memento, context, release(state, identity));
     return undefined;
   }
 
@@ -247,13 +233,8 @@ function prepareRestore(
   };
 }
 
-function release(state: SlotState, identity: string, value: MermaidTheme | undefined): SlotState {
-  const released = {
-    ...state,
-    releasedBy: identity,
-    releasedValue: value,
-    releasedValueCaptured: true as const
-  };
+function release(state: SlotState, identity: string): SlotState {
+  const released = { ...state, releasedBy: identity };
   delete released.applied;
   delete released.owner;
   delete released.pending;
@@ -295,13 +276,7 @@ async function executeTransactions(
       }
     }
   } catch (persistenceError) {
-    const failures = await recoverTransactions(
-      memento,
-      configuration,
-      transactions,
-      results,
-      persistenceError
-    );
+    const failures = await recoverTransactions(memento, configuration, transactions, results);
     if (failures.length) throw new AggregateError([persistenceError, ...failures]);
     throw persistenceError;
   }
@@ -312,40 +287,25 @@ async function recoverTransactions(
   memento: vscode.Memento,
   configuration: vscode.WorkspaceConfiguration,
   transactions: Transaction[],
-  results: PromiseSettledResult<void>[],
-  persistenceError: unknown
+  results: PromiseSettledResult<void>[]
 ): Promise<unknown[]> {
-  const conflict = persistenceError instanceof ConcurrentStateError ? persistenceError : undefined;
   const updates = transactions.map((transaction, index): ConfigurationUpdate => {
-    const isConflict = conflict?.key === transaction.stateKey;
-    const winner = isConflict ? getWinnerValue(conflict.persistedState) : undefined;
     const current = getThemeAtTarget(configuration, transaction.key, transaction.target);
     return {
       key: transaction.key,
       target: transaction.target,
-      desiredValue: isConflict ? winner?.value : transaction.previousValue,
+      desiredValue: transaction.previousValue,
       shouldWrite:
         results[index]?.status === "fulfilled" &&
         transaction.shouldWrite &&
-        current === transaction.desiredValue &&
-        (!isConflict || winner?.captured === true)
+        current === transaction.desiredValue
     };
   });
   const recoveryResults = await writeSequentially(configuration, updates);
   const failures = recoveryResults
     .filter((result): result is PromiseRejectedResult => result.status === "rejected")
     .map((result) => result.reason);
-  for (const [index, result] of recoveryResults.entries()) {
-    const transaction = transactions[index];
-    if (result.status !== "fulfilled" || !transaction || conflict?.key === transaction.stateKey) {
-      continue;
-    }
-    try {
-      await saveContext(memento, transaction, transaction.previousState);
-    } catch (error) {
-      if (!(error instanceof ConcurrentStateError)) failures.push(error);
-    }
-  }
+  failures.push(...(await restoreStates(memento, transactions)));
   return failures;
 }
 
@@ -358,7 +318,7 @@ async function restoreStates(
     try {
       await saveContext(memento, transaction, transaction.previousState);
     } catch (error) {
-      if (!(error instanceof ConcurrentStateError)) failures.push(error);
+      failures.push(error);
     }
   }
   return failures;
@@ -409,7 +369,6 @@ function loadContext(
     key,
     target,
     stateKey,
-    revision: persisted?.revision,
     state: valid ? { ...persisted } : undefined
   };
 }
@@ -419,20 +378,14 @@ async function saveContext(
   context: SlotContext,
   state: SlotState | undefined
 ): Promise<void> {
-  const persisted = memento.get<SlotState>(context.stateKey);
-  if (persisted?.revision !== context.revision) {
-    throw new ConcurrentStateError(context.stateKey, persisted);
-  }
   if (!state) {
     await memento.update(context.stateKey, undefined);
-    context.revision = undefined;
     context.state = undefined;
     return;
   }
-  const revision = `${Date.now()}:${++revisionCounter}`;
-  const next = { ...state, revision } satisfies SlotState;
+  const next = { ...state };
+  delete next.revision;
   await memento.update(context.stateKey, next);
-  context.revision = revision;
   context.state = next;
 }
 
@@ -448,18 +401,9 @@ async function discardWorkspaceState(
     key: slot === "light" ? originSection.light : originSection.dark,
     target: vscode.ConfigurationTarget.Workspace,
     stateKey,
-    revision: persisted.revision,
     state: persisted
   };
   await saveContext(memento, context, undefined);
-}
-
-function getWinnerValue(
-  state: SlotState | undefined
-): { captured: boolean; value?: MermaidTheme | undefined } | undefined {
-  if (state?.applied !== undefined) return { captured: true, value: state.applied };
-  if (state?.releasedValueCaptured) return { captured: true, value: state.releasedValue };
-  return state ? { captured: false } : undefined;
 }
 
 async function migrateSnapshot(memento: vscode.Memento, currentIdentity: string): Promise<void> {

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -305,7 +305,10 @@ async function recoverTransactions(
   const failures = recoveryResults
     .filter((result): result is PromiseRejectedResult => result.status === "rejected")
     .map((result) => result.reason);
-  failures.push(...(await restoreStates(memento, transactions)));
+  const restoredTransactions = transactions.filter(
+    (_, index) => recoveryResults[index]?.status === "fulfilled"
+  );
+  failures.push(...(await restoreStates(memento, restoredTransactions)));
   return failures;
 }
 

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -76,6 +76,17 @@ type MermaidThemeUpdateOperation = {
   previousValue: MermaidTheme | undefined;
 };
 
+type MermaidThemeStateClaim = Pick<
+  MermaidThemeUpdateOperation,
+  "slot" | "target" | "state" | "previousState"
+>;
+
+type MermaidThemeRestoration = MermaidThemeStateClaim & {
+  key: typeof originSection.light | typeof originSection.dark;
+  previousValue: MermaidTheme | undefined;
+  shouldWrite: boolean;
+};
+
 const snapshotKey = "githubMarkdown.mermaid.originalGlobalThemes";
 const stateKeyPrefix = "githubMarkdown.mermaid.themeState.v2";
 const mermaidExtensionIds = [
@@ -86,6 +97,8 @@ const MERMAID_LIGHT_THEME: MermaidTheme = "default";
 const MERMAID_DARK_THEME: MermaidTheme = "dark";
 let mermaidThemeOperationQueue: Promise<void> = Promise.resolve();
 let mermaidThemeStateRevision = 0;
+
+class ConcurrentMermaidThemeStateError extends Error {}
 
 export function getMermaidSyncTheme(): boolean {
   return getConfiguration().get<boolean>(section.syncTheme, true);
@@ -110,7 +123,18 @@ async function updateMermaidThemeSyncNow(memento: vscode.Memento): Promise<void>
 
   const [light, dark] = resolveMermaidThemes();
   const operations = prepareMermaidThemeUpdates(configuration, states, { light, dark });
-  await persistMermaidThemeStates(memento, states);
+  try {
+    await persistMermaidThemeStates(memento, states);
+  } catch (claimError) {
+    const rollbackFailures = await rollbackMermaidThemeClaims(memento, states, operations);
+    if (rollbackFailures.length > 0) {
+      throw new AggregateError(
+        [claimError, ...rollbackFailures],
+        `${getErrorMessage(claimError)}; failed to release Mermaid theme state claims`
+      );
+    }
+    throw claimError;
+  }
   const updateResults = await Promise.allSettled(
     operations.map((operation) =>
       updateMermaidTheme(configuration, operation.key, operation.theme, operation.target)
@@ -127,7 +151,24 @@ async function updateMermaidThemeSyncNow(memento: vscode.Memento): Promise<void>
     }
     markMermaidThemeStateDirty(states, operation.target, operation.slot);
   });
-  await persistMermaidThemeStates(memento, states);
+  try {
+    await persistMermaidThemeStates(memento, states);
+  } catch (persistenceError) {
+    const rollbackFailures = await rollbackMermaidThemesAfterPersistenceFailure(
+      memento,
+      configuration,
+      states,
+      operations,
+      updateResults
+    );
+    if (rollbackFailures.length > 0) {
+      throw new AggregateError(
+        [persistenceError, ...rollbackFailures],
+        `${getErrorMessage(persistenceError)}; failed to roll back Mermaid themes after a state persistence failure`
+      );
+    }
+    throw persistenceError;
+  }
 
   const failure = updateResults.find((result) => result.status === "rejected");
   if (failure?.status === "rejected") {
@@ -139,11 +180,9 @@ async function updateMermaidThemeSyncNow(memento: vscode.Memento): Promise<void>
       updateResults
     );
     if (restoreFailures.length > 0) {
-      const failureMessage =
-        failure.reason instanceof Error ? failure.reason.message : String(failure.reason);
       throw new AggregateError(
         [failure.reason, ...restoreFailures],
-        `${failureMessage}; failed to restore the original Mermaid themes`
+        `${getErrorMessage(failure.reason)}; failed to restore the original Mermaid themes`
       );
     }
     throw failure.reason;
@@ -167,13 +206,22 @@ async function restoreMermaidThemeSyncNow(
   }
 
   const states = loadedStates ?? (await loadMermaidThemeStates(memento));
-  const restorations = collectMermaidThemeRestorations(states);
+  const restorations = collectMermaidThemeRestorations(configuration, states);
+  try {
+    await persistMermaidThemeStates(memento, states);
+  } catch (claimError) {
+    const rollbackFailures = await rollbackMermaidThemeClaims(memento, states, restorations);
+    if (rollbackFailures.length > 0) {
+      throw new AggregateError(
+        [claimError, ...rollbackFailures],
+        `${getErrorMessage(claimError)}; failed to release Mermaid theme restoration claims`
+      );
+    }
+    throw claimError;
+  }
   const restoreResults = await Promise.allSettled(
-    restorations.map(({ key, state, target }) => {
-      if (
-        state.applied === undefined ||
-        getMermaidThemeAtTarget(configuration, key, target) !== state.applied
-      ) {
+    restorations.map(({ key, shouldWrite, state, target }) => {
+      if (!shouldWrite) {
         return Promise.resolve();
       }
       return updateMermaidTheme(configuration, key, state.original, target);
@@ -189,7 +237,24 @@ async function restoreMermaidThemeSyncNow(
     )[restoration.slot];
     markMermaidThemeStateDirty(states, restoration.target, restoration.slot);
   });
-  await persistMermaidThemeStates(memento, states);
+  try {
+    await persistMermaidThemeStates(memento, states);
+  } catch (persistenceError) {
+    const rollbackFailures = await rollbackMermaidRestorationsAfterPersistenceFailure(
+      memento,
+      configuration,
+      states,
+      restorations,
+      restoreResults
+    );
+    if (rollbackFailures.length > 0) {
+      throw new AggregateError(
+        [persistenceError, ...rollbackFailures],
+        `${getErrorMessage(persistenceError)}; failed to roll back Mermaid theme restoration after a state persistence failure`
+      );
+    }
+    throw persistenceError;
+  }
   const restoreFailures = restoreResults
     .filter((result): result is PromiseRejectedResult => result.status === "rejected")
     .map((result) => result.reason);
@@ -362,6 +427,10 @@ function prepareMermaidThemeUpdates(
       dirtySlots.add(slot);
       continue;
     }
+    if (effective.target === vscode.ConfigurationTarget.Global) {
+      state.owner = states.identity;
+      dirtySlots.add(slot);
+    }
     operations.push({
       slot,
       key,
@@ -375,45 +444,193 @@ function prepareMermaidThemeUpdates(
   return operations;
 }
 
-function collectMermaidThemeRestorations(states: MermaidThemeStates): {
-  slot: MermaidThemeSlot;
-  key: typeof originSection.light | typeof originSection.dark;
-  target: MermaidThemeTarget;
-  state: MermaidThemeSlotState;
-}[] {
-  const restorations: {
-    slot: MermaidThemeSlot;
-    key: typeof originSection.light | typeof originSection.dark;
-    target: MermaidThemeTarget;
-    state: MermaidThemeSlotState;
-  }[] = [];
+function collectMermaidThemeRestorations(
+  configuration: vscode.WorkspaceConfiguration,
+  states: MermaidThemeStates
+): MermaidThemeRestoration[] {
+  const restorations: MermaidThemeRestoration[] = [];
   for (const [slot, key] of [
     ["light", originSection.light],
     ["dark", originSection.dark]
   ] as const) {
-    const workspaceState = states.workspace[slot];
-    if (workspaceState) {
+    const effective = getEffectiveMermaidThemeOverride(configuration, key);
+    if (effective.target === vscode.ConfigurationTarget.Workspace) {
+      const workspaceState = states.workspace[slot];
+      if (!workspaceState) {
+        continue;
+      }
+      const previousValue = getMermaidThemeAtTarget(
+        configuration,
+        key,
+        vscode.ConfigurationTarget.Workspace
+      );
+      const previousState = { ...workspaceState };
+      states.dirtyWorkspace.add(slot);
       restorations.push({
         slot,
         key,
         target: vscode.ConfigurationTarget.Workspace,
-        state: workspaceState
+        state: workspaceState,
+        previousState,
+        previousValue,
+        shouldWrite:
+          workspaceState.applied !== undefined && previousValue === workspaceState.applied
       });
+      continue;
+    }
+
+    if (states.workspace[slot] !== undefined) {
+      delete states.workspace[slot];
+      states.dirtyWorkspace.add(slot);
     }
     const globalState = states.global[slot];
-    if (
-      globalState &&
-      (globalState.owner === states.identity || globalState.releasedBy === states.identity)
-    ) {
+    if (globalState) {
+      const previousValue = getMermaidThemeAtTarget(
+        configuration,
+        key,
+        vscode.ConfigurationTarget.Global
+      );
+      const previousState = { ...globalState };
+      globalState.owner = states.identity;
+      states.dirtyGlobal.add(slot);
       restorations.push({
         slot,
         key,
         target: vscode.ConfigurationTarget.Global,
-        state: globalState
+        state: globalState,
+        previousState,
+        previousValue,
+        shouldWrite: globalState.applied !== undefined && previousValue === globalState.applied
       });
     }
   }
   return restorations;
+}
+
+async function rollbackMermaidThemeClaims(
+  memento: vscode.Memento,
+  states: MermaidThemeStates,
+  operations: MermaidThemeStateClaim[]
+): Promise<unknown[]> {
+  const failures: unknown[] = [];
+  for (const operation of operations) {
+    if (
+      operation.state.revision === undefined ||
+      operation.state.revision === operation.previousState?.revision
+    ) {
+      continue;
+    }
+    try {
+      await restorePreviousMermaidThemeState(memento, states, operation);
+    } catch (error) {
+      if (!(error instanceof ConcurrentMermaidThemeStateError)) {
+        failures.push(error);
+      }
+    }
+  }
+  return failures;
+}
+
+async function rollbackMermaidThemesAfterPersistenceFailure(
+  memento: vscode.Memento,
+  configuration: vscode.WorkspaceConfiguration,
+  states: MermaidThemeStates,
+  operations: MermaidThemeUpdateOperation[],
+  updateResults: PromiseSettledResult<void>[]
+): Promise<unknown[]> {
+  const configurationRollbacks = operations.map((operation, index) => {
+    const updateResult = updateResults[index];
+    if (
+      updateResult?.status !== "fulfilled" ||
+      getMermaidThemeAtTarget(configuration, operation.key, operation.target) !== operation.theme
+    ) {
+      return Promise.resolve();
+    }
+    return updateMermaidTheme(
+      configuration,
+      operation.key,
+      operation.previousValue,
+      operation.target
+    );
+  });
+  const configurationResults = await Promise.allSettled(configurationRollbacks);
+  const failures = configurationResults
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+
+  for (const [index, result] of configurationResults.entries()) {
+    const operation = operations[index];
+    if (result.status !== "fulfilled" || !operation || operation.state.revision === undefined) {
+      continue;
+    }
+    try {
+      await restorePreviousMermaidThemeState(memento, states, operation);
+    } catch (error) {
+      if (!(error instanceof ConcurrentMermaidThemeStateError)) {
+        failures.push(error);
+      }
+    }
+  }
+  return failures;
+}
+
+async function rollbackMermaidRestorationsAfterPersistenceFailure(
+  memento: vscode.Memento,
+  configuration: vscode.WorkspaceConfiguration,
+  states: MermaidThemeStates,
+  restorations: MermaidThemeRestoration[],
+  restoreResults: PromiseSettledResult<void>[]
+): Promise<unknown[]> {
+  const configurationRollbacks = restorations.map((restoration, index) => {
+    const restoreResult = restoreResults[index];
+    if (
+      restoreResult?.status !== "fulfilled" ||
+      !restoration.shouldWrite ||
+      getMermaidThemeAtTarget(configuration, restoration.key, restoration.target) !==
+        restoration.state.original
+    ) {
+      return Promise.resolve();
+    }
+    return updateMermaidTheme(
+      configuration,
+      restoration.key,
+      restoration.previousValue,
+      restoration.target
+    );
+  });
+  const configurationResults = await Promise.allSettled(configurationRollbacks);
+  const failures = configurationResults
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+
+  for (const [index, result] of configurationResults.entries()) {
+    const restoration = restorations[index];
+    if (result.status !== "fulfilled" || !restoration) {
+      continue;
+    }
+    try {
+      await restorePreviousMermaidThemeState(memento, states, restoration);
+    } catch (error) {
+      if (!(error instanceof ConcurrentMermaidThemeStateError)) {
+        failures.push(error);
+      }
+    }
+  }
+  return failures;
+}
+
+async function restorePreviousMermaidThemeState(
+  memento: vscode.Memento,
+  states: MermaidThemeStates,
+  operation: MermaidThemeStateClaim
+): Promise<void> {
+  await persistMermaidThemeState(
+    memento,
+    getMermaidThemeStateKey(states.identity, operation.target, operation.slot),
+    operation.previousState ? { ...operation.previousState } : undefined,
+    getMermaidThemeStateRevision(states, operation.target, operation.slot),
+    states.identity
+  );
 }
 
 async function rollbackFailedMermaidThemeSync(
@@ -475,6 +692,18 @@ function markMermaidThemeStateDirty(
   );
 }
 
+function getMermaidThemeStateRevision(
+  states: MermaidThemeStates,
+  target: MermaidThemeTarget,
+  slot: MermaidThemeSlot
+): string | undefined {
+  return (
+    target === vscode.ConfigurationTarget.Global
+      ? states.globalRevisions
+      : states.workspaceRevisions
+  )[slot];
+}
+
 async function persistMermaidThemeStates(
   memento: vscode.Memento,
   states: MermaidThemeStates
@@ -520,7 +749,9 @@ async function persistMermaidThemeState(
 ): Promise<string | undefined> {
   const persistedState = memento.get<MermaidThemeSlotState>(key);
   if (persistedState?.revision !== expectedRevision) {
-    throw new Error("Mermaid theme state changed in another extension host");
+    throw new ConcurrentMermaidThemeStateError(
+      "Mermaid theme state changed in another extension host"
+    );
   }
   if (!state) {
     await memento.update(key, undefined);
@@ -538,6 +769,20 @@ function getGlobalThemeStateKey(slot: MermaidThemeSlot): string {
 
 function getWorkspaceThemeStateKey(identity: string, slot: MermaidThemeSlot): string {
   return `${stateKeyPrefix}.workspace.${encodeURIComponent(identity)}.${slot}`;
+}
+
+function getMermaidThemeStateKey(
+  identity: string,
+  target: MermaidThemeTarget,
+  slot: MermaidThemeSlot
+): string {
+  return target === vscode.ConfigurationTarget.Global
+    ? getGlobalThemeStateKey(slot)
+    : getWorkspaceThemeStateKey(identity, slot);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function hasMermaidExtension(): boolean {

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -25,7 +25,9 @@ export type MermaidTheme = (typeof themes)[number];
 
 type MermaidThemeTarget = vscode.ConfigurationTarget.Global | vscode.ConfigurationTarget.Workspace;
 
-type MermaidThemeSnapshot = {
+type MermaidThemeSlot = "light" | "dark";
+
+type LegacyMermaidThemeSnapshot = {
   light: MermaidTheme | undefined;
   dark: MermaidTheme | undefined;
   workspaceIdentity?: string;
@@ -43,7 +45,39 @@ type MermaidThemeSnapshot = {
   };
 };
 
+type MermaidThemeSlotState = {
+  version: 2;
+  revision?: string;
+  target: "global" | "workspace";
+  workspaceIdentity?: string | undefined;
+  original?: MermaidTheme | undefined;
+  applied?: MermaidTheme;
+  owner?: string;
+  releasedBy?: string;
+};
+
+type MermaidThemeStates = {
+  identity: string;
+  global: Partial<Record<MermaidThemeSlot, MermaidThemeSlotState>>;
+  workspace: Partial<Record<MermaidThemeSlot, MermaidThemeSlotState>>;
+  dirtyGlobal: Set<MermaidThemeSlot>;
+  dirtyWorkspace: Set<MermaidThemeSlot>;
+  globalRevisions: Partial<Record<MermaidThemeSlot, string>>;
+  workspaceRevisions: Partial<Record<MermaidThemeSlot, string>>;
+};
+
+type MermaidThemeUpdateOperation = {
+  slot: MermaidThemeSlot;
+  key: typeof originSection.light | typeof originSection.dark;
+  target: MermaidThemeTarget;
+  theme: MermaidTheme;
+  state: MermaidThemeSlotState;
+  previousState?: MermaidThemeSlotState | undefined;
+  previousValue: MermaidTheme | undefined;
+};
+
 const snapshotKey = "githubMarkdown.mermaid.originalGlobalThemes";
+const stateKeyPrefix = "githubMarkdown.mermaid.themeState.v2";
 const mermaidExtensionIds = [
   "vscode.mermaid-markdown-features",
   "bierner.markdown-mermaid"
@@ -51,6 +85,7 @@ const mermaidExtensionIds = [
 const MERMAID_LIGHT_THEME: MermaidTheme = "default";
 const MERMAID_DARK_THEME: MermaidTheme = "dark";
 let mermaidThemeOperationQueue: Promise<void> = Promise.resolve();
+let mermaidThemeStateRevision = 0;
 
 export function getMermaidSyncTheme(): boolean {
   return getConfiguration().get<boolean>(section.syncTheme, true);
@@ -62,9 +97,10 @@ export function updateMermaidThemeSync(memento: vscode.Memento): Promise<void> {
 
 async function updateMermaidThemeSyncNow(memento: vscode.Memento): Promise<void> {
   const configuration = getOriginMermaidThemeConfiguration();
+  const states = await loadMermaidThemeStates(memento);
 
   if (!getMermaidSyncTheme()) {
-    await restoreMermaidThemeSyncNow(memento, configuration);
+    await restoreMermaidThemeSyncNow(memento, configuration, states);
     return;
   }
 
@@ -72,34 +108,39 @@ async function updateMermaidThemeSyncNow(memento: vscode.Memento): Promise<void>
     return;
   }
 
-  const preservedSnapshot = await preserveMermaidThemes(memento, configuration);
-  const snapshot = releaseUserModifiedMermaidThemes(preservedSnapshot, configuration);
   const [light, dark] = resolveMermaidThemes();
-  const [lightResult, darkResult] = await Promise.allSettled([
-    updateOwnedMermaidTheme(configuration, snapshot, "light", originSection.light, light),
-    updateOwnedMermaidTheme(configuration, snapshot, "dark", originSection.dark, dark)
-  ]);
-  const applied = { ...snapshot.applied };
-  if (lightResult.status === "fulfilled" && lightResult.value) {
-    applied.light = light;
-  }
-  if (darkResult.status === "fulfilled" && darkResult.value) {
-    applied.dark = dark;
-  }
-  await memento.update(snapshotKey, {
-    ...snapshot,
-    applied
-  } satisfies MermaidThemeSnapshot);
+  const operations = prepareMermaidThemeUpdates(configuration, states, { light, dark });
+  await persistMermaidThemeStates(memento, states);
+  const updateResults = await Promise.allSettled(
+    operations.map((operation) =>
+      updateMermaidTheme(configuration, operation.key, operation.theme, operation.target)
+    )
+  );
+  updateResults.forEach((result, index) => {
+    const operation = operations[index];
+    if (result.status !== "fulfilled" || !operation) {
+      return;
+    }
+    operation.state.applied = operation.theme;
+    if (operation.target === vscode.ConfigurationTarget.Global) {
+      operation.state.owner = states.identity;
+    }
+    markMermaidThemeStateDirty(states, operation.target, operation.slot);
+  });
+  await persistMermaidThemeStates(memento, states);
 
-  const failure = [lightResult, darkResult].find((result) => result.status === "rejected");
+  const failure = updateResults.find((result) => result.status === "rejected");
   if (failure?.status === "rejected") {
-    try {
-      await restoreMermaidThemeSyncNow(memento, configuration);
-    } catch (restoreError) {
+    const restoreFailures = await rollbackFailedMermaidThemeSync(
+      memento,
+      configuration,
+      states,
+      operations,
+      updateResults
+    );
+    if (restoreFailures.length > 0) {
       const failureMessage =
         failure.reason instanceof Error ? failure.reason.message : String(failure.reason);
-      const restoreFailures =
-        restoreError instanceof AggregateError ? restoreError.errors : [restoreError];
       throw new AggregateError(
         [failure.reason, ...restoreFailures],
         `${failureMessage}; failed to restore the original Mermaid themes`
@@ -118,57 +159,43 @@ export function restoreMermaidThemeSync(
 
 async function restoreMermaidThemeSyncNow(
   memento: vscode.Memento,
-  configuration: vscode.WorkspaceConfiguration
+  configuration: vscode.WorkspaceConfiguration,
+  loadedStates?: MermaidThemeStates
 ): Promise<void> {
-  const snapshot = memento.get<MermaidThemeSnapshot>(snapshotKey);
-  if (!snapshot || !hasMermaidThemeConfiguration(configuration)) {
+  if (!hasMermaidThemeConfiguration(configuration)) {
     return;
   }
 
-  const updates: { slot: "light" | "dark"; promise: Promise<void> }[] = [];
-  const workspaceIdentityMatches =
-    snapshot.workspaceIdentity !== undefined &&
-    snapshot.workspaceIdentity === getWorkspaceIdentity();
-  const lightTarget = snapshot.targets?.light ?? vscode.ConfigurationTarget.Global;
-  if (
-    snapshot.applied?.light !== undefined &&
-    (lightTarget === vscode.ConfigurationTarget.Global || workspaceIdentityMatches) &&
-    getMermaidThemeAtTarget(configuration, originSection.light, lightTarget) ===
-      snapshot.applied.light
-  ) {
-    updates.push({
-      slot: "light",
-      promise: updateMermaidTheme(configuration, originSection.light, snapshot.light, lightTarget)
-    });
-  }
-  const darkTarget = snapshot.targets?.dark ?? vscode.ConfigurationTarget.Global;
-  if (
-    snapshot.applied?.dark !== undefined &&
-    (darkTarget === vscode.ConfigurationTarget.Global || workspaceIdentityMatches) &&
-    getMermaidThemeAtTarget(configuration, originSection.dark, darkTarget) === snapshot.applied.dark
-  ) {
-    updates.push({
-      slot: "dark",
-      promise: updateMermaidTheme(configuration, originSection.dark, snapshot.dark, darkTarget)
-    });
-  }
-
-  const restoreResults = await Promise.allSettled(updates.map(({ promise }) => promise));
-  const applied = { ...snapshot.applied };
+  const states = loadedStates ?? (await loadMermaidThemeStates(memento));
+  const restorations = collectMermaidThemeRestorations(states);
+  const restoreResults = await Promise.allSettled(
+    restorations.map(({ key, state, target }) => {
+      if (
+        state.applied === undefined ||
+        getMermaidThemeAtTarget(configuration, key, target) !== state.applied
+      ) {
+        return Promise.resolve();
+      }
+      return updateMermaidTheme(configuration, key, state.original, target);
+    })
+  );
   restoreResults.forEach((result, index) => {
-    const update = updates[index];
-    if (result.status === "fulfilled" && update) {
-      delete applied[update.slot];
+    const restoration = restorations[index];
+    if (result.status !== "fulfilled" || !restoration) {
+      return;
     }
+    delete (
+      restoration.target === vscode.ConfigurationTarget.Global ? states.global : states.workspace
+    )[restoration.slot];
+    markMermaidThemeStateDirty(states, restoration.target, restoration.slot);
   });
+  await persistMermaidThemeStates(memento, states);
   const restoreFailures = restoreResults
     .filter((result): result is PromiseRejectedResult => result.status === "rejected")
     .map((result) => result.reason);
   if (restoreFailures.length > 0) {
-    await memento.update(snapshotKey, { ...snapshot, applied } satisfies MermaidThemeSnapshot);
     throw new AggregateError(restoreFailures, "Failed to restore the original Mermaid themes");
   }
-  await memento.update(snapshotKey, undefined);
 }
 
 function enqueueMermaidThemeOperation(operation: () => Promise<void>): Promise<void> {
@@ -194,86 +221,323 @@ function resolveMermaidTheme(markdownTheme: Theme): MermaidTheme {
   return isLightTheme(markdownTheme) ? MERMAID_LIGHT_THEME : MERMAID_DARK_THEME;
 }
 
-async function preserveMermaidThemes(
-  memento: vscode.Memento,
-  configuration: vscode.WorkspaceConfiguration
-): Promise<MermaidThemeSnapshot> {
-  const snapshot = memento.get<MermaidThemeSnapshot>(snapshotKey);
-  if (snapshot) {
-    return rebaseMermaidThemesForWorkspace(memento, configuration, snapshot);
-  }
-
-  return captureMermaidThemes(memento, configuration);
-}
-
-async function captureMermaidThemes(
-  memento: vscode.Memento,
-  configuration: vscode.WorkspaceConfiguration
-): Promise<MermaidThemeSnapshot> {
-  const light = getEffectiveMermaidThemeOverride(configuration, originSection.light);
-  const dark = getEffectiveMermaidThemeOverride(configuration, originSection.dark);
-  const newSnapshot = {
-    light: light.value,
-    dark: dark.value,
-    workspaceIdentity: getWorkspaceIdentity(),
-    targets: {
-      light: light.target,
-      dark: dark.target
+async function loadMermaidThemeStates(memento: vscode.Memento): Promise<MermaidThemeStates> {
+  const identity = getWorkspaceIdentity();
+  await migrateLegacyMermaidThemeSnapshot(memento, identity);
+  const global = {} as MermaidThemeStates["global"];
+  const workspace = {} as MermaidThemeStates["workspace"];
+  const globalRevisions = {} as MermaidThemeStates["globalRevisions"];
+  const workspaceRevisions = {} as MermaidThemeStates["workspaceRevisions"];
+  for (const slot of ["light", "dark"] as const) {
+    const globalState = memento.get<MermaidThemeSlotState>(getGlobalThemeStateKey(slot));
+    if (globalState?.version === 2 && globalState.target === "global") {
+      global[slot] = { ...globalState };
+      if (globalState.revision !== undefined) {
+        globalRevisions[slot] = globalState.revision;
+      }
     }
-  } satisfies MermaidThemeSnapshot;
-  await memento.update(snapshotKey, newSnapshot);
-  return newSnapshot;
-}
-
-async function rebaseMermaidThemesForWorkspace(
-  memento: vscode.Memento,
-  configuration: vscode.WorkspaceConfiguration,
-  snapshot: MermaidThemeSnapshot
-): Promise<MermaidThemeSnapshot> {
-  const workspaceIdentity = getWorkspaceIdentity();
-  if (
-    snapshot.workspaceIdentity === workspaceIdentity ||
-    (snapshot.workspaceIdentity === undefined && snapshot.targets === undefined)
-  ) {
-    return snapshot;
+    const workspaceState = memento.get<MermaidThemeSlotState>(
+      getWorkspaceThemeStateKey(identity, slot)
+    );
+    if (
+      workspaceState?.version === 2 &&
+      workspaceState.target === "workspace" &&
+      workspaceState.workspaceIdentity === identity
+    ) {
+      workspace[slot] = { ...workspaceState };
+      if (workspaceState.revision !== undefined) {
+        workspaceRevisions[slot] = workspaceState.revision;
+      }
+    }
   }
-
-  const released = {
-    light: isGloballyReleased(snapshot, configuration, "light", originSection.light),
-    dark: isGloballyReleased(snapshot, configuration, "dark", originSection.dark)
+  return {
+    identity,
+    global,
+    workspace,
+    dirtyGlobal: new Set(),
+    dirtyWorkspace: new Set(),
+    globalRevisions,
+    workspaceRevisions
   };
-  await restoreMermaidThemeSyncNow(memento, configuration);
-  const currentSnapshot = await captureMermaidThemes(memento, configuration);
-  const rebasedSnapshot = {
-    ...currentSnapshot,
-    released: {
-      ...(currentSnapshot.targets?.light === vscode.ConfigurationTarget.Global && released.light
-        ? { light: true as const }
-        : {}),
-      ...(currentSnapshot.targets?.dark === vscode.ConfigurationTarget.Global && released.dark
-        ? { dark: true as const }
-        : {})
-    }
-  } satisfies MermaidThemeSnapshot;
-  await memento.update(snapshotKey, rebasedSnapshot);
-  return rebasedSnapshot;
 }
 
-function isGloballyReleased(
-  snapshot: MermaidThemeSnapshot,
-  configuration: vscode.WorkspaceConfiguration,
-  slot: "light" | "dark",
-  key: typeof originSection.light | typeof originSection.dark
-): boolean {
-  if (snapshot.targets?.[slot] !== vscode.ConfigurationTarget.Global) {
-    return false;
+async function migrateLegacyMermaidThemeSnapshot(
+  memento: vscode.Memento,
+  currentIdentity: string
+): Promise<void> {
+  const snapshot = memento.get<LegacyMermaidThemeSnapshot>(snapshotKey);
+  if (!snapshot) {
+    return;
   }
-  return (
-    snapshot.released?.[slot] === true ||
-    (snapshot.applied?.[slot] !== undefined &&
-      getMermaidThemeAtTarget(configuration, key, vscode.ConfigurationTarget.Global) !==
-        snapshot.applied[slot])
+
+  for (const slot of ["light", "dark"] as const) {
+    const target = snapshot.targets?.[slot] ?? vscode.ConfigurationTarget.Global;
+    const identity = snapshot.workspaceIdentity;
+    if (target === vscode.ConfigurationTarget.Workspace && identity === undefined) {
+      continue;
+    }
+    const state: MermaidThemeSlotState = {
+      version: 2,
+      target: target === vscode.ConfigurationTarget.Workspace ? "workspace" : "global",
+      original: snapshot[slot]
+    };
+    if (target === vscode.ConfigurationTarget.Workspace) {
+      state.workspaceIdentity = identity!;
+    } else if (snapshot.applied?.[slot] !== undefined) {
+      state.owner = identity ?? currentIdentity;
+    }
+    if (snapshot.applied?.[slot] !== undefined) {
+      state.applied = snapshot.applied[slot];
+    }
+    if (snapshot.released?.[slot]) {
+      state.releasedBy = identity ?? currentIdentity;
+      delete state.owner;
+      delete state.applied;
+    }
+    const key =
+      target === vscode.ConfigurationTarget.Workspace
+        ? getWorkspaceThemeStateKey(identity!, slot)
+        : getGlobalThemeStateKey(slot);
+    if (memento.get(key) === undefined) {
+      await memento.update(key, state);
+    }
+  }
+  await memento.update(snapshotKey, undefined);
+}
+
+function prepareMermaidThemeUpdates(
+  configuration: vscode.WorkspaceConfiguration,
+  states: MermaidThemeStates,
+  themes: Record<MermaidThemeSlot, MermaidTheme>
+): MermaidThemeUpdateOperation[] {
+  const operations: MermaidThemeUpdateOperation[] = [];
+  for (const [slot, key] of [
+    ["light", originSection.light],
+    ["dark", originSection.dark]
+  ] as const) {
+    const effective = getEffectiveMermaidThemeOverride(configuration, key);
+    const targetStates =
+      effective.target === vscode.ConfigurationTarget.Global ? states.global : states.workspace;
+    const dirtySlots =
+      effective.target === vscode.ConfigurationTarget.Global
+        ? states.dirtyGlobal
+        : states.dirtyWorkspace;
+    if (
+      effective.target === vscode.ConfigurationTarget.Global &&
+      states.workspace[slot] !== undefined
+    ) {
+      delete states.workspace[slot];
+      states.dirtyWorkspace.add(slot);
+    }
+
+    const existingState = targetStates[slot];
+    const previousState = existingState ? { ...existingState } : undefined;
+    const state =
+      existingState ??
+      ({
+        version: 2,
+        target: effective.target === vscode.ConfigurationTarget.Global ? "global" : "workspace",
+        original: effective.value
+      } satisfies MermaidThemeSlotState);
+    if (!existingState) {
+      if (effective.target === vscode.ConfigurationTarget.Global) {
+        state.owner = states.identity;
+      } else {
+        state.workspaceIdentity = states.identity;
+      }
+      targetStates[slot] = state;
+      dirtySlots.add(slot);
+    }
+
+    if (state.releasedBy !== undefined) {
+      continue;
+    }
+    if (
+      state.applied !== undefined &&
+      getMermaidThemeAtTarget(configuration, key, effective.target) !== state.applied
+    ) {
+      state.releasedBy = states.identity;
+      delete state.applied;
+      delete state.owner;
+      dirtySlots.add(slot);
+      continue;
+    }
+    operations.push({
+      slot,
+      key,
+      target: effective.target,
+      theme: themes[slot],
+      state,
+      previousState,
+      previousValue: getMermaidThemeAtTarget(configuration, key, effective.target)
+    });
+  }
+  return operations;
+}
+
+function collectMermaidThemeRestorations(states: MermaidThemeStates): {
+  slot: MermaidThemeSlot;
+  key: typeof originSection.light | typeof originSection.dark;
+  target: MermaidThemeTarget;
+  state: MermaidThemeSlotState;
+}[] {
+  const restorations: {
+    slot: MermaidThemeSlot;
+    key: typeof originSection.light | typeof originSection.dark;
+    target: MermaidThemeTarget;
+    state: MermaidThemeSlotState;
+  }[] = [];
+  for (const [slot, key] of [
+    ["light", originSection.light],
+    ["dark", originSection.dark]
+  ] as const) {
+    const workspaceState = states.workspace[slot];
+    if (workspaceState) {
+      restorations.push({
+        slot,
+        key,
+        target: vscode.ConfigurationTarget.Workspace,
+        state: workspaceState
+      });
+    }
+    const globalState = states.global[slot];
+    if (
+      globalState &&
+      (globalState.owner === states.identity || globalState.releasedBy === states.identity)
+    ) {
+      restorations.push({
+        slot,
+        key,
+        target: vscode.ConfigurationTarget.Global,
+        state: globalState
+      });
+    }
+  }
+  return restorations;
+}
+
+async function rollbackFailedMermaidThemeSync(
+  memento: vscode.Memento,
+  configuration: vscode.WorkspaceConfiguration,
+  states: MermaidThemeStates,
+  operations: MermaidThemeUpdateOperation[],
+  updateResults: PromiseSettledResult<void>[]
+): Promise<unknown[]> {
+  const rollbacks = operations.map((operation, index) => {
+    const result = updateResults[index];
+    const restoresPreviousOwner =
+      operation.target === vscode.ConfigurationTarget.Global &&
+      operation.previousState?.owner !== undefined &&
+      operation.previousState.owner !== states.identity;
+    const currentValue = getMermaidThemeAtTarget(configuration, operation.key, operation.target);
+    const rollback =
+      currentValue === operation.state.applied &&
+      ((restoresPreviousOwner && result?.status === "fulfilled") ||
+        (!restoresPreviousOwner && operation.state.applied !== undefined))
+        ? updateMermaidTheme(
+            configuration,
+            operation.key,
+            restoresPreviousOwner ? operation.previousValue : operation.state.original,
+            operation.target
+          )
+        : Promise.resolve();
+    return { operation, restoresPreviousOwner, rollback };
+  });
+  const rollbackResults = await Promise.allSettled(rollbacks.map(({ rollback }) => rollback));
+  rollbackResults.forEach((result, index) => {
+    const rollback = rollbacks[index];
+    if (result.status !== "fulfilled" || !rollback) {
+      return;
+    }
+    const { operation, restoresPreviousOwner } = rollback;
+    const targetStates =
+      operation.target === vscode.ConfigurationTarget.Global ? states.global : states.workspace;
+    if (restoresPreviousOwner && operation.previousState) {
+      targetStates[operation.slot] = operation.previousState;
+    } else {
+      delete targetStates[operation.slot];
+    }
+    markMermaidThemeStateDirty(states, operation.target, operation.slot);
+  });
+  await persistMermaidThemeStates(memento, states);
+  return rollbackResults
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+}
+
+function markMermaidThemeStateDirty(
+  states: MermaidThemeStates,
+  target: MermaidThemeTarget,
+  slot: MermaidThemeSlot
+): void {
+  (target === vscode.ConfigurationTarget.Global ? states.dirtyGlobal : states.dirtyWorkspace).add(
+    slot
   );
+}
+
+async function persistMermaidThemeStates(
+  memento: vscode.Memento,
+  states: MermaidThemeStates
+): Promise<void> {
+  for (const slot of states.dirtyGlobal) {
+    const revision = await persistMermaidThemeState(
+      memento,
+      getGlobalThemeStateKey(slot),
+      states.global[slot],
+      states.globalRevisions[slot],
+      states.identity
+    );
+    if (revision === undefined) {
+      delete states.globalRevisions[slot];
+    } else {
+      states.globalRevisions[slot] = revision;
+    }
+    states.dirtyGlobal.delete(slot);
+  }
+  for (const slot of states.dirtyWorkspace) {
+    const revision = await persistMermaidThemeState(
+      memento,
+      getWorkspaceThemeStateKey(states.identity, slot),
+      states.workspace[slot],
+      states.workspaceRevisions[slot],
+      states.identity
+    );
+    if (revision === undefined) {
+      delete states.workspaceRevisions[slot];
+    } else {
+      states.workspaceRevisions[slot] = revision;
+    }
+    states.dirtyWorkspace.delete(slot);
+  }
+}
+
+async function persistMermaidThemeState(
+  memento: vscode.Memento,
+  key: string,
+  state: MermaidThemeSlotState | undefined,
+  expectedRevision: string | undefined,
+  identity: string
+): Promise<string | undefined> {
+  const persistedState = memento.get<MermaidThemeSlotState>(key);
+  if (persistedState?.revision !== expectedRevision) {
+    throw new Error("Mermaid theme state changed in another extension host");
+  }
+  if (!state) {
+    await memento.update(key, undefined);
+    return undefined;
+  }
+  const revision = `${identity}:${Date.now()}:${++mermaidThemeStateRevision}`;
+  await memento.update(key, { ...state, revision } satisfies MermaidThemeSlotState);
+  state.revision = revision;
+  return revision;
+}
+
+function getGlobalThemeStateKey(slot: MermaidThemeSlot): string {
+  return `${stateKeyPrefix}.global.${slot}`;
+}
+
+function getWorkspaceThemeStateKey(identity: string, slot: MermaidThemeSlot): string {
+  return `${stateKeyPrefix}.workspace.${encodeURIComponent(identity)}.${slot}`;
 }
 
 function hasMermaidExtension(): boolean {
@@ -311,48 +575,6 @@ function getMermaidThemeAtTarget(
   return target === vscode.ConfigurationTarget.Workspace
     ? inspected?.workspaceValue
     : inspected?.globalValue;
-}
-
-function releaseUserModifiedMermaidThemes(
-  snapshot: MermaidThemeSnapshot,
-  configuration: vscode.WorkspaceConfiguration
-): MermaidThemeSnapshot {
-  const applied = { ...snapshot.applied };
-  const released = { ...snapshot.released };
-  for (const [slot, key] of [
-    ["light", originSection.light],
-    ["dark", originSection.dark]
-  ] as const) {
-    const target = snapshot.targets?.[slot] ?? vscode.ConfigurationTarget.Global;
-    if (
-      !released[slot] &&
-      applied[slot] !== undefined &&
-      getMermaidThemeAtTarget(configuration, key, target) !== applied[slot]
-    ) {
-      released[slot] = true;
-      delete applied[slot];
-    }
-  }
-  return { ...snapshot, applied, released };
-}
-
-async function updateOwnedMermaidTheme(
-  configuration: vscode.WorkspaceConfiguration,
-  snapshot: MermaidThemeSnapshot,
-  slot: "light" | "dark",
-  key: typeof originSection.light | typeof originSection.dark,
-  theme: MermaidTheme
-): Promise<boolean> {
-  if (snapshot.released?.[slot]) {
-    return false;
-  }
-  await updateMermaidTheme(
-    configuration,
-    key,
-    theme,
-    snapshot.targets?.[slot] ?? vscode.ConfigurationTarget.Global
-  );
-  return true;
 }
 
 function getEffectiveMermaidThemeOverride(

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -15,37 +15,17 @@ export const originSection = {
   dark: "darkModeTheme"
 } as const;
 
-export const section = {
-  syncTheme: "mermaid.syncTheme"
-} as const;
-
+export const section = { syncTheme: "mermaid.syncTheme" } as const;
 export const themes = ["vscode", "base", "forest", "dark", "default", "neutral"] as const;
-
 export type MermaidTheme = (typeof themes)[number];
 
-type MermaidThemeTarget = vscode.ConfigurationTarget.Global | vscode.ConfigurationTarget.Workspace;
-
-type MermaidThemeSlot = "light" | "dark";
-
-type LegacyMermaidThemeSnapshot = {
-  light: MermaidTheme | undefined;
-  dark: MermaidTheme | undefined;
-  workspaceIdentity?: string;
-  targets?: {
-    light: MermaidThemeTarget;
-    dark: MermaidThemeTarget;
-  };
-  applied?: {
-    light?: MermaidTheme;
-    dark?: MermaidTheme;
-  };
-  released?: {
-    light?: true;
-    dark?: true;
-  };
-};
-
-type MermaidThemeSlotState = {
+type Target = vscode.ConfigurationTarget.Global | vscode.ConfigurationTarget.Workspace;
+type Slot = "light" | "dark";
+type SlotKey = typeof originSection.light | typeof originSection.dark;
+type Pending =
+  | { kind: "apply"; desired: MermaidTheme; previous?: MermaidTheme | undefined }
+  | { kind: "restore"; desired?: MermaidTheme | undefined; previous?: MermaidTheme | undefined };
+type SlotState = {
   version: 2;
   revision?: string;
   target: "global" | "workspace";
@@ -54,767 +34,513 @@ type MermaidThemeSlotState = {
   applied?: MermaidTheme;
   owner?: string;
   releasedBy?: string;
+  releasedValue?: MermaidTheme | undefined;
+  releasedValueCaptured?: true;
+  pending?: Pending;
 };
-
-type MermaidThemeStates = {
-  identity: string;
-  global: Partial<Record<MermaidThemeSlot, MermaidThemeSlotState>>;
-  workspace: Partial<Record<MermaidThemeSlot, MermaidThemeSlotState>>;
-  dirtyGlobal: Set<MermaidThemeSlot>;
-  dirtyWorkspace: Set<MermaidThemeSlot>;
-  globalRevisions: Partial<Record<MermaidThemeSlot, string>>;
-  workspaceRevisions: Partial<Record<MermaidThemeSlot, string>>;
+type LegacySnapshot = {
+  light: MermaidTheme | undefined;
+  dark: MermaidTheme | undefined;
+  workspaceIdentity?: string;
+  targets?: Record<Slot, Target>;
+  applied?: Partial<Record<Slot, MermaidTheme>>;
+  released?: Partial<Record<Slot, true>>;
 };
-
-type MermaidThemeUpdateOperation = {
-  slot: MermaidThemeSlot;
-  key: typeof originSection.light | typeof originSection.dark;
-  target: MermaidThemeTarget;
-  theme: MermaidTheme;
-  state: MermaidThemeSlotState;
-  previousState?: MermaidThemeSlotState | undefined;
+type SlotContext = {
+  key: SlotKey;
+  target: Target;
+  stateKey: string;
+  revision: string | undefined;
+  state: SlotState | undefined;
+};
+type Transaction = SlotContext & {
+  state: SlotState;
+  previousState: SlotState | undefined;
   previousValue: MermaidTheme | undefined;
-};
-
-type MermaidThemeStateClaim = Pick<
-  MermaidThemeUpdateOperation,
-  "slot" | "target" | "state" | "previousState"
->;
-
-type MermaidThemeRestoration = MermaidThemeStateClaim & {
-  key: typeof originSection.light | typeof originSection.dark;
-  previousValue: MermaidTheme | undefined;
+  desiredValue: MermaidTheme | undefined;
   shouldWrite: boolean;
 };
+type ConfigurationUpdate = Pick<Transaction, "key" | "target" | "desiredValue" | "shouldWrite">;
 
 const snapshotKey = "githubMarkdown.mermaid.originalGlobalThemes";
 const stateKeyPrefix = "githubMarkdown.mermaid.themeState.v2";
+const slots = [
+  ["light", originSection.light],
+  ["dark", originSection.dark]
+] as const;
 const mermaidExtensionIds = [
   "vscode.mermaid-markdown-features",
   "bierner.markdown-mermaid"
 ] as const;
-const MERMAID_LIGHT_THEME: MermaidTheme = "default";
-const MERMAID_DARK_THEME: MermaidTheme = "dark";
-let mermaidThemeOperationQueue: Promise<void> = Promise.resolve();
-let mermaidThemeStateRevision = 0;
+let operationQueue: Promise<void> = Promise.resolve();
+let revisionCounter = 0;
 
-class ConcurrentMermaidThemeStateError extends Error {}
+class ConcurrentStateError extends Error {
+  constructor(
+    readonly key: string,
+    readonly persistedState: SlotState | undefined
+  ) {
+    super("Mermaid theme state changed in another extension host");
+  }
+}
 
 export function getMermaidSyncTheme(): boolean {
   return getConfiguration().get<boolean>(section.syncTheme, true);
 }
 
 export function updateMermaidThemeSync(memento: vscode.Memento): Promise<void> {
-  return enqueueMermaidThemeOperation(() => updateMermaidThemeSyncNow(memento));
-}
-
-async function updateMermaidThemeSyncNow(memento: vscode.Memento): Promise<void> {
-  const configuration = getOriginMermaidThemeConfiguration();
-  const states = await loadMermaidThemeStates(memento);
-
-  if (!getMermaidSyncTheme()) {
-    await restoreMermaidThemeSyncNow(memento, configuration, states);
-    return;
-  }
-
-  if (!hasMermaidExtension() || !hasMermaidThemeConfiguration(configuration)) {
-    return;
-  }
-
-  const [light, dark] = resolveMermaidThemes();
-  const operations = prepareMermaidThemeUpdates(configuration, states, { light, dark });
-  try {
-    await persistMermaidThemeStates(memento, states);
-  } catch (claimError) {
-    const rollbackFailures = await rollbackMermaidThemeClaims(memento, states, operations);
-    if (rollbackFailures.length > 0) {
-      throw new AggregateError(
-        [claimError, ...rollbackFailures],
-        `${getErrorMessage(claimError)}; failed to release Mermaid theme state claims`
-      );
-    }
-    throw claimError;
-  }
-  const updateResults = await Promise.allSettled(
-    operations.map((operation) =>
-      updateMermaidTheme(configuration, operation.key, operation.theme, operation.target)
-    )
-  );
-  updateResults.forEach((result, index) => {
-    const operation = operations[index];
-    if (result.status !== "fulfilled" || !operation) {
-      return;
-    }
-    operation.state.applied = operation.theme;
-    if (operation.target === vscode.ConfigurationTarget.Global) {
-      operation.state.owner = states.identity;
-    }
-    markMermaidThemeStateDirty(states, operation.target, operation.slot);
-  });
-  try {
-    await persistMermaidThemeStates(memento, states);
-  } catch (persistenceError) {
-    const rollbackFailures = await rollbackMermaidThemesAfterPersistenceFailure(
-      memento,
-      configuration,
-      states,
-      operations,
-      updateResults
-    );
-    if (rollbackFailures.length > 0) {
-      throw new AggregateError(
-        [persistenceError, ...rollbackFailures],
-        `${getErrorMessage(persistenceError)}; failed to roll back Mermaid themes after a state persistence failure`
-      );
-    }
-    throw persistenceError;
-  }
-
-  const failure = updateResults.find((result) => result.status === "rejected");
-  if (failure?.status === "rejected") {
-    const restoreFailures = await rollbackFailedMermaidThemeSync(
-      memento,
-      configuration,
-      states,
-      operations,
-      updateResults
-    );
-    if (restoreFailures.length > 0) {
-      throw new AggregateError(
-        [failure.reason, ...restoreFailures],
-        `${getErrorMessage(failure.reason)}; failed to restore the original Mermaid themes`
-      );
-    }
-    throw failure.reason;
-  }
+  return enqueue(() => updateNow(memento));
 }
 
 export function restoreMermaidThemeSync(
   memento: vscode.Memento,
-  configuration = getOriginMermaidThemeConfiguration()
+  configuration = getOriginConfiguration()
 ): Promise<void> {
-  return enqueueMermaidThemeOperation(() => restoreMermaidThemeSyncNow(memento, configuration));
+  return enqueue(() => restoreNow(memento, configuration));
 }
 
-async function restoreMermaidThemeSyncNow(
-  memento: vscode.Memento,
-  configuration: vscode.WorkspaceConfiguration,
-  loadedStates?: MermaidThemeStates
-): Promise<void> {
-  if (!hasMermaidThemeConfiguration(configuration)) {
+async function updateNow(memento: vscode.Memento): Promise<void> {
+  const configuration = getOriginConfiguration();
+  if (!getMermaidSyncTheme()) {
+    await restoreNow(memento, configuration);
     return;
   }
+  if (!hasMermaidExtension() || !hasConfiguration(configuration)) return;
 
-  const states = loadedStates ?? (await loadMermaidThemeStates(memento));
-  const restorations = collectMermaidThemeRestorations(configuration, states);
-  try {
-    await persistMermaidThemeStates(memento, states);
-  } catch (claimError) {
-    const rollbackFailures = await rollbackMermaidThemeClaims(memento, states, restorations);
-    if (rollbackFailures.length > 0) {
-      throw new AggregateError(
-        [claimError, ...rollbackFailures],
-        `${getErrorMessage(claimError)}; failed to release Mermaid theme restoration claims`
-      );
+  const identity = getWorkspaceIdentity();
+  await migrateSnapshot(memento, identity);
+  const [light, dark] = resolveThemes();
+  const desired = { light, dark };
+  const transactions: Transaction[] = [];
+  for (const [slot, key] of slots) {
+    const target = getEffectiveTarget(configuration, key);
+    if (target === vscode.ConfigurationTarget.Global) {
+      await discardWorkspaceState(memento, identity, slot);
     }
-    throw claimError;
-  }
-  const restoreResults = await Promise.allSettled(
-    restorations.map(({ key, shouldWrite, state, target }) => {
-      if (!shouldWrite) {
-        return Promise.resolve();
-      }
-      return updateMermaidTheme(configuration, key, state.original, target);
-    })
-  );
-  restoreResults.forEach((result, index) => {
-    const restoration = restorations[index];
-    if (result.status !== "fulfilled" || !restoration) {
-      return;
-    }
-    delete (
-      restoration.target === vscode.ConfigurationTarget.Global ? states.global : states.workspace
-    )[restoration.slot];
-    markMermaidThemeStateDirty(states, restoration.target, restoration.slot);
-  });
-  try {
-    await persistMermaidThemeStates(memento, states);
-  } catch (persistenceError) {
-    const rollbackFailures = await rollbackMermaidRestorationsAfterPersistenceFailure(
+    const context = loadContext(memento, identity, slot, key, target);
+    const transaction = await prepareApply(
       memento,
       configuration,
-      states,
-      restorations,
-      restoreResults
+      identity,
+      context,
+      desired[slot]
     );
-    if (rollbackFailures.length > 0) {
-      throw new AggregateError(
-        [persistenceError, ...rollbackFailures],
-        `${getErrorMessage(persistenceError)}; failed to roll back Mermaid theme restoration after a state persistence failure`
-      );
-    }
-    throw persistenceError;
+    if (transaction) transactions.push(transaction);
   }
-  const restoreFailures = restoreResults
+
+  const results = await executeTransactions(memento, configuration, transactions, (transaction) => {
+    const next = { ...transaction.state, applied: transaction.desiredValue as MermaidTheme };
+    delete next.pending;
+    return next;
+  });
+  const failure = results.find((result) => result.status === "rejected");
+  if (failure?.status !== "rejected") return;
+
+  try {
+    await restoreNow(memento, configuration);
+  } catch (restoreError) {
+    const restoreFailures =
+      restoreError instanceof AggregateError ? restoreError.errors : [restoreError];
+    throw new AggregateError(
+      [failure.reason, ...restoreFailures],
+      `${failure.reason instanceof Error ? failure.reason.message : String(failure.reason)}; failed to restore the original Mermaid themes`
+    );
+  }
+  throw failure.reason;
+}
+
+async function restoreNow(
+  memento: vscode.Memento,
+  configuration: vscode.WorkspaceConfiguration
+): Promise<void> {
+  if (!hasConfiguration(configuration)) return;
+  const identity = getWorkspaceIdentity();
+  await migrateSnapshot(memento, identity);
+  const transactions: Transaction[] = [];
+  for (const [slot, key] of slots) {
+    const target = getEffectiveTarget(configuration, key);
+    if (target === vscode.ConfigurationTarget.Global) {
+      await discardWorkspaceState(memento, identity, slot);
+    }
+    const context = loadContext(memento, identity, slot, key, target);
+    if (context.state) {
+      transactions.push(prepareRestore(configuration, { ...context, state: context.state }));
+    }
+  }
+  const results = await executeTransactions(memento, configuration, transactions, () => undefined);
+  const failures = results
     .filter((result): result is PromiseRejectedResult => result.status === "rejected")
     .map((result) => result.reason);
-  if (restoreFailures.length > 0) {
-    throw new AggregateError(restoreFailures, "Failed to restore the original Mermaid themes");
+  if (failures.length) {
+    throw new AggregateError(failures, "Failed to restore the original Mermaid themes");
   }
 }
 
-function enqueueMermaidThemeOperation(operation: () => Promise<void>): Promise<void> {
-  const queuedOperation = mermaidThemeOperationQueue.then(operation);
-  mermaidThemeOperationQueue = queuedOperation.catch(() => {});
-  return queuedOperation;
-}
-
-function resolveMermaidThemes(): readonly [MermaidTheme, MermaidTheme] {
-  const mode = getThemeMode();
-  if (mode === "vscode") {
-    return ["vscode", "vscode"];
+async function prepareApply(
+  memento: vscode.Memento,
+  configuration: vscode.WorkspaceConfiguration,
+  identity: string,
+  context: SlotContext,
+  desiredValue: MermaidTheme
+): Promise<Transaction | undefined> {
+  const previousValue = getThemeAtTarget(configuration, context.key, context.target);
+  let state = context.state ? { ...context.state } : undefined;
+  let reconciled = false;
+  if (state?.pending?.kind === "apply") {
+    reconciled = true;
+    if (previousValue === state.pending.desired) state.applied = state.pending.desired;
+    else if (previousValue !== state.pending.previous)
+      state = release(state, identity, previousValue);
+    if (state.pending?.kind === "apply") delete state.pending;
+  } else if (state?.pending?.kind === "restore") {
+    reconciled = true;
+    if (previousValue === state.pending.desired) state = undefined;
+    else if (previousValue === state.pending.previous) delete state.pending;
+    else state = release(state, identity, previousValue);
   }
-  if (mode === "single") {
-    const theme = resolveMermaidTheme(getSingleTheme());
-    return [theme, theme];
+  if (state?.releasedBy !== undefined) {
+    if (reconciled) await saveContext(memento, context, state);
+    return undefined;
+  }
+  if (state?.applied !== undefined && previousValue !== state.applied) {
+    await saveContext(memento, context, release(state, identity, previousValue));
+    return undefined;
   }
 
-  return [resolveMermaidTheme(getCurrentLightTheme()), resolveMermaidTheme(getCurrentDarkTheme())];
+  const previousState = state ? { ...state } : undefined;
+  state ??= {
+    version: 2,
+    target: context.target === vscode.ConfigurationTarget.Global ? "global" : "workspace",
+    original: previousValue
+  };
+  if (context.target === vscode.ConfigurationTarget.Workspace) state.workspaceIdentity = identity;
+  state.pending = { kind: "apply", desired: desiredValue, previous: previousValue };
+  return { ...context, state, previousState, previousValue, desiredValue, shouldWrite: true };
 }
 
-function resolveMermaidTheme(markdownTheme: Theme): MermaidTheme {
-  return isLightTheme(markdownTheme) ? MERMAID_LIGHT_THEME : MERMAID_DARK_THEME;
-}
-
-async function loadMermaidThemeStates(memento: vscode.Memento): Promise<MermaidThemeStates> {
-  const identity = getWorkspaceIdentity();
-  await migrateLegacyMermaidThemeSnapshot(memento, identity);
-  const global = {} as MermaidThemeStates["global"];
-  const workspace = {} as MermaidThemeStates["workspace"];
-  const globalRevisions = {} as MermaidThemeStates["globalRevisions"];
-  const workspaceRevisions = {} as MermaidThemeStates["workspaceRevisions"];
-  for (const slot of ["light", "dark"] as const) {
-    const globalState = memento.get<MermaidThemeSlotState>(getGlobalThemeStateKey(slot));
-    if (globalState?.version === 2 && globalState.target === "global") {
-      global[slot] = { ...globalState };
-      if (globalState.revision !== undefined) {
-        globalRevisions[slot] = globalState.revision;
-      }
-    }
-    const workspaceState = memento.get<MermaidThemeSlotState>(
-      getWorkspaceThemeStateKey(identity, slot)
-    );
-    if (
-      workspaceState?.version === 2 &&
-      workspaceState.target === "workspace" &&
-      workspaceState.workspaceIdentity === identity
-    ) {
-      workspace[slot] = { ...workspaceState };
-      if (workspaceState.revision !== undefined) {
-        workspaceRevisions[slot] = workspaceState.revision;
-      }
-    }
+function prepareRestore(
+  configuration: vscode.WorkspaceConfiguration,
+  context: SlotContext & { state: SlotState }
+): Transaction {
+  const previousValue = getThemeAtTarget(configuration, context.key, context.target);
+  const state = { ...context.state };
+  if (state.pending?.kind === "apply") {
+    if (previousValue === state.pending.desired) state.applied = state.pending.desired;
+    else if (previousValue !== state.pending.previous) delete state.applied;
+    delete state.pending;
+  }
+  const pendingRestore = state.pending?.kind === "restore" ? state.pending : undefined;
+  const shouldWrite = pendingRestore
+    ? previousValue === pendingRestore.previous
+    : state.applied !== undefined && previousValue === state.applied;
+  const previousState = { ...state };
+  if (shouldWrite) {
+    state.pending = { kind: "restore", desired: state.original, previous: previousValue };
   }
   return {
-    identity,
-    global,
-    workspace,
-    dirtyGlobal: new Set(),
-    dirtyWorkspace: new Set(),
-    globalRevisions,
-    workspaceRevisions
+    ...context,
+    state,
+    previousState,
+    previousValue,
+    desiredValue: state.original,
+    shouldWrite
   };
 }
 
-async function migrateLegacyMermaidThemeSnapshot(
+function release(state: SlotState, identity: string, value: MermaidTheme | undefined): SlotState {
+  const released = {
+    ...state,
+    releasedBy: identity,
+    releasedValue: value,
+    releasedValueCaptured: true as const
+  };
+  delete released.applied;
+  delete released.owner;
+  delete released.pending;
+  return released;
+}
+
+async function executeTransactions(
   memento: vscode.Memento,
-  currentIdentity: string
-): Promise<void> {
-  const snapshot = memento.get<LegacyMermaidThemeSnapshot>(snapshotKey);
-  if (!snapshot) {
-    return;
+  configuration: vscode.WorkspaceConfiguration,
+  transactions: Transaction[],
+  finalize: (transaction: Transaction) => SlotState | undefined
+): Promise<PromiseSettledResult<void>[]> {
+  const claimed: Transaction[] = [];
+  try {
+    for (const transaction of transactions) {
+      await saveContext(memento, transaction, transaction.state);
+      claimed.push(transaction);
+    }
+  } catch (claimError) {
+    const failures = await restoreStates(memento, claimed);
+    if (failures.length) throw new AggregateError([claimError, ...failures]);
+    throw claimError;
   }
 
+  const results = await writeSequentially(
+    configuration,
+    transactions.map(({ key, target, desiredValue, shouldWrite }) => ({
+      key,
+      target,
+      desiredValue,
+      shouldWrite
+    }))
+  );
+  try {
+    for (const [index, result] of results.entries()) {
+      const transaction = transactions[index];
+      if (result.status === "fulfilled" && transaction) {
+        await saveContext(memento, transaction, finalize(transaction));
+      }
+    }
+  } catch (persistenceError) {
+    const failures = await recoverTransactions(
+      memento,
+      configuration,
+      transactions,
+      results,
+      persistenceError
+    );
+    if (failures.length) throw new AggregateError([persistenceError, ...failures]);
+    throw persistenceError;
+  }
+  return results;
+}
+
+async function recoverTransactions(
+  memento: vscode.Memento,
+  configuration: vscode.WorkspaceConfiguration,
+  transactions: Transaction[],
+  results: PromiseSettledResult<void>[],
+  persistenceError: unknown
+): Promise<unknown[]> {
+  const conflict = persistenceError instanceof ConcurrentStateError ? persistenceError : undefined;
+  const updates = transactions.map((transaction, index): ConfigurationUpdate => {
+    const isConflict = conflict?.key === transaction.stateKey;
+    const winner = isConflict ? getWinnerValue(conflict.persistedState) : undefined;
+    const current = getThemeAtTarget(configuration, transaction.key, transaction.target);
+    return {
+      key: transaction.key,
+      target: transaction.target,
+      desiredValue: isConflict ? winner?.value : transaction.previousValue,
+      shouldWrite:
+        results[index]?.status === "fulfilled" &&
+        transaction.shouldWrite &&
+        current === transaction.desiredValue &&
+        (!isConflict || winner?.captured === true)
+    };
+  });
+  const recoveryResults = await writeSequentially(configuration, updates);
+  const failures = recoveryResults
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  for (const [index, result] of recoveryResults.entries()) {
+    const transaction = transactions[index];
+    if (result.status !== "fulfilled" || !transaction || conflict?.key === transaction.stateKey) {
+      continue;
+    }
+    try {
+      await saveContext(memento, transaction, transaction.previousState);
+    } catch (error) {
+      if (!(error instanceof ConcurrentStateError)) failures.push(error);
+    }
+  }
+  return failures;
+}
+
+async function restoreStates(
+  memento: vscode.Memento,
+  transactions: Transaction[]
+): Promise<unknown[]> {
+  const failures: unknown[] = [];
+  for (const transaction of transactions) {
+    try {
+      await saveContext(memento, transaction, transaction.previousState);
+    } catch (error) {
+      if (!(error instanceof ConcurrentStateError)) failures.push(error);
+    }
+  }
+  return failures;
+}
+
+async function writeSequentially(
+  configuration: vscode.WorkspaceConfiguration,
+  updates: ConfigurationUpdate[]
+): Promise<PromiseSettledResult<void>[]> {
+  const results: PromiseSettledResult<void>[] = [];
+  for (const update of updates) {
+    if (!update.shouldWrite) {
+      results.push({ status: "fulfilled", value: undefined });
+      continue;
+    }
+    try {
+      let settled = false;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        await configuration.update(update.key, update.desiredValue, update.target);
+        if (getThemeAtTarget(configuration, update.key, update.target) === update.desiredValue) {
+          settled = true;
+          break;
+        }
+      }
+      if (!settled) throw new Error(`Mermaid theme configuration did not settle for ${update.key}`);
+      results.push({ status: "fulfilled", value: undefined });
+    } catch (reason) {
+      results.push({ status: "rejected", reason });
+    }
+  }
+  return results;
+}
+
+function loadContext(
+  memento: vscode.Memento,
+  identity: string,
+  slot: Slot,
+  key: SlotKey,
+  target: Target
+): SlotContext {
+  const stateKey = getStateKey(identity, target, slot);
+  const persisted = memento.get<SlotState>(stateKey);
+  const valid =
+    persisted?.version === 2 &&
+    persisted.target === (target === vscode.ConfigurationTarget.Global ? "global" : "workspace") &&
+    (target === vscode.ConfigurationTarget.Global || persisted.workspaceIdentity === identity);
+  return {
+    key,
+    target,
+    stateKey,
+    revision: persisted?.revision,
+    state: valid ? { ...persisted } : undefined
+  };
+}
+
+async function saveContext(
+  memento: vscode.Memento,
+  context: SlotContext,
+  state: SlotState | undefined
+): Promise<void> {
+  const persisted = memento.get<SlotState>(context.stateKey);
+  if (persisted?.revision !== context.revision) {
+    throw new ConcurrentStateError(context.stateKey, persisted);
+  }
+  if (!state) {
+    await memento.update(context.stateKey, undefined);
+    context.revision = undefined;
+    context.state = undefined;
+    return;
+  }
+  const revision = `${Date.now()}:${++revisionCounter}`;
+  const next = { ...state, revision } satisfies SlotState;
+  await memento.update(context.stateKey, next);
+  context.revision = revision;
+  context.state = next;
+}
+
+async function discardWorkspaceState(
+  memento: vscode.Memento,
+  identity: string,
+  slot: Slot
+): Promise<void> {
+  const stateKey = getWorkspaceStateKey(identity, slot);
+  const persisted = memento.get<SlotState>(stateKey);
+  if (!persisted) return;
+  const context: SlotContext = {
+    key: slot === "light" ? originSection.light : originSection.dark,
+    target: vscode.ConfigurationTarget.Workspace,
+    stateKey,
+    revision: persisted.revision,
+    state: persisted
+  };
+  await saveContext(memento, context, undefined);
+}
+
+function getWinnerValue(
+  state: SlotState | undefined
+): { captured: boolean; value?: MermaidTheme | undefined } | undefined {
+  if (state?.applied !== undefined) return { captured: true, value: state.applied };
+  if (state?.releasedValueCaptured) return { captured: true, value: state.releasedValue };
+  return state ? { captured: false } : undefined;
+}
+
+async function migrateSnapshot(memento: vscode.Memento, currentIdentity: string): Promise<void> {
+  const snapshot = memento.get<LegacySnapshot>(snapshotKey);
+  if (!snapshot) return;
   for (const slot of ["light", "dark"] as const) {
     const target = snapshot.targets?.[slot] ?? vscode.ConfigurationTarget.Global;
     const identity = snapshot.workspaceIdentity;
-    if (target === vscode.ConfigurationTarget.Workspace && identity === undefined) {
-      continue;
-    }
-    const state: MermaidThemeSlotState = {
+    if (target === vscode.ConfigurationTarget.Workspace && !identity) continue;
+    const state: SlotState = {
       version: 2,
       target: target === vscode.ConfigurationTarget.Workspace ? "workspace" : "global",
       original: snapshot[slot]
     };
-    if (target === vscode.ConfigurationTarget.Workspace) {
-      state.workspaceIdentity = identity!;
-    } else if (snapshot.applied?.[slot] !== undefined) {
-      state.owner = identity ?? currentIdentity;
-    }
-    if (snapshot.applied?.[slot] !== undefined) {
-      state.applied = snapshot.applied[slot];
-    }
+    if (target === vscode.ConfigurationTarget.Workspace) state.workspaceIdentity = identity;
+    if (snapshot.applied?.[slot] !== undefined) state.applied = snapshot.applied[slot];
     if (snapshot.released?.[slot]) {
       state.releasedBy = identity ?? currentIdentity;
-      delete state.owner;
       delete state.applied;
     }
-    const key =
-      target === vscode.ConfigurationTarget.Workspace
-        ? getWorkspaceThemeStateKey(identity!, slot)
-        : getGlobalThemeStateKey(slot);
-    if (memento.get(key) === undefined) {
-      await memento.update(key, state);
-    }
+    const key = getStateKey(identity ?? currentIdentity, target, slot);
+    if (memento.get(key) === undefined) await memento.update(key, state);
   }
   await memento.update(snapshotKey, undefined);
 }
 
-function prepareMermaidThemeUpdates(
-  configuration: vscode.WorkspaceConfiguration,
-  states: MermaidThemeStates,
-  themes: Record<MermaidThemeSlot, MermaidTheme>
-): MermaidThemeUpdateOperation[] {
-  const operations: MermaidThemeUpdateOperation[] = [];
-  for (const [slot, key] of [
-    ["light", originSection.light],
-    ["dark", originSection.dark]
-  ] as const) {
-    const effective = getEffectiveMermaidThemeOverride(configuration, key);
-    const targetStates =
-      effective.target === vscode.ConfigurationTarget.Global ? states.global : states.workspace;
-    const dirtySlots =
-      effective.target === vscode.ConfigurationTarget.Global
-        ? states.dirtyGlobal
-        : states.dirtyWorkspace;
-    if (
-      effective.target === vscode.ConfigurationTarget.Global &&
-      states.workspace[slot] !== undefined
-    ) {
-      delete states.workspace[slot];
-      states.dirtyWorkspace.add(slot);
-    }
+function enqueue(operation: () => Promise<void>): Promise<void> {
+  const queued = operationQueue.then(operation);
+  operationQueue = queued.catch(() => {});
+  return queued;
+}
 
-    const existingState = targetStates[slot];
-    const previousState = existingState ? { ...existingState } : undefined;
-    const state =
-      existingState ??
-      ({
-        version: 2,
-        target: effective.target === vscode.ConfigurationTarget.Global ? "global" : "workspace",
-        original: effective.value
-      } satisfies MermaidThemeSlotState);
-    if (!existingState) {
-      if (effective.target === vscode.ConfigurationTarget.Global) {
-        state.owner = states.identity;
-      } else {
-        state.workspaceIdentity = states.identity;
-      }
-      targetStates[slot] = state;
-      dirtySlots.add(slot);
-    }
-
-    if (state.releasedBy !== undefined) {
-      continue;
-    }
-    if (
-      state.applied !== undefined &&
-      getMermaidThemeAtTarget(configuration, key, effective.target) !== state.applied
-    ) {
-      state.releasedBy = states.identity;
-      delete state.applied;
-      delete state.owner;
-      dirtySlots.add(slot);
-      continue;
-    }
-    if (effective.target === vscode.ConfigurationTarget.Global) {
-      state.owner = states.identity;
-      dirtySlots.add(slot);
-    }
-    operations.push({
-      slot,
-      key,
-      target: effective.target,
-      theme: themes[slot],
-      state,
-      previousState,
-      previousValue: getMermaidThemeAtTarget(configuration, key, effective.target)
-    });
+function resolveThemes(): readonly [MermaidTheme, MermaidTheme] {
+  const mode = getThemeMode();
+  if (mode === "vscode") return ["vscode", "vscode"];
+  if (mode === "single") {
+    const theme = resolveTheme(getSingleTheme());
+    return [theme, theme];
   }
-  return operations;
+  return [resolveTheme(getCurrentLightTheme()), resolveTheme(getCurrentDarkTheme())];
 }
 
-function collectMermaidThemeRestorations(
-  configuration: vscode.WorkspaceConfiguration,
-  states: MermaidThemeStates
-): MermaidThemeRestoration[] {
-  const restorations: MermaidThemeRestoration[] = [];
-  for (const [slot, key] of [
-    ["light", originSection.light],
-    ["dark", originSection.dark]
-  ] as const) {
-    const effective = getEffectiveMermaidThemeOverride(configuration, key);
-    if (effective.target === vscode.ConfigurationTarget.Workspace) {
-      const workspaceState = states.workspace[slot];
-      if (!workspaceState) {
-        continue;
-      }
-      const previousValue = getMermaidThemeAtTarget(
-        configuration,
-        key,
-        vscode.ConfigurationTarget.Workspace
-      );
-      const previousState = { ...workspaceState };
-      states.dirtyWorkspace.add(slot);
-      restorations.push({
-        slot,
-        key,
-        target: vscode.ConfigurationTarget.Workspace,
-        state: workspaceState,
-        previousState,
-        previousValue,
-        shouldWrite:
-          workspaceState.applied !== undefined && previousValue === workspaceState.applied
-      });
-      continue;
-    }
-
-    if (states.workspace[slot] !== undefined) {
-      delete states.workspace[slot];
-      states.dirtyWorkspace.add(slot);
-    }
-    const globalState = states.global[slot];
-    if (globalState) {
-      const previousValue = getMermaidThemeAtTarget(
-        configuration,
-        key,
-        vscode.ConfigurationTarget.Global
-      );
-      const previousState = { ...globalState };
-      globalState.owner = states.identity;
-      states.dirtyGlobal.add(slot);
-      restorations.push({
-        slot,
-        key,
-        target: vscode.ConfigurationTarget.Global,
-        state: globalState,
-        previousState,
-        previousValue,
-        shouldWrite: globalState.applied !== undefined && previousValue === globalState.applied
-      });
-    }
-  }
-  return restorations;
+function resolveTheme(theme: Theme): MermaidTheme {
+  return isLightTheme(theme) ? "default" : "dark";
 }
 
-async function rollbackMermaidThemeClaims(
-  memento: vscode.Memento,
-  states: MermaidThemeStates,
-  operations: MermaidThemeStateClaim[]
-): Promise<unknown[]> {
-  const failures: unknown[] = [];
-  for (const operation of operations) {
-    if (
-      operation.state.revision === undefined ||
-      operation.state.revision === operation.previousState?.revision
-    ) {
-      continue;
-    }
-    try {
-      await restorePreviousMermaidThemeState(memento, states, operation);
-    } catch (error) {
-      if (!(error instanceof ConcurrentMermaidThemeStateError)) {
-        failures.push(error);
-      }
-    }
-  }
-  return failures;
+function getWorkspaceIdentity(): string {
+  if (vscode.workspace.workspaceFile)
+    return `workspace:${vscode.workspace.workspaceFile.toString(true)}`;
+  const folders = vscode.workspace.workspaceFolders;
+  return folders?.length
+    ? `folders:${folders.map(({ uri }) => uri.toString(true)).join("\n")}`
+    : "empty-window";
 }
 
-async function rollbackMermaidThemesAfterPersistenceFailure(
-  memento: vscode.Memento,
-  configuration: vscode.WorkspaceConfiguration,
-  states: MermaidThemeStates,
-  operations: MermaidThemeUpdateOperation[],
-  updateResults: PromiseSettledResult<void>[]
-): Promise<unknown[]> {
-  const configurationRollbacks = operations.map((operation, index) => {
-    const updateResult = updateResults[index];
-    if (
-      updateResult?.status !== "fulfilled" ||
-      getMermaidThemeAtTarget(configuration, operation.key, operation.target) !== operation.theme
-    ) {
-      return Promise.resolve();
-    }
-    return updateMermaidTheme(
-      configuration,
-      operation.key,
-      operation.previousValue,
-      operation.target
-    );
-  });
-  const configurationResults = await Promise.allSettled(configurationRollbacks);
-  const failures = configurationResults
-    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
-    .map((result) => result.reason);
-
-  for (const [index, result] of configurationResults.entries()) {
-    const operation = operations[index];
-    if (result.status !== "fulfilled" || !operation || operation.state.revision === undefined) {
-      continue;
-    }
-    try {
-      await restorePreviousMermaidThemeState(memento, states, operation);
-    } catch (error) {
-      if (!(error instanceof ConcurrentMermaidThemeStateError)) {
-        failures.push(error);
-      }
-    }
-  }
-  return failures;
-}
-
-async function rollbackMermaidRestorationsAfterPersistenceFailure(
-  memento: vscode.Memento,
-  configuration: vscode.WorkspaceConfiguration,
-  states: MermaidThemeStates,
-  restorations: MermaidThemeRestoration[],
-  restoreResults: PromiseSettledResult<void>[]
-): Promise<unknown[]> {
-  const configurationRollbacks = restorations.map((restoration, index) => {
-    const restoreResult = restoreResults[index];
-    if (
-      restoreResult?.status !== "fulfilled" ||
-      !restoration.shouldWrite ||
-      getMermaidThemeAtTarget(configuration, restoration.key, restoration.target) !==
-        restoration.state.original
-    ) {
-      return Promise.resolve();
-    }
-    return updateMermaidTheme(
-      configuration,
-      restoration.key,
-      restoration.previousValue,
-      restoration.target
-    );
-  });
-  const configurationResults = await Promise.allSettled(configurationRollbacks);
-  const failures = configurationResults
-    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
-    .map((result) => result.reason);
-
-  for (const [index, result] of configurationResults.entries()) {
-    const restoration = restorations[index];
-    if (result.status !== "fulfilled" || !restoration) {
-      continue;
-    }
-    try {
-      await restorePreviousMermaidThemeState(memento, states, restoration);
-    } catch (error) {
-      if (!(error instanceof ConcurrentMermaidThemeStateError)) {
-        failures.push(error);
-      }
-    }
-  }
-  return failures;
-}
-
-async function restorePreviousMermaidThemeState(
-  memento: vscode.Memento,
-  states: MermaidThemeStates,
-  operation: MermaidThemeStateClaim
-): Promise<void> {
-  await persistMermaidThemeState(
-    memento,
-    getMermaidThemeStateKey(states.identity, operation.target, operation.slot),
-    operation.previousState ? { ...operation.previousState } : undefined,
-    getMermaidThemeStateRevision(states, operation.target, operation.slot),
-    states.identity
-  );
-}
-
-async function rollbackFailedMermaidThemeSync(
-  memento: vscode.Memento,
-  configuration: vscode.WorkspaceConfiguration,
-  states: MermaidThemeStates,
-  operations: MermaidThemeUpdateOperation[],
-  updateResults: PromiseSettledResult<void>[]
-): Promise<unknown[]> {
-  const rollbacks = operations.map((operation, index) => {
-    const result = updateResults[index];
-    const restoresPreviousOwner =
-      operation.target === vscode.ConfigurationTarget.Global &&
-      operation.previousState?.owner !== undefined &&
-      operation.previousState.owner !== states.identity;
-    const currentValue = getMermaidThemeAtTarget(configuration, operation.key, operation.target);
-    const rollback =
-      currentValue === operation.state.applied &&
-      ((restoresPreviousOwner && result?.status === "fulfilled") ||
-        (!restoresPreviousOwner && operation.state.applied !== undefined))
-        ? updateMermaidTheme(
-            configuration,
-            operation.key,
-            restoresPreviousOwner ? operation.previousValue : operation.state.original,
-            operation.target
-          )
-        : Promise.resolve();
-    return { operation, restoresPreviousOwner, rollback };
-  });
-  const rollbackResults = await Promise.allSettled(rollbacks.map(({ rollback }) => rollback));
-  rollbackResults.forEach((result, index) => {
-    const rollback = rollbacks[index];
-    if (result.status !== "fulfilled" || !rollback) {
-      return;
-    }
-    const { operation, restoresPreviousOwner } = rollback;
-    const targetStates =
-      operation.target === vscode.ConfigurationTarget.Global ? states.global : states.workspace;
-    if (restoresPreviousOwner && operation.previousState) {
-      targetStates[operation.slot] = operation.previousState;
-    } else {
-      delete targetStates[operation.slot];
-    }
-    markMermaidThemeStateDirty(states, operation.target, operation.slot);
-  });
-  await persistMermaidThemeStates(memento, states);
-  return rollbackResults
-    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
-    .map((result) => result.reason);
-}
-
-function markMermaidThemeStateDirty(
-  states: MermaidThemeStates,
-  target: MermaidThemeTarget,
-  slot: MermaidThemeSlot
-): void {
-  (target === vscode.ConfigurationTarget.Global ? states.dirtyGlobal : states.dirtyWorkspace).add(
-    slot
-  );
-}
-
-function getMermaidThemeStateRevision(
-  states: MermaidThemeStates,
-  target: MermaidThemeTarget,
-  slot: MermaidThemeSlot
-): string | undefined {
-  return (
-    target === vscode.ConfigurationTarget.Global
-      ? states.globalRevisions
-      : states.workspaceRevisions
-  )[slot];
-}
-
-async function persistMermaidThemeStates(
-  memento: vscode.Memento,
-  states: MermaidThemeStates
-): Promise<void> {
-  for (const slot of states.dirtyGlobal) {
-    const revision = await persistMermaidThemeState(
-      memento,
-      getGlobalThemeStateKey(slot),
-      states.global[slot],
-      states.globalRevisions[slot],
-      states.identity
-    );
-    if (revision === undefined) {
-      delete states.globalRevisions[slot];
-    } else {
-      states.globalRevisions[slot] = revision;
-    }
-    states.dirtyGlobal.delete(slot);
-  }
-  for (const slot of states.dirtyWorkspace) {
-    const revision = await persistMermaidThemeState(
-      memento,
-      getWorkspaceThemeStateKey(states.identity, slot),
-      states.workspace[slot],
-      states.workspaceRevisions[slot],
-      states.identity
-    );
-    if (revision === undefined) {
-      delete states.workspaceRevisions[slot];
-    } else {
-      states.workspaceRevisions[slot] = revision;
-    }
-    states.dirtyWorkspace.delete(slot);
-  }
-}
-
-async function persistMermaidThemeState(
-  memento: vscode.Memento,
-  key: string,
-  state: MermaidThemeSlotState | undefined,
-  expectedRevision: string | undefined,
-  identity: string
-): Promise<string | undefined> {
-  const persistedState = memento.get<MermaidThemeSlotState>(key);
-  if (persistedState?.revision !== expectedRevision) {
-    throw new ConcurrentMermaidThemeStateError(
-      "Mermaid theme state changed in another extension host"
-    );
-  }
-  if (!state) {
-    await memento.update(key, undefined);
-    return undefined;
-  }
-  const revision = `${identity}:${Date.now()}:${++mermaidThemeStateRevision}`;
-  await memento.update(key, { ...state, revision } satisfies MermaidThemeSlotState);
-  state.revision = revision;
-  return revision;
-}
-
-function getGlobalThemeStateKey(slot: MermaidThemeSlot): string {
-  return `${stateKeyPrefix}.global.${slot}`;
-}
-
-function getWorkspaceThemeStateKey(identity: string, slot: MermaidThemeSlot): string {
+function getWorkspaceStateKey(identity: string, slot: Slot): string {
   return `${stateKeyPrefix}.workspace.${encodeURIComponent(identity)}.${slot}`;
 }
 
-function getMermaidThemeStateKey(
-  identity: string,
-  target: MermaidThemeTarget,
-  slot: MermaidThemeSlot
-): string {
+function getStateKey(identity: string, target: Target, slot: Slot): string {
   return target === vscode.ConfigurationTarget.Global
-    ? getGlobalThemeStateKey(slot)
-    : getWorkspaceThemeStateKey(identity, slot);
+    ? `${stateKeyPrefix}.global.${slot}`
+    : getWorkspaceStateKey(identity, slot);
 }
 
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+function getOriginConfiguration(): vscode.WorkspaceConfiguration {
+  return vscode.workspace.getConfiguration(originSection.namespace);
+}
+
+function hasConfiguration(configuration: vscode.WorkspaceConfiguration): boolean {
+  return slots.every(([, key]) => configuration.inspect(key) !== undefined);
 }
 
 function hasMermaidExtension(): boolean {
   return mermaidExtensionIds.some((id) => vscode.extensions.getExtension(id) !== undefined);
 }
 
-function getOriginMermaidThemeConfiguration(): vscode.WorkspaceConfiguration {
-  return vscode.workspace.getConfiguration(originSection.namespace);
-}
-
-function getWorkspaceIdentity(): string {
-  if (vscode.workspace.workspaceFile) {
-    return `workspace:${vscode.workspace.workspaceFile.toString(true)}`;
-  }
-  const workspaceFolders = vscode.workspace.workspaceFolders;
-  if (workspaceFolders && workspaceFolders.length > 0) {
-    return `folders:${workspaceFolders.map(({ uri }) => uri.toString(true)).join("\n")}`;
-  }
-  return "empty-window";
-}
-
-function hasMermaidThemeConfiguration(configuration: vscode.WorkspaceConfiguration): boolean {
-  return (
-    configuration.inspect(originSection.light) !== undefined &&
-    configuration.inspect(originSection.dark) !== undefined
-  );
-}
-
-function getMermaidThemeAtTarget(
+function getThemeAtTarget(
   configuration: vscode.WorkspaceConfiguration,
-  key: typeof originSection.light | typeof originSection.dark,
-  target: MermaidThemeTarget
+  key: SlotKey,
+  target: Target
 ): MermaidTheme | undefined {
   const inspected = configuration.inspect<MermaidTheme>(key);
   return target === vscode.ConfigurationTarget.Workspace
@@ -822,28 +548,9 @@ function getMermaidThemeAtTarget(
     : inspected?.globalValue;
 }
 
-function getEffectiveMermaidThemeOverride(
-  configuration: vscode.WorkspaceConfiguration,
-  key: typeof originSection.light | typeof originSection.dark
-): { value: MermaidTheme | undefined; target: MermaidThemeTarget } {
+function getEffectiveTarget(configuration: vscode.WorkspaceConfiguration, key: SlotKey): Target {
   const inspected = configuration.inspect<MermaidTheme>(key);
-  if (inspected?.workspaceValue !== undefined) {
-    return {
-      value: inspected.workspaceValue,
-      target: vscode.ConfigurationTarget.Workspace
-    };
-  }
-  return {
-    value: inspected?.globalValue,
-    target: vscode.ConfigurationTarget.Global
-  };
-}
-
-async function updateMermaidTheme(
-  configuration: vscode.WorkspaceConfiguration,
-  key: typeof originSection.light | typeof originSection.dark,
-  theme: MermaidTheme | undefined,
-  target: MermaidThemeTarget = vscode.ConfigurationTarget.Global
-): Promise<void> {
-  await configuration.update(key, theme, target);
+  return inspected?.workspaceValue !== undefined
+    ? vscode.ConfigurationTarget.Workspace
+    : vscode.ConfigurationTarget.Global;
 }

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -203,6 +203,13 @@ async function preserveMermaidThemes(
     return rebaseMermaidThemesForWorkspace(memento, configuration, snapshot);
   }
 
+  return captureMermaidThemes(memento, configuration);
+}
+
+async function captureMermaidThemes(
+  memento: vscode.Memento,
+  configuration: vscode.WorkspaceConfiguration
+): Promise<MermaidThemeSnapshot> {
   const light = getEffectiveMermaidThemeOverride(configuration, originSection.light);
   const dark = getEffectiveMermaidThemeOverride(configuration, originSection.dark);
   const newSnapshot = {
@@ -226,38 +233,47 @@ async function rebaseMermaidThemesForWorkspace(
   const workspaceIdentity = getWorkspaceIdentity();
   if (
     snapshot.workspaceIdentity === workspaceIdentity ||
-    (snapshot.targets?.light !== vscode.ConfigurationTarget.Workspace &&
-      snapshot.targets?.dark !== vscode.ConfigurationTarget.Workspace)
+    (snapshot.workspaceIdentity === undefined && snapshot.targets === undefined)
   ) {
     return snapshot;
   }
 
-  const rebasedSnapshot: MermaidThemeSnapshot = {
-    ...snapshot,
-    workspaceIdentity,
-    applied: { ...snapshot.applied },
-    released: { ...snapshot.released }
+  const released = {
+    light: isGloballyReleased(snapshot, configuration, "light", originSection.light),
+    dark: isGloballyReleased(snapshot, configuration, "dark", originSection.dark)
   };
-  if (snapshot.targets?.light === vscode.ConfigurationTarget.Workspace) {
-    rebasedSnapshot.light = getMermaidThemeAtTarget(
-      configuration,
-      originSection.light,
-      vscode.ConfigurationTarget.Workspace
-    );
-    delete rebasedSnapshot.applied?.light;
-    delete rebasedSnapshot.released?.light;
-  }
-  if (snapshot.targets?.dark === vscode.ConfigurationTarget.Workspace) {
-    rebasedSnapshot.dark = getMermaidThemeAtTarget(
-      configuration,
-      originSection.dark,
-      vscode.ConfigurationTarget.Workspace
-    );
-    delete rebasedSnapshot.applied?.dark;
-    delete rebasedSnapshot.released?.dark;
-  }
+  await restoreMermaidThemeSyncNow(memento, configuration);
+  const currentSnapshot = await captureMermaidThemes(memento, configuration);
+  const rebasedSnapshot = {
+    ...currentSnapshot,
+    released: {
+      ...(currentSnapshot.targets?.light === vscode.ConfigurationTarget.Global && released.light
+        ? { light: true as const }
+        : {}),
+      ...(currentSnapshot.targets?.dark === vscode.ConfigurationTarget.Global && released.dark
+        ? { dark: true as const }
+        : {})
+    }
+  } satisfies MermaidThemeSnapshot;
   await memento.update(snapshotKey, rebasedSnapshot);
   return rebasedSnapshot;
+}
+
+function isGloballyReleased(
+  snapshot: MermaidThemeSnapshot,
+  configuration: vscode.WorkspaceConfiguration,
+  slot: "light" | "dark",
+  key: typeof originSection.light | typeof originSection.dark
+): boolean {
+  if (snapshot.targets?.[slot] !== vscode.ConfigurationTarget.Global) {
+    return false;
+  }
+  return (
+    snapshot.released?.[slot] === true ||
+    (snapshot.applied?.[slot] !== undefined &&
+      getMermaidThemeAtTarget(configuration, key, vscode.ConfigurationTarget.Global) !==
+        snapshot.applied[slot])
+  );
 }
 
 function hasMermaidExtension(): boolean {

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -145,13 +145,14 @@ async function restoreNow(
   await migrateSnapshot(memento, identity);
   const transactions: Transaction[] = [];
   for (const [slot, key] of slots) {
-    const target = getEffectiveTarget(configuration, key);
-    if (target === vscode.ConfigurationTarget.Global) {
-      await discardWorkspaceState(memento, identity, slot);
-    }
-    const context = loadContext(memento, identity, slot, key, target);
-    if (context.state) {
-      transactions.push(prepareRestore(configuration, { ...context, state: context.state }));
+    for (const target of [
+      vscode.ConfigurationTarget.Global,
+      vscode.ConfigurationTarget.Workspace
+    ] as const) {
+      const context = loadContext(memento, identity, slot, key, target);
+      if (context.state) {
+        transactions.push(prepareRestore(configuration, { ...context, state: context.state }));
+      }
     }
   }
   const results = await executeTransactions(memento, configuration, transactions, () => undefined);

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -23,9 +23,15 @@ export const themes = ["vscode", "base", "forest", "dark", "default", "neutral"]
 
 export type MermaidTheme = (typeof themes)[number];
 
+type MermaidThemeTarget = vscode.ConfigurationTarget.Global | vscode.ConfigurationTarget.Workspace;
+
 type MermaidThemeSnapshot = {
   light: MermaidTheme | undefined;
   dark: MermaidTheme | undefined;
+  targets?: {
+    light: MermaidThemeTarget;
+    dark: MermaidThemeTarget;
+  };
   applied?: {
     light?: MermaidTheme;
     dark?: MermaidTheme;
@@ -64,8 +70,18 @@ async function updateMermaidThemeSyncNow(memento: vscode.Memento): Promise<void>
   const snapshot = await preserveMermaidThemes(memento, configuration);
   const [light, dark] = resolveMermaidThemes();
   const [lightResult, darkResult] = await Promise.allSettled([
-    updateMermaidTheme(configuration, originSection.light, light),
-    updateMermaidTheme(configuration, originSection.dark, dark)
+    updateMermaidTheme(
+      configuration,
+      originSection.light,
+      light,
+      snapshot.targets?.light ?? vscode.ConfigurationTarget.Global
+    ),
+    updateMermaidTheme(
+      configuration,
+      originSection.dark,
+      dark,
+      snapshot.targets?.dark ?? vscode.ConfigurationTarget.Global
+    )
   ]);
   const applied = { ...snapshot.applied };
   if (lightResult.status === "fulfilled") {
@@ -114,17 +130,22 @@ async function restoreMermaidThemeSyncNow(
   }
 
   const updates: Promise<void>[] = [];
+  const lightTarget = snapshot.targets?.light ?? vscode.ConfigurationTarget.Global;
   if (
     snapshot.applied?.light !== undefined &&
-    getGlobalMermaidTheme(configuration, originSection.light) === snapshot.applied.light
+    getMermaidThemeAtTarget(configuration, originSection.light, lightTarget) ===
+      snapshot.applied.light
   ) {
-    updates.push(updateMermaidTheme(configuration, originSection.light, snapshot.light));
+    updates.push(
+      updateMermaidTheme(configuration, originSection.light, snapshot.light, lightTarget)
+    );
   }
+  const darkTarget = snapshot.targets?.dark ?? vscode.ConfigurationTarget.Global;
   if (
     snapshot.applied?.dark !== undefined &&
-    getGlobalMermaidTheme(configuration, originSection.dark) === snapshot.applied.dark
+    getMermaidThemeAtTarget(configuration, originSection.dark, darkTarget) === snapshot.applied.dark
   ) {
-    updates.push(updateMermaidTheme(configuration, originSection.dark, snapshot.dark));
+    updates.push(updateMermaidTheme(configuration, originSection.dark, snapshot.dark, darkTarget));
   }
 
   const restoreResults = await Promise.allSettled(updates);
@@ -169,9 +190,15 @@ async function preserveMermaidThemes(
     return snapshot;
   }
 
+  const light = getEffectiveMermaidThemeOverride(configuration, originSection.light);
+  const dark = getEffectiveMermaidThemeOverride(configuration, originSection.dark);
   const newSnapshot = {
-    light: getGlobalMermaidTheme(configuration, originSection.light),
-    dark: getGlobalMermaidTheme(configuration, originSection.dark)
+    light: light.value,
+    dark: dark.value,
+    targets: {
+      light: light.target,
+      dark: dark.target
+    }
   } satisfies MermaidThemeSnapshot;
   await memento.update(snapshotKey, newSnapshot);
   return newSnapshot;
@@ -192,17 +219,39 @@ function hasMermaidThemeConfiguration(configuration: vscode.WorkspaceConfigurati
   );
 }
 
-function getGlobalMermaidTheme(
+function getMermaidThemeAtTarget(
+  configuration: vscode.WorkspaceConfiguration,
+  key: typeof originSection.light | typeof originSection.dark,
+  target: MermaidThemeTarget
+): MermaidTheme | undefined {
+  const inspected = configuration.inspect<MermaidTheme>(key);
+  return target === vscode.ConfigurationTarget.Workspace
+    ? inspected?.workspaceValue
+    : inspected?.globalValue;
+}
+
+function getEffectiveMermaidThemeOverride(
   configuration: vscode.WorkspaceConfiguration,
   key: typeof originSection.light | typeof originSection.dark
-): MermaidTheme | undefined {
-  return configuration.inspect<MermaidTheme>(key)?.globalValue;
+): { value: MermaidTheme | undefined; target: MermaidThemeTarget } {
+  const inspected = configuration.inspect<MermaidTheme>(key);
+  if (inspected?.workspaceValue !== undefined) {
+    return {
+      value: inspected.workspaceValue,
+      target: vscode.ConfigurationTarget.Workspace
+    };
+  }
+  return {
+    value: inspected?.globalValue,
+    target: vscode.ConfigurationTarget.Global
+  };
 }
 
 async function updateMermaidTheme(
   configuration: vscode.WorkspaceConfiguration,
   key: typeof originSection.light | typeof originSection.dark,
-  theme: MermaidTheme | undefined
+  theme: MermaidTheme | undefined,
+  target: MermaidThemeTarget = vscode.ConfigurationTarget.Global
 ): Promise<void> {
-  await configuration.update(key, theme, vscode.ConfigurationTarget.Global);
+  await configuration.update(key, theme, target);
 }

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -28,6 +28,7 @@ type MermaidThemeTarget = vscode.ConfigurationTarget.Global | vscode.Configurati
 type MermaidThemeSnapshot = {
   light: MermaidTheme | undefined;
   dark: MermaidTheme | undefined;
+  workspaceIdentity?: string;
   targets?: {
     light: MermaidThemeTarget;
     dark: MermaidThemeTarget;
@@ -35,6 +36,10 @@ type MermaidThemeSnapshot = {
   applied?: {
     light?: MermaidTheme;
     dark?: MermaidTheme;
+  };
+  released?: {
+    light?: true;
+    dark?: true;
   };
 };
 
@@ -67,27 +72,18 @@ async function updateMermaidThemeSyncNow(memento: vscode.Memento): Promise<void>
     return;
   }
 
-  const snapshot = await preserveMermaidThemes(memento, configuration);
+  const preservedSnapshot = await preserveMermaidThemes(memento, configuration);
+  const snapshot = releaseUserModifiedMermaidThemes(preservedSnapshot, configuration);
   const [light, dark] = resolveMermaidThemes();
   const [lightResult, darkResult] = await Promise.allSettled([
-    updateMermaidTheme(
-      configuration,
-      originSection.light,
-      light,
-      snapshot.targets?.light ?? vscode.ConfigurationTarget.Global
-    ),
-    updateMermaidTheme(
-      configuration,
-      originSection.dark,
-      dark,
-      snapshot.targets?.dark ?? vscode.ConfigurationTarget.Global
-    )
+    updateOwnedMermaidTheme(configuration, snapshot, "light", originSection.light, light),
+    updateOwnedMermaidTheme(configuration, snapshot, "dark", originSection.dark, dark)
   ]);
   const applied = { ...snapshot.applied };
-  if (lightResult.status === "fulfilled") {
+  if (lightResult.status === "fulfilled" && lightResult.value) {
     applied.light = light;
   }
-  if (darkResult.status === "fulfilled") {
+  if (darkResult.status === "fulfilled" && darkResult.value) {
     applied.dark = dark;
   }
   await memento.update(snapshotKey, {
@@ -129,30 +125,47 @@ async function restoreMermaidThemeSyncNow(
     return;
   }
 
-  const updates: Promise<void>[] = [];
+  const updates: { slot: "light" | "dark"; promise: Promise<void> }[] = [];
+  const workspaceIdentityMatches =
+    snapshot.workspaceIdentity !== undefined &&
+    snapshot.workspaceIdentity === getWorkspaceIdentity();
   const lightTarget = snapshot.targets?.light ?? vscode.ConfigurationTarget.Global;
   if (
     snapshot.applied?.light !== undefined &&
+    (lightTarget === vscode.ConfigurationTarget.Global || workspaceIdentityMatches) &&
     getMermaidThemeAtTarget(configuration, originSection.light, lightTarget) ===
       snapshot.applied.light
   ) {
-    updates.push(
-      updateMermaidTheme(configuration, originSection.light, snapshot.light, lightTarget)
-    );
+    updates.push({
+      slot: "light",
+      promise: updateMermaidTheme(configuration, originSection.light, snapshot.light, lightTarget)
+    });
   }
   const darkTarget = snapshot.targets?.dark ?? vscode.ConfigurationTarget.Global;
   if (
     snapshot.applied?.dark !== undefined &&
+    (darkTarget === vscode.ConfigurationTarget.Global || workspaceIdentityMatches) &&
     getMermaidThemeAtTarget(configuration, originSection.dark, darkTarget) === snapshot.applied.dark
   ) {
-    updates.push(updateMermaidTheme(configuration, originSection.dark, snapshot.dark, darkTarget));
+    updates.push({
+      slot: "dark",
+      promise: updateMermaidTheme(configuration, originSection.dark, snapshot.dark, darkTarget)
+    });
   }
 
-  const restoreResults = await Promise.allSettled(updates);
+  const restoreResults = await Promise.allSettled(updates.map(({ promise }) => promise));
+  const applied = { ...snapshot.applied };
+  restoreResults.forEach((result, index) => {
+    const update = updates[index];
+    if (result.status === "fulfilled" && update) {
+      delete applied[update.slot];
+    }
+  });
   const restoreFailures = restoreResults
     .filter((result): result is PromiseRejectedResult => result.status === "rejected")
     .map((result) => result.reason);
   if (restoreFailures.length > 0) {
+    await memento.update(snapshotKey, { ...snapshot, applied } satisfies MermaidThemeSnapshot);
     throw new AggregateError(restoreFailures, "Failed to restore the original Mermaid themes");
   }
   await memento.update(snapshotKey, undefined);
@@ -187,7 +200,7 @@ async function preserveMermaidThemes(
 ): Promise<MermaidThemeSnapshot> {
   const snapshot = memento.get<MermaidThemeSnapshot>(snapshotKey);
   if (snapshot) {
-    return snapshot;
+    return rebaseMermaidThemesForWorkspace(memento, configuration, snapshot);
   }
 
   const light = getEffectiveMermaidThemeOverride(configuration, originSection.light);
@@ -195,6 +208,7 @@ async function preserveMermaidThemes(
   const newSnapshot = {
     light: light.value,
     dark: dark.value,
+    workspaceIdentity: getWorkspaceIdentity(),
     targets: {
       light: light.target,
       dark: dark.target
@@ -204,12 +218,65 @@ async function preserveMermaidThemes(
   return newSnapshot;
 }
 
+async function rebaseMermaidThemesForWorkspace(
+  memento: vscode.Memento,
+  configuration: vscode.WorkspaceConfiguration,
+  snapshot: MermaidThemeSnapshot
+): Promise<MermaidThemeSnapshot> {
+  const workspaceIdentity = getWorkspaceIdentity();
+  if (
+    snapshot.workspaceIdentity === workspaceIdentity ||
+    (snapshot.targets?.light !== vscode.ConfigurationTarget.Workspace &&
+      snapshot.targets?.dark !== vscode.ConfigurationTarget.Workspace)
+  ) {
+    return snapshot;
+  }
+
+  const rebasedSnapshot: MermaidThemeSnapshot = {
+    ...snapshot,
+    workspaceIdentity,
+    applied: { ...snapshot.applied },
+    released: { ...snapshot.released }
+  };
+  if (snapshot.targets?.light === vscode.ConfigurationTarget.Workspace) {
+    rebasedSnapshot.light = getMermaidThemeAtTarget(
+      configuration,
+      originSection.light,
+      vscode.ConfigurationTarget.Workspace
+    );
+    delete rebasedSnapshot.applied?.light;
+    delete rebasedSnapshot.released?.light;
+  }
+  if (snapshot.targets?.dark === vscode.ConfigurationTarget.Workspace) {
+    rebasedSnapshot.dark = getMermaidThemeAtTarget(
+      configuration,
+      originSection.dark,
+      vscode.ConfigurationTarget.Workspace
+    );
+    delete rebasedSnapshot.applied?.dark;
+    delete rebasedSnapshot.released?.dark;
+  }
+  await memento.update(snapshotKey, rebasedSnapshot);
+  return rebasedSnapshot;
+}
+
 function hasMermaidExtension(): boolean {
   return mermaidExtensionIds.some((id) => vscode.extensions.getExtension(id) !== undefined);
 }
 
 function getOriginMermaidThemeConfiguration(): vscode.WorkspaceConfiguration {
   return vscode.workspace.getConfiguration(originSection.namespace);
+}
+
+function getWorkspaceIdentity(): string {
+  if (vscode.workspace.workspaceFile) {
+    return `workspace:${vscode.workspace.workspaceFile.toString(true)}`;
+  }
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (workspaceFolders && workspaceFolders.length > 0) {
+    return `folders:${workspaceFolders.map(({ uri }) => uri.toString(true)).join("\n")}`;
+  }
+  return "empty-window";
 }
 
 function hasMermaidThemeConfiguration(configuration: vscode.WorkspaceConfiguration): boolean {
@@ -228,6 +295,48 @@ function getMermaidThemeAtTarget(
   return target === vscode.ConfigurationTarget.Workspace
     ? inspected?.workspaceValue
     : inspected?.globalValue;
+}
+
+function releaseUserModifiedMermaidThemes(
+  snapshot: MermaidThemeSnapshot,
+  configuration: vscode.WorkspaceConfiguration
+): MermaidThemeSnapshot {
+  const applied = { ...snapshot.applied };
+  const released = { ...snapshot.released };
+  for (const [slot, key] of [
+    ["light", originSection.light],
+    ["dark", originSection.dark]
+  ] as const) {
+    const target = snapshot.targets?.[slot] ?? vscode.ConfigurationTarget.Global;
+    if (
+      !released[slot] &&
+      applied[slot] !== undefined &&
+      getMermaidThemeAtTarget(configuration, key, target) !== applied[slot]
+    ) {
+      released[slot] = true;
+      delete applied[slot];
+    }
+  }
+  return { ...snapshot, applied, released };
+}
+
+async function updateOwnedMermaidTheme(
+  configuration: vscode.WorkspaceConfiguration,
+  snapshot: MermaidThemeSnapshot,
+  slot: "light" | "dark",
+  key: typeof originSection.light | typeof originSection.dark,
+  theme: MermaidTheme
+): Promise<boolean> {
+  if (snapshot.released?.[slot]) {
+    return false;
+  }
+  await updateMermaidTheme(
+    configuration,
+    key,
+    theme,
+    snapshot.targets?.[slot] ?? vscode.ConfigurationTarget.Global
+  );
+  return true;
 }
 
 function getEffectiveMermaidThemeOverride(

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -212,6 +212,53 @@ describe("Mermaid theme synchronization", () => {
     ]);
   });
 
+  it("allows another global-target workspace to restore a crashed owner's settings", async () => {
+    const memento = createTestMemento();
+    await updateMermaidThemeSync(memento);
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    markdownConfig["mermaid.syncTheme"] = false;
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "neutral", target: 1 },
+      { key: "darkModeTheme", value: "forest", target: 1 }
+    ]);
+  });
+
+  it("clears a global release so a later enable can capture and synchronize again", async () => {
+    const memento = createTestMemento();
+    await updateMermaidThemeSync(memento);
+    mermaidGlobalConfig["lightModeTheme"] = "base";
+    await updateMermaidThemeSync(memento);
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    markdownConfig["mermaid.syncTheme"] = false;
+    await updateMermaidThemeSync(memento);
+
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "forest"
+    });
+
+    markdownConfig["mermaid.syncTheme"] = true;
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "default", target: 1 },
+      { key: "darkModeTheme", value: "dark", target: 1 }
+    ]);
+
+    markdownConfig["mermaid.syncTheme"] = false;
+    await updateMermaidThemeSync(memento);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "forest"
+    });
+  });
+
   it("restores workspace Mermaid overrides when synchronization is disabled", async () => {
     const memento = createTestMemento();
     mermaidWorkspaceConfig = {
@@ -573,7 +620,7 @@ describe("Mermaid theme synchronization", () => {
     });
   });
 
-  it("does not overwrite a newer global lease from another extension host", async () => {
+  it("claims an existing global lease before writing configuration", async () => {
     const storedMemento = createTestMemento();
     const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
     await storedMemento.update(lightStateKey, {
@@ -606,7 +653,8 @@ describe("Mermaid theme synchronization", () => {
       },
       keys: () => storedMemento.keys()
     };
-    mermaidGlobalConfig["lightModeTheme"] = "base";
+    mermaidGlobalConfig["lightModeTheme"] = "default";
+    markdownConfig["theme.mode"] = "vscode";
 
     await expect(updateMermaidThemeSync(memento)).rejects.toThrow(
       "Mermaid theme state changed in another extension host"
@@ -614,6 +662,109 @@ describe("Mermaid theme synchronization", () => {
 
     expect(updateCalls).toEqual([]);
     expect(persistedKeys).not.toContain(lightStateKey);
+  });
+
+  it("rolls back configuration when a newer global lease wins after the write", async () => {
+    const storedMemento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    const darkStateKey = "githubMarkdown.mermaid.themeState.v2.global.dark";
+    await storedMemento.update(lightStateKey, {
+      version: 2,
+      revision: "workspace-a:1",
+      target: "global",
+      original: "neutral",
+      applied: "default",
+      owner: "workspace:file:///workspace-a.code-workspace"
+    });
+    await storedMemento.update(darkStateKey, {
+      version: 2,
+      revision: "workspace-a:2",
+      target: "global",
+      original: "forest",
+      releasedBy: "workspace:file:///workspace-a.code-workspace"
+    });
+    const concurrentLightState = {
+      version: 2 as const,
+      revision: "workspace-b:3",
+      target: "global" as const,
+      original: "neutral",
+      applied: "dark",
+      owner: "workspace:file:///workspace-b.code-workspace"
+    };
+    let concurrentWriteInjected = false;
+    let lightStateReads = 0;
+    const memento: typeof storedMemento = {
+      get: <T>(key: string, defaultValue?: T) => {
+        if (key === lightStateKey && ++lightStateReads === 3 && !concurrentWriteInjected) {
+          concurrentWriteInjected = true;
+          void storedMemento.update(lightStateKey, concurrentLightState);
+          return concurrentLightState as T;
+        }
+        return storedMemento.get(key, defaultValue);
+      },
+      update: (key: string, value: unknown) => storedMemento.update(key, value),
+      keys: () => storedMemento.keys()
+    };
+    mermaidGlobalConfig["lightModeTheme"] = "default";
+    markdownConfig["theme.mode"] = "vscode";
+
+    await expect(updateMermaidThemeSync(memento)).rejects.toThrow(
+      "Mermaid theme state changed in another extension host"
+    );
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "vscode", target: 1 },
+      { key: "lightModeTheme", value: "default", target: 1 }
+    ]);
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("default");
+    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
+  });
+
+  it("rolls back a restoration when a newer global lease wins after the write", async () => {
+    const storedMemento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    await storedMemento.update(lightStateKey, {
+      version: 2,
+      revision: "workspace-a:1",
+      target: "global",
+      original: "neutral",
+      applied: "default",
+      owner: "workspace:file:///workspace-a.code-workspace"
+    });
+    const concurrentLightState = {
+      version: 2 as const,
+      revision: "workspace-c:2",
+      target: "global" as const,
+      original: "base",
+      applied: "dark",
+      owner: "workspace:file:///workspace-c.code-workspace"
+    };
+    let concurrentWriteInjected = false;
+    let lightStateReads = 0;
+    const memento: typeof storedMemento = {
+      get: <T>(key: string, defaultValue?: T) => {
+        if (key === lightStateKey && ++lightStateReads === 3 && !concurrentWriteInjected) {
+          concurrentWriteInjected = true;
+          void storedMemento.update(lightStateKey, concurrentLightState);
+          return concurrentLightState as T;
+        }
+        return storedMemento.get(key, defaultValue);
+      },
+      update: (key: string, value: unknown) => storedMemento.update(key, value),
+      keys: () => storedMemento.keys()
+    };
+    mermaidGlobalConfig["lightModeTheme"] = "default";
+
+    await expect(restoreMermaidThemeSync(memento)).rejects.toThrow(
+      "Mermaid theme state changed in another extension host"
+    );
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "neutral", target: 1 },
+      { key: "lightModeTheme", value: "default", target: 1 }
+    ]);
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("default");
+    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
   });
 
   it.each([

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -456,8 +456,8 @@ describe("Mermaid theme synchronization", () => {
       darkModeTheme: "vscode"
     });
     expect(mermaidGlobalConfig).toEqual({
-      lightModeTheme: "default",
-      darkModeTheme: "dark"
+      lightModeTheme: "neutral",
+      darkModeTheme: "forest"
     });
 
     workspaceIdentity = "file:///workspace-a.code-workspace";
@@ -669,6 +669,37 @@ describe("Mermaid theme synchronization", () => {
     expect(mermaidGlobalConfig).toEqual({
       lightModeTheme: "neutral",
       darkModeTheme: "forest"
+    });
+  });
+
+  it("restores owned global and current workspace themes when synchronization stops after a target switch", async () => {
+    const memento = createTestMemento();
+    await updateMermaidThemeSync(memento);
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    };
+    await updateMermaidThemeSync(memento);
+
+    markdownConfig["mermaid.syncTheme"] = false;
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "neutral", target: 1 },
+      { key: "lightModeTheme", value: "base", target: 2 },
+      { key: "darkModeTheme", value: "forest", target: 1 },
+      { key: "darkModeTheme", value: "vscode", target: 2 }
+    ]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "forest"
+    });
+    expect(mermaidWorkspaceConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
     });
   });
 

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -258,6 +258,51 @@ describe("Mermaid theme synchronization", () => {
     });
   });
 
+  it("keeps independent workspace snapshots when returning to earlier workspaces", async () => {
+    const memento = createTestMemento();
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    };
+    await updateMermaidThemeSync(memento);
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "neutral",
+      darkModeTheme: "base"
+    };
+    await updateMermaidThemeSync(memento);
+
+    expect(
+      memento.keys().filter((key) => key.includes("mermaid.themeState.v2.workspace"))
+    ).toHaveLength(4);
+
+    workspaceIdentity = "file:///workspace-a.code-workspace";
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "default",
+      darkModeTheme: "dark"
+    };
+    markdownConfig["mermaid.syncTheme"] = false;
+    await updateMermaidThemeSync(memento);
+
+    expect(mermaidWorkspaceConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    });
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "default",
+      darkModeTheme: "dark"
+    };
+    await updateMermaidThemeSync(memento);
+
+    expect(mermaidWorkspaceConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "base"
+    });
+  });
+
   it("re-resolves the Mermaid targets after the extension host changes workspaces", async () => {
     const memento = createTestMemento();
     mermaidWorkspaceConfig = {
@@ -300,8 +345,6 @@ describe("Mermaid theme synchronization", () => {
     await updateMermaidThemeSync(memento);
 
     expect(updateCalls).toEqual([
-      { key: "lightModeTheme", value: "neutral", target: 1 },
-      { key: "darkModeTheme", value: "forest", target: 1 },
       { key: "lightModeTheme", value: "default", target: 2 },
       { key: "darkModeTheme", value: "dark", target: 2 }
     ]);
@@ -313,6 +356,15 @@ describe("Mermaid theme synchronization", () => {
       lightModeTheme: "base",
       darkModeTheme: "vscode"
     });
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "default",
+      darkModeTheme: "dark"
+    });
+
+    workspaceIdentity = "file:///workspace-a.code-workspace";
+    mermaidWorkspaceConfig = {};
+    await updateMermaidThemeSync(memento);
+
     expect(mermaidGlobalConfig).toEqual({
       lightModeTheme: "neutral",
       darkModeTheme: "forest"
@@ -343,6 +395,42 @@ describe("Mermaid theme synchronization", () => {
     });
   });
 
+  it("migrates a workspace snapshot without exposing it to another workspace", async () => {
+    const memento = createTestMemento();
+    await memento.update("githubMarkdown.mermaid.originalGlobalThemes", {
+      light: "base",
+      dark: "vscode",
+      workspaceIdentity: "workspace:file:///workspace-a.code-workspace",
+      targets: {
+        light: 2,
+        dark: 2
+      },
+      applied: {
+        light: "default",
+        dark: "dark"
+      }
+    });
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "default",
+      darkModeTheme: "dark"
+    };
+    markdownConfig["mermaid.syncTheme"] = false;
+    updateCalls.length = 0;
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([]);
+
+    workspaceIdentity = "file:///workspace-a.code-workspace";
+    await updateMermaidThemeSync(memento);
+
+    expect(mermaidWorkspaceConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    });
+  });
+
   it("stops synchronizing a Mermaid slot after the user changes that target", async () => {
     const memento = createTestMemento();
 
@@ -367,6 +455,32 @@ describe("Mermaid theme synchronization", () => {
     expect(mermaidGlobalConfig).toEqual({
       lightModeTheme: "base",
       darkModeTheme: "forest"
+    });
+  });
+
+  it("keeps a global user takeover across workspaces that use workspace overrides", async () => {
+    const memento = createTestMemento();
+
+    await updateMermaidThemeSync(memento);
+    mermaidGlobalConfig["lightModeTheme"] = "base";
+    await updateMermaidThemeSync(memento);
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "neutral",
+      darkModeTheme: "vscode"
+    };
+    await updateMermaidThemeSync(memento);
+
+    workspaceIdentity = "file:///workspace-c.code-workspace";
+    mermaidWorkspaceConfig = {};
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "darkModeTheme", value: "dark", target: 1 }]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "dark"
     });
   });
 
@@ -457,6 +571,49 @@ describe("Mermaid theme synchronization", () => {
       lightModeTheme: "neutral",
       darkModeTheme: "forest"
     });
+  });
+
+  it("does not overwrite a newer global lease from another extension host", async () => {
+    const storedMemento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    await storedMemento.update(lightStateKey, {
+      version: 2,
+      revision: "workspace-a:1",
+      target: "global",
+      original: "neutral",
+      applied: "default",
+      owner: "workspace:file:///workspace-a.code-workspace"
+    });
+    let lightStateReads = 0;
+    const persistedKeys: string[] = [];
+    const memento: typeof storedMemento = {
+      get: <T>(key: string, defaultValue?: T) => {
+        if (key === lightStateKey && ++lightStateReads > 1) {
+          return {
+            version: 2,
+            revision: "workspace-b:2",
+            target: "global",
+            original: "neutral",
+            applied: "dark",
+            owner: "workspace:file:///workspace-b.code-workspace"
+          } as T;
+        }
+        return storedMemento.get(key, defaultValue);
+      },
+      update: async (key: string, value: unknown) => {
+        persistedKeys.push(key);
+        await storedMemento.update(key, value);
+      },
+      keys: () => storedMemento.keys()
+    };
+    mermaidGlobalConfig["lightModeTheme"] = "base";
+
+    await expect(updateMermaidThemeSync(memento)).rejects.toThrow(
+      "Mermaid theme state changed in another extension host"
+    );
+
+    expect(updateCalls).toEqual([]);
+    expect(persistedKeys).not.toContain(lightStateKey);
   });
 
   it.each([

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -16,6 +16,7 @@ let mermaidGlobalConfig: Record<string, string | undefined> = {
 let mermaidWorkspaceConfig: Record<string, string | undefined> = {};
 let mermaidConfigurationRegistered = true;
 let mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features"]);
+let workspaceIdentity = "file:///workspace-a.code-workspace";
 
 const updateCalls: { key: string; value: string | undefined; target: number }[] = [];
 let updateFailures = new Set<string>();
@@ -38,6 +39,9 @@ vi.mock("vscode", () => ({
       getExtension: (id: string) => (mermaidExtensionIds.has(id) ? {} : undefined)
     },
     workspace: {
+      get workspaceFile() {
+        return { toString: () => workspaceIdentity };
+      },
       getConfiguration: (namespace?: string) => {
         if (namespace === "markdown-mermaid") {
           return {
@@ -94,6 +98,7 @@ describe("Mermaid theme synchronization", () => {
     mermaidWorkspaceConfig = {};
     mermaidConfigurationRegistered = true;
     mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features"]);
+    workspaceIdentity = "file:///workspace-a.code-workspace";
     updateFailures = new Set();
     updateGates = new Map();
     updateFailureCalls = new Set();
@@ -197,10 +202,6 @@ describe("Mermaid theme synchronization", () => {
     const memento = createTestMemento();
 
     await updateMermaidThemeSync(memento);
-    mermaidGlobalConfig["lightModeTheme"] = "base";
-    mermaidGlobalConfig["darkModeTheme"] = "vscode";
-    await updateMermaidThemeSync(memento);
-
     markdownConfig["mermaid.syncTheme"] = false;
     updateCalls.length = 0;
     await updateMermaidThemeSync(memento);
@@ -228,6 +229,107 @@ describe("Mermaid theme synchronization", () => {
     });
     expect(mermaidGlobalConfig).toEqual({
       lightModeTheme: "neutral",
+      darkModeTheme: "forest"
+    });
+  });
+
+  it("does not restore workspace overrides captured for another workspace", async () => {
+    const memento = createTestMemento();
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    };
+
+    await updateMermaidThemeSync(memento);
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "default",
+      darkModeTheme: "dark"
+    };
+    markdownConfig["mermaid.syncTheme"] = false;
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([]);
+    expect(mermaidWorkspaceConfig).toEqual({
+      lightModeTheme: "default",
+      darkModeTheme: "dark"
+    });
+  });
+
+  it("rebases workspace synchronization after the extension host changes workspaces", async () => {
+    const memento = createTestMemento();
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    };
+
+    await updateMermaidThemeSync(memento);
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "neutral",
+      darkModeTheme: "base"
+    };
+    await updateMermaidThemeSync(memento);
+
+    markdownConfig["mermaid.syncTheme"] = false;
+    await updateMermaidThemeSync(memento);
+
+    expect(mermaidWorkspaceConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "base"
+    });
+  });
+
+  it("restores global snapshots created before workspace targets were recorded", async () => {
+    const memento = createTestMemento();
+    await memento.update("githubMarkdown.mermaid.originalGlobalThemes", {
+      light: "neutral",
+      dark: "forest",
+      applied: {
+        light: "default",
+        dark: "dark"
+      }
+    });
+    mermaidGlobalConfig = {
+      lightModeTheme: "default",
+      darkModeTheme: "dark"
+    };
+    markdownConfig["mermaid.syncTheme"] = false;
+
+    await updateMermaidThemeSync(memento);
+
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "forest"
+    });
+  });
+
+  it("stops synchronizing a Mermaid slot after the user changes that target", async () => {
+    const memento = createTestMemento();
+
+    await updateMermaidThemeSync(memento);
+    mermaidGlobalConfig["lightModeTheme"] = "base";
+    markdownConfig["theme.mode"] = "vscode";
+    updateCalls.length = 0;
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "darkModeTheme", value: "vscode", target: 1 }]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    });
+
+    markdownConfig["mermaid.syncTheme"] = false;
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "darkModeTheme", value: "forest", target: 1 }]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "base",
       darkModeTheme: "forest"
     });
   });

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -1061,6 +1061,50 @@ describe("Mermaid theme synchronization", () => {
     expect(storedMemento.keys()).toEqual([]);
   });
 
+  it("keeps rollback intent when final state persistence and one configuration rollback fail", async () => {
+    const storedMemento = createTestMemento();
+    let updateCount = 0;
+    const memento: typeof storedMemento = {
+      get: <T>(key: string, defaultValue?: T) => storedMemento.get(key, defaultValue),
+      update: async (key: string, value: unknown) => {
+        if (++updateCount === 3) throw new Error("Failed to finalize Mermaid state");
+        await storedMemento.update(key, value);
+      },
+      keys: () => storedMemento.keys()
+    };
+    updateFailureCalls.add(4);
+
+    const error = await updateMermaidThemeSync(memento).catch((reason: unknown) => reason);
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([
+      expect.objectContaining({ message: "Failed to finalize Mermaid state" }),
+      expect.objectContaining({ message: "Failed to update darkModeTheme" })
+    ]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "dark"
+    });
+    expect(storedMemento.get("githubMarkdown.mermaid.themeState.v2.global.light")).toBeUndefined();
+    expect(storedMemento.get("githubMarkdown.mermaid.themeState.v2.global.dark")).toEqual(
+      expect.objectContaining({
+        pending: { kind: "apply", desired: "dark", previous: "forest" }
+      })
+    );
+
+    updateFailureCalls.clear();
+    updateCalls.length = 0;
+    markdownConfig["mermaid.syncTheme"] = false;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "darkModeTheme", value: "forest", target: 1 }]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "forest"
+    });
+    expect(storedMemento.keys()).toEqual([]);
+  });
+
   it.each([
     ["darkModeTheme", "lightModeTheme"],
     ["lightModeTheme", "darkModeTheme"]

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -33,25 +33,6 @@ function getEffectiveMermaidConfig(): Record<string, string | undefined> {
   };
 }
 
-function injectStateOnRead(
-  storedMemento: ReturnType<typeof createTestMemento>,
-  stateKey: string,
-  concurrentState: unknown
-): ReturnType<typeof createTestMemento> {
-  let reads = 0;
-  return {
-    get: <T>(key: string, defaultValue?: T) => {
-      if (key === stateKey && ++reads === 3) {
-        void storedMemento.update(stateKey, concurrentState);
-        return concurrentState as T;
-      }
-      return storedMemento.get(key, defaultValue);
-    },
-    update: (key: string, value: unknown) => storedMemento.update(key, value),
-    keys: () => storedMemento.keys()
-  };
-}
-
 vi.mock("vscode", () => ({
   default: {
     ConfigurationTarget: { Global: 1, Workspace: 2 },
@@ -981,8 +962,7 @@ describe("Mermaid theme synchronization", () => {
     expect(memento.get(lightStateKey)).toEqual(
       expect.objectContaining({
         original: "neutral",
-        releasedBy: "workspace:file:///workspace-a.code-workspace",
-        releasedValue: "neutral"
+        releasedBy: "workspace:file:///workspace-a.code-workspace"
       })
     );
     expect(memento.get(lightStateKey)).not.toHaveProperty("pending");
@@ -990,245 +970,95 @@ describe("Mermaid theme synchronization", () => {
     expect(memento.get(lightStateKey)).not.toHaveProperty("owner");
   });
 
-  it("claims an existing global lease before writing configuration", async () => {
-    const storedMemento = createTestMemento();
-    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
-    await storedMemento.update(lightStateKey, {
-      version: 2,
-      revision: "workspace-a:1",
-      target: "global",
-      original: "neutral",
-      applied: "default",
-      owner: "workspace:file:///workspace-a.code-workspace"
-    });
-    let lightStateReads = 0;
-    const persistedKeys: string[] = [];
-    const memento: typeof storedMemento = {
-      get: <T>(key: string, defaultValue?: T) => {
-        if (key === lightStateKey && ++lightStateReads > 1) {
-          return {
-            version: 2,
-            revision: "workspace-b:2",
-            target: "global",
-            original: "neutral",
-            applied: "dark",
-            owner: "workspace:file:///workspace-b.code-workspace"
-          } as T;
-        }
-        return storedMemento.get(key, defaultValue);
-      },
-      update: async (key: string, value: unknown) => {
-        persistedKeys.push(key);
-        await storedMemento.update(key, value);
-      },
-      keys: () => storedMemento.keys()
-    };
-    mermaidGlobalConfig["lightModeTheme"] = "default";
-    markdownConfig["theme.mode"] = "vscode";
-
-    await expect(updateMermaidThemeSync(memento)).rejects.toThrow(
-      "Mermaid theme state changed in another extension host"
-    );
-
-    expect(updateCalls).toEqual([]);
-    expect(persistedKeys).not.toContain(lightStateKey);
-  });
-
-  it("rolls back configuration when a newer global lease wins after the write", async () => {
+  it("does not roll back a completed single-host write when Memento reads lag an update", async () => {
     const storedMemento = createTestMemento();
     const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
     const darkStateKey = "githubMarkdown.mermaid.themeState.v2.global.dark";
     await storedMemento.update(lightStateKey, {
       version: 2,
-      revision: "workspace-a:1",
+      revision: "initial-light",
       target: "global",
-      original: "neutral",
-      applied: "default",
-      owner: "workspace:file:///workspace-a.code-workspace"
+      applied: "default"
     });
     await storedMemento.update(darkStateKey, {
       version: 2,
-      revision: "workspace-a:2",
+      revision: "initial-dark",
       target: "global",
-      original: "forest",
-      releasedBy: "workspace:file:///workspace-a.code-workspace"
+      applied: "default"
     });
-    const concurrentLightState = {
-      version: 2 as const,
-      revision: "workspace-b:3",
-      target: "global" as const,
-      original: "neutral",
-      applied: "dark",
-      owner: "workspace:file:///workspace-b.code-workspace"
+    const staleReads = new Map<string, unknown>();
+    const memento: typeof storedMemento = {
+      get: <T>(key: string, defaultValue?: T) => {
+        if (staleReads.has(key)) {
+          const stale = staleReads.get(key) as T;
+          staleReads.delete(key);
+          return stale;
+        }
+        return storedMemento.get(key, defaultValue);
+      },
+      update: async (key: string, value: unknown) => {
+        const previous = storedMemento.get(key);
+        await storedMemento.update(key, value);
+        if (key === lightStateKey || key === darkStateKey) staleReads.set(key, previous);
+      },
+      keys: () => storedMemento.keys()
     };
-    const memento = injectStateOnRead(storedMemento, lightStateKey, concurrentLightState);
-    mermaidGlobalConfig["lightModeTheme"] = "default";
-    markdownConfig["theme.mode"] = "vscode";
-
-    await expect(updateMermaidThemeSync(memento)).rejects.toThrow(
-      "Mermaid theme state changed in another extension host"
-    );
-
-    expect(updateCalls).toEqual([
-      { key: "lightModeTheme", value: "vscode", target: 1 },
-      { key: "lightModeTheme", value: "dark", target: 1 }
-    ]);
-    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("dark");
-    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
-
-    workspaceIdentity = "file:///workspace-b.code-workspace";
+    mermaidGlobalConfig = { lightModeTheme: "default", darkModeTheme: "default" };
     markdownConfig["theme.mode"] = "single";
     markdownConfig["theme.single"] = "dark_dimmed";
-    updateCalls.length = 0;
-    await updateMermaidThemeSync(memento);
 
-    expect(updateCalls).toEqual([{ key: "lightModeTheme", value: "dark", target: 1 }]);
-    expect(storedMemento.get(lightStateKey)).toEqual(expect.objectContaining({ applied: "dark" }));
-    expect(storedMemento.get(lightStateKey)).not.toHaveProperty("releasedBy");
-  });
-
-  it("rolls back a restoration when a newer global lease wins after the write", async () => {
-    const storedMemento = createTestMemento();
-    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
-    await storedMemento.update(lightStateKey, {
-      version: 2,
-      revision: "workspace-a:1",
-      target: "global",
-      original: "neutral",
-      applied: "default",
-      owner: "workspace:file:///workspace-a.code-workspace"
-    });
-    const concurrentLightState = {
-      version: 2 as const,
-      revision: "workspace-c:2",
-      target: "global" as const,
-      original: "base",
-      applied: "dark",
-      owner: "workspace:file:///workspace-c.code-workspace"
-    };
-    const memento = injectStateOnRead(storedMemento, lightStateKey, concurrentLightState);
-    mermaidGlobalConfig["lightModeTheme"] = "default";
-
-    await expect(restoreMermaidThemeSync(memento)).rejects.toThrow(
-      "Mermaid theme state changed in another extension host"
-    );
-
-    expect(updateCalls).toEqual([
-      { key: "lightModeTheme", value: "neutral", target: 1 },
-      { key: "lightModeTheme", value: "dark", target: 1 }
-    ]);
-    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("dark");
-    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
-
-    workspaceIdentity = "file:///workspace-c.code-workspace";
-    markdownConfig["theme.mode"] = "single";
-    markdownConfig["theme.single"] = "dark_dimmed";
-    updateCalls.length = 0;
-    await updateMermaidThemeSync(memento);
+    await expect(updateMermaidThemeSync(memento)).resolves.toBeUndefined();
 
     expect(updateCalls).toEqual([
       { key: "lightModeTheme", value: "dark", target: 1 },
       { key: "darkModeTheme", value: "dark", target: 1 }
     ]);
-    expect(storedMemento.get(lightStateKey)).toEqual(expect.objectContaining({ applied: "dark" }));
-    expect(storedMemento.get(lightStateKey)).not.toHaveProperty("releasedBy");
+    expect(mermaidGlobalConfig).toEqual({ lightModeTheme: "dark", darkModeTheme: "dark" });
+    expect(storedMemento.get(lightStateKey)).not.toHaveProperty("revision");
+    expect(storedMemento.get(darkStateKey)).not.toHaveProperty("revision");
   });
 
-  it("recovers the user's value when a released global lease wins after the write", async () => {
+  it("removes an earlier state claim when persisting the next claim fails", async () => {
     const storedMemento = createTestMemento();
-    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
-    await storedMemento.update(lightStateKey, {
-      version: 2,
-      revision: "workspace-a:1",
-      target: "global",
-      original: "neutral",
-      applied: "default",
-      owner: "workspace:file:///workspace-a.code-workspace"
-    });
-    await storedMemento.update("githubMarkdown.mermaid.themeState.v2.global.dark", {
-      version: 2,
-      revision: "workspace-a:2",
-      target: "global",
-      original: "forest",
-      releasedBy: "workspace:file:///workspace-a.code-workspace"
-    });
-    const concurrentLightState = {
-      version: 2 as const,
-      revision: "workspace-b:3",
-      target: "global" as const,
-      original: "neutral",
-      releasedBy: "workspace:file:///workspace-b.code-workspace",
-      releasedValue: "forest" as const,
-      releasedValueCaptured: true as const
+    let updateCount = 0;
+    const memento: typeof storedMemento = {
+      get: <T>(key: string, defaultValue?: T) => storedMemento.get(key, defaultValue),
+      update: async (key: string, value: unknown) => {
+        if (++updateCount === 2) throw new Error("Failed to persist Mermaid state");
+        await storedMemento.update(key, value);
+      },
+      keys: () => storedMemento.keys()
     };
-    const memento = injectStateOnRead(storedMemento, lightStateKey, concurrentLightState);
-    mermaidGlobalConfig["lightModeTheme"] = "default";
-    markdownConfig["theme.mode"] = "vscode";
 
     await expect(updateMermaidThemeSync(memento)).rejects.toThrow(
-      "Mermaid theme state changed in another extension host"
+      "Failed to persist Mermaid state"
     );
 
-    expect(updateCalls).toEqual([
-      { key: "lightModeTheme", value: "vscode", target: 1 },
-      { key: "lightModeTheme", value: "forest", target: 1 }
-    ]);
-    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("forest");
-    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
-
-    workspaceIdentity = "file:///workspace-b.code-workspace";
-    updateCalls.length = 0;
-    await updateMermaidThemeSync(memento);
-
     expect(updateCalls).toEqual([]);
-    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("forest");
-    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
+    expect(storedMemento.keys()).toEqual([]);
   });
 
-  it("preserves the current value when a winning released lease predates value capture", async () => {
+  it("rolls back configuration and state when final state persistence fails", async () => {
     const storedMemento = createTestMemento();
-    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
-    await storedMemento.update(lightStateKey, {
-      version: 2,
-      revision: "workspace-a:1",
-      target: "global",
-      original: "neutral",
-      applied: "default",
-      owner: "workspace:file:///workspace-a.code-workspace"
-    });
-    await storedMemento.update("githubMarkdown.mermaid.themeState.v2.global.dark", {
-      version: 2,
-      revision: "workspace-a:2",
-      target: "global",
-      original: "forest",
-      releasedBy: "workspace:file:///workspace-a.code-workspace"
-    });
-    const concurrentLightState = {
-      version: 2 as const,
-      revision: "workspace-b:3",
-      target: "global" as const,
-      original: "neutral",
-      releasedBy: "workspace:file:///workspace-b.code-workspace"
+    let updateCount = 0;
+    const memento: typeof storedMemento = {
+      get: <T>(key: string, defaultValue?: T) => storedMemento.get(key, defaultValue),
+      update: async (key: string, value: unknown) => {
+        if (++updateCount === 3) throw new Error("Failed to finalize Mermaid state");
+        await storedMemento.update(key, value);
+      },
+      keys: () => storedMemento.keys()
     };
-    const memento = injectStateOnRead(storedMemento, lightStateKey, concurrentLightState);
-    mermaidGlobalConfig["lightModeTheme"] = "default";
-    markdownConfig["theme.mode"] = "vscode";
 
     await expect(updateMermaidThemeSync(memento)).rejects.toThrow(
-      "Mermaid theme state changed in another extension host"
+      "Failed to finalize Mermaid state"
     );
 
-    expect(updateCalls).toEqual([{ key: "lightModeTheme", value: "vscode", target: 1 }]);
-    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("vscode");
-    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
-
-    workspaceIdentity = "file:///workspace-b.code-workspace";
-    updateCalls.length = 0;
-    await updateMermaidThemeSync(memento);
-
-    expect(updateCalls).toEqual([]);
-    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("vscode");
-    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "forest"
+    });
+    expect(storedMemento.keys()).toEqual([]);
   });
 
   it.each([

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -13,6 +13,7 @@ let mermaidGlobalConfig: Record<string, string | undefined> = {
   lightModeTheme: "neutral",
   darkModeTheme: "forest"
 };
+let mermaidWorkspaceConfig: Record<string, string | undefined> = {};
 let mermaidConfigurationRegistered = true;
 let mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features"]);
 
@@ -22,9 +23,17 @@ let updateGates = new Map<string, Promise<void>>();
 let updateFailureCalls = new Set<number>();
 let updateGateCalls = new Map<number, Promise<void>>();
 
+function getEffectiveMermaidConfig(): Record<string, string | undefined> {
+  return {
+    lightModeTheme:
+      mermaidWorkspaceConfig["lightModeTheme"] ?? mermaidGlobalConfig["lightModeTheme"],
+    darkModeTheme: mermaidWorkspaceConfig["darkModeTheme"] ?? mermaidGlobalConfig["darkModeTheme"]
+  };
+}
+
 vi.mock("vscode", () => ({
   default: {
-    ConfigurationTarget: { Global: 1 },
+    ConfigurationTarget: { Global: 1, Workspace: 2 },
     extensions: {
       getExtension: (id: string) => (mermaidExtensionIds.has(id) ? {} : undefined)
     },
@@ -34,7 +43,10 @@ vi.mock("vscode", () => ({
           return {
             inspect: (key: string) =>
               mermaidConfigurationRegistered
-                ? { globalValue: mermaidGlobalConfig[key] }
+                ? {
+                    globalValue: mermaidGlobalConfig[key],
+                    workspaceValue: mermaidWorkspaceConfig[key]
+                  }
                 : undefined,
             update: async (key: string, value: string | undefined, target: number) => {
               updateCalls.push({ key, value, target });
@@ -46,7 +58,11 @@ vi.mock("vscode", () => ({
               if (updateGate) {
                 await updateGate;
               }
-              mermaidGlobalConfig[key] = value;
+              if (target === 2) {
+                mermaidWorkspaceConfig[key] = value;
+              } else {
+                mermaidGlobalConfig[key] = value;
+              }
             }
           };
         }
@@ -75,6 +91,7 @@ describe("Mermaid theme synchronization", () => {
       lightModeTheme: "neutral",
       darkModeTheme: "forest"
     };
+    mermaidWorkspaceConfig = {};
     mermaidConfigurationRegistered = true;
     mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features"]);
     updateFailures = new Set();
@@ -94,6 +111,25 @@ describe("Mermaid theme synchronization", () => {
       { key: "lightModeTheme", value: "default", target: 1 },
       { key: "darkModeTheme", value: "dark", target: 1 }
     ]);
+  });
+
+  it("synchronizes workspace Mermaid overrides without changing global settings", async () => {
+    const memento = createTestMemento();
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    };
+
+    await updateMermaidThemeSync(memento);
+
+    expect(getEffectiveMermaidConfig()).toEqual({
+      lightModeTheme: "default",
+      darkModeTheme: "dark"
+    });
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "forest"
+    });
   });
 
   it("configures both Mermaid slots from the fixed theme in single mode", async () => {
@@ -175,6 +211,27 @@ describe("Mermaid theme synchronization", () => {
     ]);
   });
 
+  it("restores workspace Mermaid overrides when synchronization is disabled", async () => {
+    const memento = createTestMemento();
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    };
+
+    await updateMermaidThemeSync(memento);
+    markdownConfig["mermaid.syncTheme"] = false;
+    await updateMermaidThemeSync(memento);
+
+    expect(getEffectiveMermaidConfig()).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    });
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "forest"
+    });
+  });
+
   it("restores the original themes when disabling synchronization overlaps an update", async () => {
     const memento = createTestMemento();
     let releaseUpdate = () => {};
@@ -239,6 +296,27 @@ describe("Mermaid theme synchronization", () => {
     expect(updateCalls).toEqual([{ key: "darkModeTheme", value: "forest", target: 1 }]);
     expect(mermaidGlobalConfig).toEqual({
       lightModeTheme: "base",
+      darkModeTheme: "forest"
+    });
+  });
+
+  it("does not overwrite workspace Mermaid choices made while synchronization was active", async () => {
+    const memento = createTestMemento();
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    };
+
+    await updateMermaidThemeSync(memento);
+    mermaidWorkspaceConfig["lightModeTheme"] = "forest";
+    await restoreMermaidThemeSync(memento);
+
+    expect(getEffectiveMermaidConfig()).toEqual({
+      lightModeTheme: "forest",
+      darkModeTheme: "vscode"
+    });
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
       darkModeTheme: "forest"
     });
   });

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -23,12 +23,32 @@ let updateFailures = new Set<string>();
 let updateGates = new Map<string, Promise<void>>();
 let updateFailureCalls = new Set<number>();
 let updateGateCalls = new Map<number, Promise<void>>();
+let updateNoopCalls = new Set<number>();
 
 function getEffectiveMermaidConfig(): Record<string, string | undefined> {
   return {
     lightModeTheme:
       mermaidWorkspaceConfig["lightModeTheme"] ?? mermaidGlobalConfig["lightModeTheme"],
     darkModeTheme: mermaidWorkspaceConfig["darkModeTheme"] ?? mermaidGlobalConfig["darkModeTheme"]
+  };
+}
+
+function injectStateOnRead(
+  storedMemento: ReturnType<typeof createTestMemento>,
+  stateKey: string,
+  concurrentState: unknown
+): ReturnType<typeof createTestMemento> {
+  let reads = 0;
+  return {
+    get: <T>(key: string, defaultValue?: T) => {
+      if (key === stateKey && ++reads === 3) {
+        void storedMemento.update(stateKey, concurrentState);
+        return concurrentState as T;
+      }
+      return storedMemento.get(key, defaultValue);
+    },
+    update: (key: string, value: unknown) => storedMemento.update(key, value),
+    keys: () => storedMemento.keys()
   };
 }
 
@@ -61,6 +81,9 @@ vi.mock("vscode", () => ({
               const updateGate = updateGateCalls.get(callNumber) ?? updateGates.get(key);
               if (updateGate) {
                 await updateGate;
+              }
+              if (updateNoopCalls.has(callNumber)) {
+                return;
               }
               if (target === 2) {
                 mermaidWorkspaceConfig[key] = value;
@@ -103,6 +126,7 @@ describe("Mermaid theme synchronization", () => {
     updateGates = new Map();
     updateFailureCalls = new Set();
     updateGateCalls = new Map();
+    updateNoopCalls = new Set();
   });
 
   it("configures both Mermaid slots from the system-mode light and dark themes", async () => {
@@ -150,6 +174,53 @@ describe("Mermaid theme synchronization", () => {
     ]);
   });
 
+  it("retries a fulfilled configuration write that did not reach its target", async () => {
+    const memento = createTestMemento();
+    updateNoopCalls.add(2);
+    markdownConfig["theme.mode"] = "single";
+    markdownConfig["theme.single"] = "dark_dimmed";
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "dark", target: 1 },
+      { key: "darkModeTheme", value: "dark", target: 1 },
+      { key: "darkModeTheme", value: "dark", target: 1 }
+    ]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "dark",
+      darkModeTheme: "dark"
+    });
+    expect(memento.get("githubMarkdown.mermaid.themeState.v2.global.dark")).toEqual(
+      expect.objectContaining({ applied: "dark" })
+    );
+  });
+
+  it("waits for the first configuration write to settle before starting the second", async () => {
+    const memento = createTestMemento();
+    let releaseFirstUpdate = () => {};
+    updateGates.set(
+      "lightModeTheme",
+      new Promise<void>((resolve) => {
+        releaseFirstUpdate = resolve;
+      })
+    );
+
+    const synchronization = updateMermaidThemeSync(memento);
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(1));
+    const callsBeforeFirstSettled = [...updateCalls];
+    releaseFirstUpdate();
+    await synchronization;
+
+    expect(callsBeforeFirstSettled).toEqual([
+      { key: "lightModeTheme", value: "default", target: 1 }
+    ]);
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "default", target: 1 },
+      { key: "darkModeTheme", value: "dark", target: 1 }
+    ]);
+  });
+
   it("uses the Mermaid VS Code theme for both slots in VS Code mode", async () => {
     const memento = createTestMemento();
     markdownConfig["theme.mode"] = "vscode";
@@ -172,7 +243,7 @@ describe("Mermaid theme synchronization", () => {
     updateGates.set("darkModeTheme", firstUpdateGate);
 
     const firstUpdate = updateMermaidThemeSync(memento);
-    await vi.waitFor(() => expect(updateCalls).toHaveLength(2));
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(1));
 
     markdownConfig["theme.mode"] = "vscode";
     updateGates.clear();
@@ -541,7 +612,7 @@ describe("Mermaid theme synchronization", () => {
     updateGates.set("darkModeTheme", updateGate);
 
     const update = updateMermaidThemeSync(memento);
-    await vi.waitFor(() => expect(updateCalls).toHaveLength(2));
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(1));
 
     markdownConfig["mermaid.syncTheme"] = false;
     const restore = updateMermaidThemeSync(memento);
@@ -567,7 +638,7 @@ describe("Mermaid theme synchronization", () => {
     updateGates.set("darkModeTheme", updateGate);
 
     const update = updateMermaidThemeSync(memento);
-    await vi.waitFor(() => expect(updateCalls).toHaveLength(2));
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(1));
 
     const restore = restoreMermaidThemeSync(memento);
     await Promise.resolve();
@@ -618,6 +689,305 @@ describe("Mermaid theme synchronization", () => {
       lightModeTheme: "neutral",
       darkModeTheme: "forest"
     });
+  });
+
+  it("resumes synchronization after restoration wrote configuration before state cleanup", async () => {
+    const memento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    await memento.update(lightStateKey, {
+      version: 2,
+      revision: "workspace-a:1",
+      target: "global",
+      original: "neutral",
+      applied: "dark",
+      owner: "workspace:file:///workspace-a.code-workspace",
+      pending: {
+        kind: "restore",
+        desired: "neutral",
+        previous: "dark"
+      }
+    });
+    await memento.update("githubMarkdown.mermaid.themeState.v2.global.dark", {
+      version: 2,
+      revision: "workspace-a:2",
+      target: "global",
+      original: "forest",
+      releasedBy: "workspace:file:///workspace-a.code-workspace"
+    });
+    mermaidGlobalConfig["lightModeTheme"] = "neutral";
+    markdownConfig["theme.mode"] = "single";
+    markdownConfig["theme.single"] = "dark_dimmed";
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "lightModeTheme", value: "dark", target: 1 }]);
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("dark");
+    expect(memento.get(lightStateKey)).toEqual(
+      expect.objectContaining({
+        original: "neutral",
+        applied: "dark"
+      })
+    );
+    expect(memento.get(lightStateKey)).not.toHaveProperty("pending");
+    expect(memento.get(lightStateKey)).not.toHaveProperty("releasedBy");
+  });
+
+  it("resumes synchronization after restoration was claimed before its configuration write", async () => {
+    const memento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    await memento.update(lightStateKey, {
+      version: 2,
+      revision: "workspace-a:1",
+      target: "global",
+      original: "neutral",
+      applied: "dark",
+      owner: "workspace:file:///workspace-a.code-workspace",
+      pending: {
+        kind: "restore",
+        desired: "neutral",
+        previous: "dark"
+      }
+    });
+    await memento.update("githubMarkdown.mermaid.themeState.v2.global.dark", {
+      version: 2,
+      revision: "workspace-a:2",
+      target: "global",
+      original: "forest",
+      releasedBy: "workspace:file:///workspace-a.code-workspace"
+    });
+    mermaidGlobalConfig["lightModeTheme"] = "dark";
+    markdownConfig["theme.mode"] = "single";
+    markdownConfig["theme.single"] = "dark_dimmed";
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "lightModeTheme", value: "dark", target: 1 }]);
+    expect(memento.get(lightStateKey)).toEqual(
+      expect.objectContaining({
+        original: "neutral",
+        applied: "dark",
+        owner: "workspace:file:///workspace-a.code-workspace"
+      })
+    );
+    expect(memento.get(lightStateKey)).not.toHaveProperty("pending");
+    expect(memento.get(lightStateKey)).not.toHaveProperty("releasedBy");
+  });
+
+  it("persists restoration intent before writing configuration", async () => {
+    const memento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    await updateMermaidThemeSync(memento);
+    updateCalls.length = 0;
+    let releaseUpdates = () => {};
+    const updateGate = new Promise<void>((resolve) => {
+      releaseUpdates = resolve;
+    });
+    updateGates.set("lightModeTheme", updateGate);
+    updateGates.set("darkModeTheme", updateGate);
+
+    const restoration = restoreMermaidThemeSync(memento);
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(1));
+    const persistedBeforeWrite = memento.get(lightStateKey);
+    releaseUpdates();
+    await restoration;
+
+    expect(persistedBeforeWrite).toEqual(
+      expect.objectContaining({
+        applied: "default",
+        pending: {
+          kind: "restore",
+          desired: "neutral",
+          previous: "default"
+        }
+      })
+    );
+  });
+
+  it("retries synchronization after an apply was claimed before its configuration write", async () => {
+    const memento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    await memento.update(lightStateKey, {
+      version: 2,
+      revision: "workspace-a:1",
+      target: "global",
+      original: "neutral",
+      applied: "default",
+      owner: "workspace:file:///workspace-a.code-workspace",
+      pending: {
+        kind: "apply",
+        desired: "dark",
+        previous: "default"
+      }
+    });
+    await memento.update("githubMarkdown.mermaid.themeState.v2.global.dark", {
+      version: 2,
+      revision: "workspace-a:2",
+      target: "global",
+      original: "forest",
+      releasedBy: "workspace:file:///workspace-a.code-workspace"
+    });
+    mermaidGlobalConfig["lightModeTheme"] = "default";
+    markdownConfig["theme.mode"] = "single";
+    markdownConfig["theme.single"] = "dark_dimmed";
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "lightModeTheme", value: "dark", target: 1 }]);
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("dark");
+    expect(memento.get(lightStateKey)).toEqual(
+      expect.objectContaining({
+        original: "neutral",
+        applied: "dark",
+        owner: "workspace:file:///workspace-a.code-workspace"
+      })
+    );
+    expect(memento.get(lightStateKey)).not.toHaveProperty("pending");
+    expect(memento.get(lightStateKey)).not.toHaveProperty("releasedBy");
+  });
+
+  it("persists apply intent before writing configuration", async () => {
+    const memento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    let releaseUpdates = () => {};
+    const updateGate = new Promise<void>((resolve) => {
+      releaseUpdates = resolve;
+    });
+    updateGates.set("lightModeTheme", updateGate);
+    updateGates.set("darkModeTheme", updateGate);
+
+    const synchronization = updateMermaidThemeSync(memento);
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(1));
+    const persistedBeforeWrite = memento.get(lightStateKey);
+    releaseUpdates();
+    await synchronization;
+
+    expect(persistedBeforeWrite).toEqual(
+      expect.objectContaining({
+        original: "neutral",
+        pending: {
+          kind: "apply",
+          desired: "default",
+          previous: "neutral"
+        }
+      })
+    );
+  });
+
+  it("finalizes synchronization after an apply wrote configuration before state cleanup", async () => {
+    const memento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    await memento.update(lightStateKey, {
+      version: 2,
+      revision: "workspace-a:1",
+      target: "global",
+      original: "neutral",
+      applied: "default",
+      owner: "workspace:file:///workspace-a.code-workspace",
+      pending: {
+        kind: "apply",
+        desired: "dark",
+        previous: "default"
+      }
+    });
+    await memento.update("githubMarkdown.mermaid.themeState.v2.global.dark", {
+      version: 2,
+      revision: "workspace-a:2",
+      target: "global",
+      original: "forest",
+      releasedBy: "workspace:file:///workspace-a.code-workspace"
+    });
+    mermaidGlobalConfig["lightModeTheme"] = "dark";
+    markdownConfig["theme.mode"] = "single";
+    markdownConfig["theme.single"] = "dark_dimmed";
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "lightModeTheme", value: "dark", target: 1 }]);
+    expect(memento.get(lightStateKey)).toEqual(
+      expect.objectContaining({
+        original: "neutral",
+        applied: "dark",
+        owner: "workspace:file:///workspace-a.code-workspace"
+      })
+    );
+    expect(memento.get(lightStateKey)).not.toHaveProperty("pending");
+    expect(memento.get(lightStateKey)).not.toHaveProperty("releasedBy");
+  });
+
+  it("restores an apply that wrote configuration before synchronization was disabled", async () => {
+    const memento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    await memento.update(lightStateKey, {
+      version: 2,
+      revision: "workspace-a:1",
+      target: "global",
+      original: "neutral",
+      applied: "default",
+      owner: "workspace:file:///workspace-a.code-workspace",
+      pending: {
+        kind: "apply",
+        desired: "dark",
+        previous: "default"
+      }
+    });
+    await memento.update("githubMarkdown.mermaid.themeState.v2.global.dark", {
+      version: 2,
+      revision: "workspace-a:2",
+      target: "global",
+      original: "forest",
+      releasedBy: "workspace:file:///workspace-a.code-workspace"
+    });
+    mermaidGlobalConfig["lightModeTheme"] = "dark";
+    markdownConfig["mermaid.syncTheme"] = false;
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "lightModeTheme", value: "neutral", target: 1 }]);
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("neutral");
+    expect(memento.get(lightStateKey)).toBeUndefined();
+  });
+
+  it("releases a pending apply when the user changes configuration back to its original value", async () => {
+    const memento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    await memento.update(lightStateKey, {
+      version: 2,
+      revision: "workspace-a:1",
+      target: "global",
+      original: "neutral",
+      applied: "default",
+      owner: "workspace:file:///workspace-a.code-workspace",
+      pending: {
+        kind: "apply",
+        desired: "dark",
+        previous: "default"
+      }
+    });
+    await memento.update("githubMarkdown.mermaid.themeState.v2.global.dark", {
+      version: 2,
+      revision: "workspace-a:2",
+      target: "global",
+      original: "forest",
+      releasedBy: "workspace:file:///workspace-a.code-workspace"
+    });
+    mermaidGlobalConfig["lightModeTheme"] = "neutral";
+    markdownConfig["theme.mode"] = "single";
+    markdownConfig["theme.single"] = "dark_dimmed";
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([]);
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("neutral");
+    expect(memento.get(lightStateKey)).toEqual(
+      expect.objectContaining({
+        original: "neutral",
+        releasedBy: "workspace:file:///workspace-a.code-workspace",
+        releasedValue: "neutral"
+      })
+    );
+    expect(memento.get(lightStateKey)).not.toHaveProperty("pending");
+    expect(memento.get(lightStateKey)).not.toHaveProperty("applied");
+    expect(memento.get(lightStateKey)).not.toHaveProperty("owner");
   });
 
   it("claims an existing global lease before writing configuration", async () => {
@@ -691,20 +1061,7 @@ describe("Mermaid theme synchronization", () => {
       applied: "dark",
       owner: "workspace:file:///workspace-b.code-workspace"
     };
-    let concurrentWriteInjected = false;
-    let lightStateReads = 0;
-    const memento: typeof storedMemento = {
-      get: <T>(key: string, defaultValue?: T) => {
-        if (key === lightStateKey && ++lightStateReads === 3 && !concurrentWriteInjected) {
-          concurrentWriteInjected = true;
-          void storedMemento.update(lightStateKey, concurrentLightState);
-          return concurrentLightState as T;
-        }
-        return storedMemento.get(key, defaultValue);
-      },
-      update: (key: string, value: unknown) => storedMemento.update(key, value),
-      keys: () => storedMemento.keys()
-    };
+    const memento = injectStateOnRead(storedMemento, lightStateKey, concurrentLightState);
     mermaidGlobalConfig["lightModeTheme"] = "default";
     markdownConfig["theme.mode"] = "vscode";
 
@@ -714,10 +1071,20 @@ describe("Mermaid theme synchronization", () => {
 
     expect(updateCalls).toEqual([
       { key: "lightModeTheme", value: "vscode", target: 1 },
-      { key: "lightModeTheme", value: "default", target: 1 }
+      { key: "lightModeTheme", value: "dark", target: 1 }
     ]);
-    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("default");
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("dark");
     expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    markdownConfig["theme.mode"] = "single";
+    markdownConfig["theme.single"] = "dark_dimmed";
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "lightModeTheme", value: "dark", target: 1 }]);
+    expect(storedMemento.get(lightStateKey)).toEqual(expect.objectContaining({ applied: "dark" }));
+    expect(storedMemento.get(lightStateKey)).not.toHaveProperty("releasedBy");
   });
 
   it("rolls back a restoration when a newer global lease wins after the write", async () => {
@@ -739,20 +1106,7 @@ describe("Mermaid theme synchronization", () => {
       applied: "dark",
       owner: "workspace:file:///workspace-c.code-workspace"
     };
-    let concurrentWriteInjected = false;
-    let lightStateReads = 0;
-    const memento: typeof storedMemento = {
-      get: <T>(key: string, defaultValue?: T) => {
-        if (key === lightStateKey && ++lightStateReads === 3 && !concurrentWriteInjected) {
-          concurrentWriteInjected = true;
-          void storedMemento.update(lightStateKey, concurrentLightState);
-          return concurrentLightState as T;
-        }
-        return storedMemento.get(key, defaultValue);
-      },
-      update: (key: string, value: unknown) => storedMemento.update(key, value),
-      keys: () => storedMemento.keys()
-    };
+    const memento = injectStateOnRead(storedMemento, lightStateKey, concurrentLightState);
     mermaidGlobalConfig["lightModeTheme"] = "default";
 
     await expect(restoreMermaidThemeSync(memento)).rejects.toThrow(
@@ -761,9 +1115,119 @@ describe("Mermaid theme synchronization", () => {
 
     expect(updateCalls).toEqual([
       { key: "lightModeTheme", value: "neutral", target: 1 },
-      { key: "lightModeTheme", value: "default", target: 1 }
+      { key: "lightModeTheme", value: "dark", target: 1 }
     ]);
-    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("default");
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("dark");
+    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
+
+    workspaceIdentity = "file:///workspace-c.code-workspace";
+    markdownConfig["theme.mode"] = "single";
+    markdownConfig["theme.single"] = "dark_dimmed";
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "dark", target: 1 },
+      { key: "darkModeTheme", value: "dark", target: 1 }
+    ]);
+    expect(storedMemento.get(lightStateKey)).toEqual(expect.objectContaining({ applied: "dark" }));
+    expect(storedMemento.get(lightStateKey)).not.toHaveProperty("releasedBy");
+  });
+
+  it("recovers the user's value when a released global lease wins after the write", async () => {
+    const storedMemento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    await storedMemento.update(lightStateKey, {
+      version: 2,
+      revision: "workspace-a:1",
+      target: "global",
+      original: "neutral",
+      applied: "default",
+      owner: "workspace:file:///workspace-a.code-workspace"
+    });
+    await storedMemento.update("githubMarkdown.mermaid.themeState.v2.global.dark", {
+      version: 2,
+      revision: "workspace-a:2",
+      target: "global",
+      original: "forest",
+      releasedBy: "workspace:file:///workspace-a.code-workspace"
+    });
+    const concurrentLightState = {
+      version: 2 as const,
+      revision: "workspace-b:3",
+      target: "global" as const,
+      original: "neutral",
+      releasedBy: "workspace:file:///workspace-b.code-workspace",
+      releasedValue: "forest" as const,
+      releasedValueCaptured: true as const
+    };
+    const memento = injectStateOnRead(storedMemento, lightStateKey, concurrentLightState);
+    mermaidGlobalConfig["lightModeTheme"] = "default";
+    markdownConfig["theme.mode"] = "vscode";
+
+    await expect(updateMermaidThemeSync(memento)).rejects.toThrow(
+      "Mermaid theme state changed in another extension host"
+    );
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "vscode", target: 1 },
+      { key: "lightModeTheme", value: "forest", target: 1 }
+    ]);
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("forest");
+    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([]);
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("forest");
+    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
+  });
+
+  it("preserves the current value when a winning released lease predates value capture", async () => {
+    const storedMemento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    await storedMemento.update(lightStateKey, {
+      version: 2,
+      revision: "workspace-a:1",
+      target: "global",
+      original: "neutral",
+      applied: "default",
+      owner: "workspace:file:///workspace-a.code-workspace"
+    });
+    await storedMemento.update("githubMarkdown.mermaid.themeState.v2.global.dark", {
+      version: 2,
+      revision: "workspace-a:2",
+      target: "global",
+      original: "forest",
+      releasedBy: "workspace:file:///workspace-a.code-workspace"
+    });
+    const concurrentLightState = {
+      version: 2 as const,
+      revision: "workspace-b:3",
+      target: "global" as const,
+      original: "neutral",
+      releasedBy: "workspace:file:///workspace-b.code-workspace"
+    };
+    const memento = injectStateOnRead(storedMemento, lightStateKey, concurrentLightState);
+    mermaidGlobalConfig["lightModeTheme"] = "default";
+    markdownConfig["theme.mode"] = "vscode";
+
+    await expect(updateMermaidThemeSync(memento)).rejects.toThrow(
+      "Mermaid theme state changed in another extension host"
+    );
+
+    expect(updateCalls).toEqual([{ key: "lightModeTheme", value: "vscode", target: 1 }]);
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("vscode");
+    expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([]);
+    expect(mermaidGlobalConfig["lightModeTheme"]).toBe("vscode");
     expect(storedMemento.get(lightStateKey)).toEqual(concurrentLightState);
   });
 
@@ -786,7 +1250,9 @@ describe("Mermaid theme synchronization", () => {
       const synchronization = expect(updateMermaidThemeSync(memento)).rejects.toThrow(
         `Failed to update ${failedKey}`
       );
-      await vi.waitFor(() => expect(updateCalls).toHaveLength(2));
+      await vi.waitFor(() =>
+        expect(updateCalls).toHaveLength(failedKey === "darkModeTheme" ? 1 : 2)
+      );
       releaseAppliedUpdate();
       await synchronization;
 
@@ -796,6 +1262,38 @@ describe("Mermaid theme synchronization", () => {
       });
     }
   );
+
+  it("persists rollback intent before restoring a partially applied synchronization", async () => {
+    const memento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    let releaseRollback = () => {};
+    updateFailureCalls.add(2);
+    updateGateCalls.set(
+      3,
+      new Promise<void>((resolve) => {
+        releaseRollback = resolve;
+      })
+    );
+
+    const synchronization = expect(updateMermaidThemeSync(memento)).rejects.toThrow(
+      "Failed to update darkModeTheme"
+    );
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(3));
+    const persistedBeforeRollback = memento.get(lightStateKey);
+    releaseRollback();
+    await synchronization;
+
+    expect(persistedBeforeRollback).toEqual(
+      expect.objectContaining({
+        applied: "default",
+        pending: {
+          kind: "restore",
+          desired: "neutral",
+          previous: "default"
+        }
+      })
+    );
+  });
 
   it("reports update and rollback failures while keeping the snapshot retryable", async () => {
     const memento = createTestMemento();
@@ -809,7 +1307,7 @@ describe("Mermaid theme synchronization", () => {
     updateFailures.add("darkModeTheme");
 
     const synchronization = updateMermaidThemeSync(memento).catch((error: unknown) => error);
-    await vi.waitFor(() => expect(updateCalls).toHaveLength(2));
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(1));
     updateFailures.add("lightModeTheme");
     releaseLightUpdate();
 

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -258,7 +258,7 @@ describe("Mermaid theme synchronization", () => {
     });
   });
 
-  it("rebases workspace synchronization after the extension host changes workspaces", async () => {
+  it("re-resolves the Mermaid targets after the extension host changes workspaces", async () => {
     const memento = createTestMemento();
     mermaidWorkspaceConfig = {
       lightModeTheme: "base",
@@ -268,18 +268,54 @@ describe("Mermaid theme synchronization", () => {
     await updateMermaidThemeSync(memento);
 
     workspaceIdentity = "file:///workspace-b.code-workspace";
-    mermaidWorkspaceConfig = {
-      lightModeTheme: "neutral",
-      darkModeTheme: "base"
-    };
+    mermaidWorkspaceConfig = {};
+    updateCalls.length = 0;
     await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "default", target: 1 },
+      { key: "darkModeTheme", value: "dark", target: 1 }
+    ]);
+
+    markdownConfig["mermaid.syncTheme"] = false;
+    await updateMermaidThemeSync(memento);
+
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "forest"
+    });
+  });
+
+  it("adopts workspace targets after leaving a workspace that used global themes", async () => {
+    const memento = createTestMemento();
+
+    await updateMermaidThemeSync(memento);
+
+    workspaceIdentity = "file:///workspace-b.code-workspace";
+    mermaidWorkspaceConfig = {
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    };
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "neutral", target: 1 },
+      { key: "darkModeTheme", value: "forest", target: 1 },
+      { key: "lightModeTheme", value: "default", target: 2 },
+      { key: "darkModeTheme", value: "dark", target: 2 }
+    ]);
 
     markdownConfig["mermaid.syncTheme"] = false;
     await updateMermaidThemeSync(memento);
 
     expect(mermaidWorkspaceConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "vscode"
+    });
+    expect(mermaidGlobalConfig).toEqual({
       lightModeTheme: "neutral",
-      darkModeTheme: "base"
+      darkModeTheme: "forest"
     });
   });
 


### PR DESCRIPTION
## 根因

Mermaid 主题同步最初只保存一份 Global 快照，并按停止同步时的当前 effective target 恢复。用户先在没有 workspace override 的工作区同步 Global，随后切换到具有 Workspace override 的工作区时，停止同步只会恢复 Workspace 值，仍由扩展持有的 Global 值会被遗留。

此外，配置写入与 Memento 持久化不是一个原子操作；扩展宿主在 apply、restore 或 rollback 中断后，需要能够识别已完成和未完成的转换，同时不能覆盖同步期间用户主动修改的新值。

## 修改内容

- 每个 Mermaid slot 在存在显式 workspace override 时写入 Workspace，否则写入 Global。
- Global 与 Workspace 分别保存原值、已应用值及 pending journal；Workspace 记录按 workspace identity 隔离。
- 停止同步或扩展停用时，同时恢复仍由扩展持有的 Global 记录和当前 workspace identity 的 Workspace 记录。
- 用户修改某个 target 后释放该记录，后续同步、恢复和跨工作区切换不会覆盖用户的新选择。
- apply、restore 与 rollback 在写配置前持久化意图，并在宿主中断后继续或安全回退。
- 更新 `ARCHITECTURE.md`，记录 target 选择、workspace identity、pending/released 恢复协议及多宿主边界。

## 用户影响

使用 `markdown-mermaid` 且为工作区设置了 Mermaid 主题覆盖时，GitHub Markdown 主题同步现在会更新真正生效的配置层级。关闭同步、切换工作区后关闭同步或停用扩展时，会恢复扩展仍拥有的 Global 和当前 Workspace 原值；同步期间用户主动修改的值保持不变。

## TDD 证据

- RED：新增 A 工作区捕获 Global → B 工作区同步 Workspace override → 在 B 关闭同步的公开 seam 用例；旧实现只执行 2 次 Workspace restore，缺少 2 次 Global restore，结果为 44 passed / 1 failed。
- GREEN：restore 阶段对每个 slot 同时处理 Global journal 与当前 identity 的 Workspace journal；定向测试 45/45、全量 47 files / 324 tests 通过。
- 既有 takeover、重叠 update/deactivate、pending apply/restore、部分 rollback 与 Memento 失败用例全部保持通过。

## 验证

- `pnpm exec vitest run tests/integrations/mermaid.test.ts`
- `nub run test`
- `nub run test:coverage`
- `nubx tsc --noEmit`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nub run build`
- VS Code 1.129 desktop preview：全新隔离 profile 冷启动通过，同一 profile 连续第二次运行通过
- pinned Web preview host 通过
- pre-commit hook：format、lint、47 files / 324 tests 通过

## 兼容性与边界

- 未提高 `engines.vscode`，未引入 Node-only extension runtime API；desktop 与 Web entrypoint 保持兼容。
- 配置 target 仍限定为 Global/Workspace；这些 window-scope 设置不写 WorkspaceFolder。
- 多个同时运行的 extension host 无法对共享 Global 设置执行原子 CAS；该场景仍采用 last-writer 行为。宿主观察到用户 takeover 后会释放对应记录，后续恢复不会覆盖该选择。
- README 中英文已覆盖用户侧 Workspace 行为，本次无需重复修改；现有 `[Unreleased]` Mermaid 条目已涵盖可观察结果。
