### PR TITLE
fix(markdown): resolve project-root images in nested documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+### Markdown preview
+
+- Raw HTML images with project-root `src` paths now resolve from the workspace root when the Markdown file is inside a subdirectory, instead of looking for the image beneath that subdirectory.
+
 ### Themes and appearance
 
 - Theme and theme-mode Quick Picks now display Chinese labels in Simplified Chinese VS Code, and confirmation messages no longer mix Chinese text with English theme names.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This project focuses on three practical outcomes:
 - **Footnotes** — `[^1]` references with automatic numbering, backrefs, and a footnotes section at the bottom.
 - **Alerts** — `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, and `[!CAUTION]` render with proper icons and styling.
 - **Emoji Shortcodes** — `:rocket:`, `:+1:`, `:tada:` and thousands more, including both Unicode emoji and image-based custom emoji from GitHub.
-- **HTML Image Path Rewriting** — absolute paths in HTML `<img>` tags (`/path/to/img`) are rewritten to relative paths (`./path/to/img`), so project-local images work correctly in VS Code's webview preview.
+- **HTML Project-Root Images** — absolute paths in HTML `<img>` tags (`/path/to/img`) resolve from the workspace root in VS Code's webview preview, including from Markdown files in subdirectories.
 
 ### Pixel-Verified Preview Parity
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,7 +76,7 @@ VS Code 自带的 Markdown Preview 更偏通用渲染，而开发者真正关心
 - **脚注** — `[^1]` 引用自动编号、自动回跳链接，并在文末生成脚注区域。
 - **Alerts** — `[!NOTE]`、`[!TIP]`、`[!IMPORTANT]`、`[!WARNING]`、`[!CAUTION]` 五种提示框，附带正确的图标和样式。
 - **Emoji 短代码** — `:rocket:`、`:+1:`、`:tada:` 等数千个短代码，同时支持 Unicode emoji 和 GitHub 自定义图片 emoji。
-- **HTML 图片路径重写** — HTML `<img>` 标签中的绝对路径（`/path/to/img`）会重写为相对路径（`./path/to/img`），让项目本地图片在 VS Code webview 预览中正常显示。
+- **HTML 项目根图片** — HTML `<img>` 标签中的绝对路径（`/path/to/img`）会在 VS Code webview 预览中从工作区根目录解析，位于子目录中的 Markdown 文件也能正确引用。
 
 ### 经过像素验证的预览一致性
 

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -1,17 +1,43 @@
+import vscode from "vscode";
 import type MarkdownIt from "markdown-it";
 
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const projectRootSrcAttributePattern =
   /(<img(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+src[\t\n\f\r ]*=[\t\n\f\r ]*)(?:(["'])(\/(?!\/)[^"']+)\2|(\/(?!\/)[^\t\n\f\r "'`=<>]+))/i;
 
-function rewriteImgSrc(html: string): string {
+type ImageRenderEnv = {
+  currentDocument?: vscode.Uri;
+  resourceProvider?: Pick<vscode.Webview, "asWebviewUri">;
+};
+
+function rewriteImgSrc(html: string, env: ImageRenderEnv | undefined): string {
   return html.replace(imageTagPattern, (imageTag) =>
     imageTag.replace(
       projectRootSrcAttributePattern,
       (_match, before, quote = "", quotedSrc, unquotedSrc) =>
-        `${before}${quote}.${quotedSrc ?? unquotedSrc}${quote}`
+        `${before}${quote}${toProjectRootResourceUri(quotedSrc ?? unquotedSrc, env)}${quote}`
     )
   );
+}
+
+function toProjectRootResourceUri(src: string, env: ImageRenderEnv | undefined): string {
+  const currentDocument = env?.currentDocument;
+  const resourceProvider = env?.resourceProvider;
+  const workspaceFolder = currentDocument
+    ? vscode.workspace.getWorkspaceFolder(currentDocument)
+    : undefined;
+  if (!workspaceFolder || !resourceProvider) return `.${src}`;
+
+  try {
+    const parsed = vscode.Uri.parse(`markdown-link:${src}`);
+    const resource = vscode.Uri.joinPath(workspaceFolder.uri, parsed.fsPath).with({
+      fragment: parsed.fragment,
+      query: parsed.query
+    });
+    return resourceProvider.asWebviewUri(resource).toString(true);
+  } catch {
+    return `.${src}`;
+  }
 }
 
 export default function markdownItImageUrl(md: MarkdownIt): MarkdownIt {
@@ -22,7 +48,7 @@ export default function markdownItImageUrl(md: MarkdownIt): MarkdownIt {
 
     md.renderer.rules[ruleName] = (tokens, idx, options, env, self) => {
       if (tokens[idx]) {
-        tokens[idx].content = rewriteImgSrc(tokens[idx].content);
+        tokens[idx].content = rewriteImgSrc(tokens[idx].content, env as ImageRenderEnv);
       }
       return defaultRender(tokens, idx, options, env, self);
     };

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -30,7 +30,7 @@ function toProjectRootResourceUri(src: string, env: ImageRenderEnv | undefined):
 
   try {
     const parsed = vscode.Uri.parse(`markdown-link:${src}`);
-    const resource = vscode.Uri.joinPath(workspaceFolder.uri, parsed.fsPath).with({
+    const resource = vscode.Uri.joinPath(workspaceFolder.uri, parsed.path).with({
       fragment: parsed.fragment,
       query: parsed.query
     });

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -1,4 +1,4 @@
-import vscode from "vscode";
+import * as vscode from "vscode";
 import type MarkdownIt from "markdown-it";
 
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -51,7 +51,7 @@ const vscode = vi.hoisted(() => {
   };
 });
 
-vi.mock("vscode", () => ({ default: vscode }));
+vi.mock("vscode", () => ({ ...vscode, default: vscode }));
 
 import githubImageUrl from "../../src/plugins/markdown-it-github-image-url";
 

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -8,12 +8,9 @@ const vscode = vi.hoisted(() => {
       readonly path: string,
       readonly query = "",
       readonly fragment = "",
-      readonly authority = ""
+      readonly authority = "",
+      readonly fsPath = path
     ) {}
-
-    get fsPath(): string {
-      return this.path;
-    }
 
     toString(): string {
       return `${this.scheme}://${this.authority}${this.path}${this.query ? `?${this.query}` : ""}${this.fragment ? `#${this.fragment}` : ""}`;
@@ -25,7 +22,8 @@ const vscode = vi.hoisted(() => {
         this.path,
         change.query ?? this.query,
         change.fragment ?? this.fragment,
-        this.authority
+        this.authority,
+        this.fsPath
       );
     }
   }
@@ -42,7 +40,14 @@ const vscode = vi.hoisted(() => {
       parse(value: string): MockUri {
         const match = /^(.*?):(?:\/\/)?([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/.exec(value);
         if (!match?.[1] || match[2] === undefined) throw new Error(`Invalid URI: ${value}`);
-        return new MockUri(match[1], match[2], match[3], match[4]);
+        return new MockUri(
+          match[1],
+          match[2],
+          match[3],
+          match[4],
+          "",
+          match[2].replaceAll("/", "\\")
+        );
       }
     },
     workspace: {
@@ -65,21 +70,24 @@ describe("markdown-it-github-image-url", () => {
   it.each([
     ["root document", "/workspace/README.md"],
     ["nested document", "/workspace/docs/guide.md"]
-  ])("resolves a project-root HTML image from a %s", (_case, documentPath) => {
-    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
-    const html = md.render('<img src="/assets/logo.svg" alt="logo">', {
-      currentDocument: new vscode.MockUri("file", documentPath),
-      resourceProvider: {
-        asWebviewUri(
-          resource: InstanceType<typeof vscode.MockUri>
-        ): InstanceType<typeof vscode.MockUri> {
-          return new vscode.MockUri("https", resource.path, "", "", "webview.test");
+  ])(
+    "resolves a project-root HTML image from a %s using URI path semantics",
+    (_case, documentPath) => {
+      const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+      const html = md.render('<img src="/assets/logo.svg" alt="logo">', {
+        currentDocument: new vscode.MockUri("file", documentPath),
+        resourceProvider: {
+          asWebviewUri(
+            resource: InstanceType<typeof vscode.MockUri>
+          ): InstanceType<typeof vscode.MockUri> {
+            return new vscode.MockUri("https", resource.path, "", "", "webview.test");
+          }
         }
-      }
-    });
+      });
 
-    expect(html).toContain('src="https://webview.test/workspace/assets/logo.svg"');
-  });
+      expect(html).toContain('src="https://webview.test/workspace/assets/logo.svg"');
+    }
+  );
 
   it("does not touch already-relative paths", () => {
     const md = new MarkdownIt().use(githubImageUrl);

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -1,5 +1,58 @@
 import MarkdownIt from "markdown-it";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const vscode = vi.hoisted(() => {
+  class MockUri {
+    constructor(
+      readonly scheme: string,
+      readonly path: string,
+      readonly query = "",
+      readonly fragment = "",
+      readonly authority = ""
+    ) {}
+
+    get fsPath(): string {
+      return this.path;
+    }
+
+    toString(): string {
+      return `${this.scheme}://${this.authority}${this.path}${this.query ? `?${this.query}` : ""}${this.fragment ? `#${this.fragment}` : ""}`;
+    }
+
+    with(change: { fragment?: string; query?: string }): MockUri {
+      return new MockUri(
+        this.scheme,
+        this.path,
+        change.query ?? this.query,
+        change.fragment ?? this.fragment,
+        this.authority
+      );
+    }
+  }
+
+  return {
+    MockUri,
+    Uri: {
+      joinPath(base: MockUri, path: string): MockUri {
+        return new MockUri(
+          base.scheme,
+          `${base.path.replace(/\/$/, "")}/${path.replace(/^\//, "")}`
+        );
+      },
+      parse(value: string): MockUri {
+        const match = /^(.*?):(?:\/\/)?([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/.exec(value);
+        if (!match?.[1] || match[2] === undefined) throw new Error(`Invalid URI: ${value}`);
+        return new MockUri(match[1], match[2], match[3], match[4]);
+      }
+    },
+    workspace: {
+      getWorkspaceFolder: () => ({ uri: new MockUri("file", "/workspace") })
+    }
+  };
+});
+
+vi.mock("vscode", () => ({ default: vscode }));
+
 import githubImageUrl from "../../src/plugins/markdown-it-github-image-url";
 
 describe("markdown-it-github-image-url", () => {
@@ -7,6 +60,25 @@ describe("markdown-it-github-image-url", () => {
     const md = new MarkdownIt({ html: true }).use(githubImageUrl);
     const html = md.render('<img src="/images/photo.png" alt="alt">');
     expect(html).toContain('src="./images/photo.png"');
+  });
+
+  it.each([
+    ["root document", "/workspace/README.md"],
+    ["nested document", "/workspace/docs/guide.md"]
+  ])("resolves a project-root HTML image from a %s", (_case, documentPath) => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render('<img src="/assets/logo.svg" alt="logo">', {
+      currentDocument: new vscode.MockUri("file", documentPath),
+      resourceProvider: {
+        asWebviewUri(
+          resource: InstanceType<typeof vscode.MockUri>
+        ): InstanceType<typeof vscode.MockUri> {
+          return new vscode.MockUri("https", resource.path, "", "", "webview.test");
+        }
+      }
+    });
+
+    expect(html).toContain('src="https://webview.test/workspace/assets/logo.svg"');
   });
 
   it("does not touch already-relative paths", () => {


### PR DESCRIPTION
## 根因

原始 HTML 图片插件将 `/assets/logo.svg` 无条件改写为 `./assets/logo.svg`。VS Code Markdown webview 的 document base 指向当前 Markdown 文件，因此根目录文档可以正确显示，但 `docs/guide.md` 会错误解析为 `docs/assets/logo.svg`。

## 修改

- 从 VS Code MarkdownIt render env 读取 `currentDocument` 与 `resourceProvider`。
- 使用当前文档所属 workspace folder 解析项目根路径，再通过 `asWebviewUri` 输出最终资源 URI。
- 缺少 VS Code document env 时继续使用原有 `./` 回退，不改变独立 MarkdownIt 调用。
- 同步修正英文/中文 README 对项目根图片行为的说明。
- 该变化会恢复嵌套文档中用户可见的图片，因此按 changelog admission rules 记录在 `[Unreleased]`。

## TDD 证据

Red：

- 公共 seam 为 `MarkdownIt.render(rawHtml, renderEnv)` 的最终 HTML。
- 根目录 `/workspace/README.md` 与嵌套 `/workspace/docs/guide.md` 两个用例都期望 `https://webview.test/workspace/assets/logo.svg`。
- 修复前新增两例均失败，实际输出为 `src="./assets/logo.svg"`。

Green：

- 定向测试 10/10 通过。
- 根目录与嵌套文档现在输出同一 workspace-root webview URI。
- 已有相对路径、外部 URL、协议相对 URL、quoted/unquoted 与 `data-src` 行为保持通过。

## 验证

- 全量单元测试：47 个文件、297 个测试通过。
- `tsc --noEmit` 通过。
- 普通及 type-aware oxlint 通过。
- oxfmt 检查通过。
- 生产构建通过。
- 最低支持版本 VS Code 1.74 desktop host smoke 通过。
- pinned Web host smoke 通过。
- pre-commit hooks（format、lint、全量测试）通过。

## 证据边界

VS Code 1.74 与当前主线源码都提供相同的 `currentDocument` / `resourceProvider` render env，并使用 workspace folder + `asWebviewUri` 处理 Markdown 项目根图片。本 PR 的 URI 回归由公开 MarkdownIt 输出 seam 确定性验证；desktop/Web host smoke 验证扩展激活和宿主兼容，但没有通过真实文件系统加载嵌套图片。

仓库声明 Nub 0.7.2，但当前环境未安装该版本；所有 Nub 命令显式使用已安装的 0.7.1。