### PR TITLE
fix(release): prepare manual tag releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -150,8 +150,36 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  publish:
+  prepare-release:
     needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: vscode-github-markdown-${{ github.ref_name }}
+          path: release
+
+      - name: Ensure draft GitHub Release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "GitHub Release $GITHUB_REF_NAME already exists"
+            exit 0
+          fi
+
+          gh release create "$GITHUB_REF_NAME" \
+            --draft \
+            --verify-tag \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release/release-CHANGELOG.txt \
+            --repo "$GITHUB_REPOSITORY"
+
+  publish:
+    needs: prepare-release
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/tests/scripts/release/publish-workflow.test.ts
+++ b/tests/scripts/release/publish-workflow.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  new URL("../../../.github/workflows/publish.yml", import.meta.url),
+  "utf8"
+);
+
+describe("manual tag publishing", () => {
+  it("ensures a draft GitHub Release exists before publishing to the Marketplace", () => {
+    const prepareStart = workflow.indexOf("  prepare-release:");
+    const publishStart = workflow.indexOf("  publish:");
+    const marketplaceStart = workflow.indexOf("Publish to VS Code Marketplace");
+
+    expect(prepareStart).toBeGreaterThan(-1);
+    expect(prepareStart).toBeLessThan(publishStart);
+    expect(prepareStart).toBeLessThan(marketplaceStart);
+
+    const prepareJob = workflow.slice(prepareStart, publishStart);
+    expect(prepareJob).toContain("needs: verify");
+    expect(prepareJob).toContain("contents: write");
+    expect(prepareJob).toContain('gh release view "$GITHUB_REF_NAME"');
+    expect(prepareJob).toContain('gh release create "$GITHUB_REF_NAME"');
+    expect(prepareJob).toContain("--draft");
+    expect(prepareJob).toContain("--verify-tag");
+
+    const publishJob = workflow.slice(publishStart, workflow.indexOf("  finalize:"));
+    expect(publishJob).toContain("needs: prepare-release");
+  });
+});


### PR DESCRIPTION
## 修改内容

- 在 Marketplace 发布前新增 `prepare-release` job
- Release Please 已创建对应 draft Release 时直接复用
- 手动创建并推送 tag 时，自动创建经过 `--verify-tag` 校验的 draft Release
- 将 `contents: write` 隔离在准备 job；Marketplace job 继续保持 `contents: read`
- 增加发布工作流契约测试，锁定 job 顺序、依赖和权限

## 根因

恢复文档允许直接创建并推送签名 tag，但原工作流直到 Marketplace 发布完成后才运行 `gh release upload`。手动 tag 不会自动创建 GitHub Release，因此 finalize 可能在 Marketplace 已发布后失败。

## TDD 证据

- Red：旧工作流上定向测试失败，`prepare-release` job 不存在。
- Green：准备 job 在 Marketplace 前复用或创建 draft Release；定向测试 1/1、全量 48 files / 296 tests 通过。

## 验证

- `nub run test`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nubx tsc --noEmit`
- `nub run build`
- Ruby YAML parse PASS
- 本机 `gh release create --help` 确认 `--draft`、`--verify-tag`、`--title`、`--notes-file` 参数可用

未实际创建测试 Release，避免改变外部发布状态；该边界由工作流契约测试、现有 tag/Release 路径和 CI 负责验证。`CHANGELOG.md` 按 admission rules 有意省略。当前环境使用已安装的 Nub 0.7.1；仓库声明的 0.7.2 未安装。
