### PR TITLE
test(host): isolate preview profiles by worktree

### DIFF
--- a/scripts/host/desktop-preview-profile.ts
+++ b/scripts/host/desktop-preview-profile.ts
@@ -1,0 +1,15 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+
+export function resolveDesktopPreviewDirectories(
+  temporaryDirectory: string,
+  version: string,
+  projectRoot: string
+): { extensionsDir: string; userDataDir: string } {
+  const dataDir = join(temporaryDirectory, "vsgm-host-preview", version);
+  const projectId = createHash("sha256").update(projectRoot).digest("base64url").slice(0, 12);
+  return {
+    extensionsDir: join(dataDir, "extensions"),
+    userDataDir: join(dataDir, projectId)
+  };
+}

--- a/scripts/host/desktop-preview.ts
+++ b/scripts/host/desktop-preview.ts
@@ -3,12 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _electron as electron } from "playwright";
 import { project } from "../shared/project";
+import { resolveDesktopPreviewDirectories } from "./desktop-preview-profile";
 import { assertClientRenderedPreview } from "./preview";
 import { hostVersions } from "./versions";
 
 const version = process.env["VSCODE_TEST_VERSION"] ?? hostVersions.pinnedPreview.desktopVersion;
 const fixtures = join(project.root, "tests", "fixtures", "host");
-const dataDir = join(tmpdir(), "vsgm-host-preview", version);
+const directories = resolveDesktopPreviewDirectories(tmpdir(), version, project.root);
 const executablePath = await downloadAndUnzipVSCode(version);
 const application = await electron.launch({
   executablePath,
@@ -16,8 +17,8 @@ const application = await electron.launch({
   args: [
     fixtures,
     `--extensionDevelopmentPath=${project.root}`,
-    `--user-data-dir=${join(dataDir, "user-data")}`,
-    `--extensions-dir=${join(dataDir, "extensions")}`,
+    `--user-data-dir=${directories.userDataDir}`,
+    `--extensions-dir=${directories.extensionsDir}`,
     "--disable-extensions",
     "--disable-workspace-trust",
     "--skip-release-notes",

--- a/tests/scripts/host/desktop-preview-profile.test.ts
+++ b/tests/scripts/host/desktop-preview-profile.test.ts
@@ -1,0 +1,33 @@
+import { basename } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveDesktopPreviewDirectories } from "../../../scripts/host/desktop-preview-profile";
+
+describe("resolveDesktopPreviewDirectories", () => {
+  it("isolates user data by project root while reusing version-scoped caches", () => {
+    const temporaryDirectory = "/tmp";
+    const version = "1.129.0";
+    const firstRoot = "/worktrees/first/project";
+    const secondRoot = "/worktrees/second/project";
+    const first = resolveDesktopPreviewDirectories(temporaryDirectory, version, firstRoot);
+    const firstAgain = resolveDesktopPreviewDirectories(temporaryDirectory, version, firstRoot);
+    const second = resolveDesktopPreviewDirectories(temporaryDirectory, version, secondRoot);
+
+    expect(first.userDataDir).not.toBe(second.userDataDir);
+    expect(first).toEqual(firstAgain);
+    expect(first.extensionsDir).toBe(second.extensionsDir);
+    expect(basename(first.userDataDir)).toMatch(/^[0-9A-Za-z_-]+$/);
+    expect(basename(first.userDataDir)).not.toMatch(/first|project|worktrees/);
+    expect(first.userDataDir).not.toContain(firstRoot);
+  });
+
+  it("keeps the VS Code IPC socket within the macOS path limit", () => {
+    const macOsTemporaryDirectory = "/var/folders/jr/dv9vfr19001_lpq7pbnyls640000gn/T";
+    const { userDataDir } = resolveDesktopPreviewDirectories(
+      macOsTemporaryDirectory,
+      "1.129.0",
+      "/worktrees/first/project"
+    );
+
+    expect(Buffer.byteLength(`${userDataDir}/1.12-main.sock`)).toBeLessThanOrEqual(103);
+  });
+});


### PR DESCRIPTION
## 根因

桌面 preview 宿主只按 VS Code 版本生成固定的 `user-data` 路径。不同仓库/worktree 因而共享 settings、globalState 与 IPC/profile 状态，一条分支的测试状态会污染另一条分支，造成可重复的假失败。

## 变更

- 提取公开的 `resolveDesktopPreviewDirectories` 路径 seam。
- 用 project root 的 SHA-256 派生 72-bit base64url 标识，只隔离 `userDataDir`。
- 同一 worktree 与版本跨运行继续复用 profile；版本级 `extensionsDir` 和 VS Code 下载缓存保持不变。
- 将标识压缩为 12 个字符，使 macOS 上 VS Code IPC socket 路径保持在 103-byte 限制内，且目录名不暴露完整项目路径。

## TDD 证据

1. RED：两个不同 project roots 都解析为同一个 `/tmp/vsgm-host-preview/1.129.0/user-data`，目标测试 1 failed。
2. GREEN：加入 root 派生标识后，隔离、确定性、共享版本缓存与路径脱敏断言通过。
3. RED：真实 desktop 启动暴露 macOS IPC 路径为 116 bytes，VS Code 报 `IPC handle ... is longer than 103 chars`；新增公开 seam 边界测试稳定失败。
4. GREEN：改为 12 字符 base64url 标识后，socket 路径为 102 bytes，目标测试 2/2 通过，desktop 连续两次通过。

## 验证

- `pnpm exec vitest run tests/scripts/host/desktop-preview-profile.test.ts`：2 passed
- `nub run test`：48 files / 297 tests passed
- `nubx tsc --noEmit`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nub run build`
- `nub run verify:parity`
- `nub run test:host:desktop:preview`：连续两次通过并命中现有 VS Code 1.129 安装缓存
- 两个真实 worktree roots 的公开 seam：隔离=true、同 root 稳定=true、版本缓存共享=true、socket=102 bytes
- `nub run test:host:web:preview`：通过
- pre-commit format/lint/test：通过

## CHANGELOG

省略。本次仅修复内部 host 验证可靠性，不改变扩展用户可观察行为，按项目 changelog 准入规则不应记录。