### PR TITLE
fix(markdown): safely serialize unquoted image paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file records notable changes that people can observe or act on when using t
 
 ### Markdown preview
 
-- Raw HTML images with project-root `src` paths now resolve correctly from nested Markdown files and remain intact when unquoted paths contain encoded spaces.
+- Raw HTML images with project-root `src` paths now resolve correctly from nested Markdown files, including unquoted paths with encoded spaces and paths containing existing HTML entity references.
 
 ### Themes and appearance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file records notable changes that people can observe or act on when using t
 
 ### Markdown preview
 
-- Raw HTML images with project-root `src` paths now resolve from the workspace root when the Markdown file is inside a subdirectory, instead of looking for the image beneath that subdirectory.
+- Raw HTML images with project-root `src` paths now resolve correctly from nested Markdown files and remain intact when unquoted paths contain encoded spaces.
 
 ### Themes and appearance
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "release:note": "nub scripts/release/index.ts"
   },
   "dependencies": {
+    "entities": "4.5.0",
     "unicode-case-folding": "1.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
 
   .:
     dependencies:
+      entities:
+        specifier: 4.5.0
+        version: 4.5.0
       unicode-case-folding:
         specifier: 1.1.1
         version: 1.1.1

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -1,25 +1,57 @@
 import * as vscode from "vscode";
 import type MarkdownIt from "markdown-it";
-import { decodeHTMLAttribute } from "entities/lib/decode.js";
+import { decodeCodePoint } from "entities/lib/decode.js";
 
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const projectRootSrcAttributePattern =
   /(<img(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+src[\t\n\f\r ]*=[\t\n\f\r ]*)(?:(["'])(\/(?!\/)[^"']+)\2|(\/(?!\/)[^\t\n\f\r "'`=<>]+))/i;
+const htmlEntityPattern = /&(?:#[xX][\da-fA-F]+;?|#\d+;?|[a-zA-Z][a-zA-Z0-9]{1,31};?)/g;
+const legacyHtmlEntityNames = new Set(
+  "AElig AMP Aacute Acirc Agrave Aring Atilde Auml COPY Ccedil ETH Eacute Ecirc Egrave Euml GT Iacute Icirc Igrave Iuml LT Ntilde Oacute Ocirc Ograve Oslash Otilde Ouml QUOT REG THORN Uacute Ucirc Ugrave Uuml Yacute aacute acirc acute aelig agrave amp aring atilde auml brvbar ccedil cedil cent copy curren deg divide eacute ecirc egrave eth euml frac12 frac14 frac34 gt iacute icirc iexcl igrave iquest iuml laquo lt macr micro middot nbsp not ntilde oacute ocirc ograve ordf ordm oslash otilde ouml para plusmn pound quot raquo reg sect shy sup1 sup2 sup3 szlig thorn times uacute ucirc ugrave uml uuml yacute yen yuml".split(
+    " "
+  )
+);
 type ImageRenderEnv = {
   currentDocument?: vscode.Uri;
   resourceProvider?: Pick<vscode.Webview, "asWebviewUri">;
 };
 
-function rewriteImgSrc(html: string, env: ImageRenderEnv | undefined): string {
+function rewriteImgSrc(
+  html: string,
+  env: ImageRenderEnv | undefined,
+  decodeNamedEntity: (value: string) => string
+): string {
   return html.replace(imageTagPattern, (imageTag) =>
     imageTag.replace(
       projectRootSrcAttributePattern,
       (_match, before, quote = "", quotedSrc, unquotedSrc) => {
-        const src = decodeHTMLAttribute(quotedSrc ?? unquotedSrc);
+        const src = decodeHtmlAttribute(quotedSrc ?? unquotedSrc, decodeNamedEntity);
         return `${before}${serializeAttributeValue(toProjectRootResourceUri(src, env), quote)}`;
       }
     )
   );
+}
+
+function decodeHtmlAttribute(value: string, decodeNamedEntity: (value: string) => string): string {
+  return value.replace(htmlEntityPattern, (reference, offset: number, input: string) => {
+    if (reference.startsWith("&#")) {
+      const hexadecimal = reference[2]?.toLowerCase() === "x";
+      const digits = reference.slice(hexadecimal ? 3 : 2, reference.endsWith(";") ? -1 : undefined);
+      return decodeCodePoint(Number.parseInt(digits, hexadecimal ? 16 : 10));
+    }
+
+    if (reference.endsWith(";")) return decodeNamedEntity(reference);
+
+    const name = reference.slice(1);
+    const nextCharacter = input[offset + reference.length];
+    if (
+      !legacyHtmlEntityNames.has(name) ||
+      (nextCharacter !== undefined && /[=0-9A-Za-z]/.test(nextCharacter))
+    ) {
+      return reference;
+    }
+    return decodeNamedEntity(`${reference};`);
+  });
 }
 
 function serializeAttributeValue(value: string, quote: string): string {
@@ -58,7 +90,11 @@ export default function markdownItImageUrl(md: MarkdownIt): MarkdownIt {
 
     md.renderer.rules[ruleName] = (tokens, idx, options, env, self) => {
       if (tokens[idx]) {
-        tokens[idx].content = rewriteImgSrc(tokens[idx].content, env as ImageRenderEnv);
+        tokens[idx].content = rewriteImgSrc(
+          tokens[idx].content,
+          env as ImageRenderEnv,
+          md.utils.unescapeAll
+        );
       }
       return defaultRender(tokens, idx, options, env, self);
     };

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -4,23 +4,31 @@ import type MarkdownIt from "markdown-it";
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const projectRootSrcAttributePattern =
   /(<img(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+src[\t\n\f\r ]*=[\t\n\f\r ]*)(?:(["'])(\/(?!\/)[^"']+)\2|(\/(?!\/)[^\t\n\f\r "'`=<>]+))/i;
+const htmlEntityPattern = /&[a-z#][a-z0-9]{1,31};/gi;
 
 type ImageRenderEnv = {
   currentDocument?: vscode.Uri;
   resourceProvider?: Pick<vscode.Webview, "asWebviewUri">;
 };
 
-function rewriteImgSrc(html: string, env: ImageRenderEnv | undefined): string {
+function rewriteImgSrc(
+  html: string,
+  env: ImageRenderEnv | undefined,
+  decodeHtmlEntity: (entity: string) => string
+): string {
   return html.replace(imageTagPattern, (imageTag) =>
     imageTag.replace(
       projectRootSrcAttributePattern,
-      (_match, before, quote = "", quotedSrc, unquotedSrc) =>
-        `${before}${serializeAttributeValue(
-          toProjectRootResourceUri(quotedSrc ?? unquotedSrc, env),
-          quote
-        )}`
+      (_match, before, quote = "", quotedSrc, unquotedSrc) => {
+        const src = decodeHtmlEntities(quotedSrc ?? unquotedSrc, decodeHtmlEntity);
+        return `${before}${serializeAttributeValue(toProjectRootResourceUri(src, env), quote)}`;
+      }
     )
   );
+}
+
+function decodeHtmlEntities(value: string, decodeHtmlEntity: (entity: string) => string): string {
+  return value.replace(htmlEntityPattern, (entity) => decodeHtmlEntity(entity));
 }
 
 function serializeAttributeValue(value: string, quote: string): string {
@@ -59,7 +67,9 @@ export default function markdownItImageUrl(md: MarkdownIt): MarkdownIt {
 
     md.renderer.rules[ruleName] = (tokens, idx, options, env, self) => {
       if (tokens[idx]) {
-        tokens[idx].content = rewriteImgSrc(tokens[idx].content, env as ImageRenderEnv);
+        tokens[idx].content = rewriteImgSrc(tokens[idx].content, env as ImageRenderEnv, (entity) =>
+          md.utils.unescapeAll(entity)
+        );
       }
       return defaultRender(tokens, idx, options, env, self);
     };

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -15,9 +15,20 @@ function rewriteImgSrc(html: string, env: ImageRenderEnv | undefined): string {
     imageTag.replace(
       projectRootSrcAttributePattern,
       (_match, before, quote = "", quotedSrc, unquotedSrc) =>
-        `${before}${quote}${toProjectRootResourceUri(quotedSrc ?? unquotedSrc, env)}${quote}`
+        `${before}${serializeAttributeValue(
+          toProjectRootResourceUri(quotedSrc ?? unquotedSrc, env),
+          quote
+        )}`
     )
   );
+}
+
+function serializeAttributeValue(value: string, quote: string): string {
+  const delimiter = quote === "'" ? "'" : '"';
+  const escaped = value
+    .replaceAll("&", "&amp;")
+    .replaceAll(delimiter, delimiter === '"' ? "&quot;" : "&#39;");
+  return `${delimiter}${escaped}${delimiter}`;
 }
 
 function toProjectRootResourceUri(src: string, env: ImageRenderEnv | undefined): string {

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -4,7 +4,14 @@ import type MarkdownIt from "markdown-it";
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const projectRootSrcAttributePattern =
   /(<img(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+src[\t\n\f\r ]*=[\t\n\f\r ]*)(?:(["'])(\/(?!\/)[^"']+)\2|(\/(?!\/)[^\t\n\f\r "'`=<>]+))/i;
-const htmlEntityPattern = /&[a-z#][a-z0-9]{1,31};/gi;
+const htmlEntityPattern = /&(?:#[xX][\da-fA-F]+;?|#\d+;?|[a-zA-Z][a-zA-Z0-9]{1,31};?)/g;
+// WHATWG named character references that may omit their trailing semicolon:
+// https://html.spec.whatwg.org/entities.json
+const legacyHtmlEntityNames = new Set(
+  "AElig AMP Aacute Acirc Agrave Aring Atilde Auml COPY Ccedil ETH Eacute Ecirc Egrave Euml GT Iacute Icirc Igrave Iuml LT Ntilde Oacute Ocirc Ograve Oslash Otilde Ouml QUOT REG THORN Uacute Ucirc Ugrave Uuml Yacute aacute acirc acute aelig agrave amp aring atilde auml brvbar ccedil cedil cent copy curren deg divide eacute ecirc egrave eth euml frac12 frac14 frac34 gt iacute icirc iexcl igrave iquest iuml laquo lt macr micro middot nbsp not ntilde oacute ocirc ograve ordf ordm oslash otilde ouml para plusmn pound quot raquo reg sect shy sup1 sup2 sup3 szlig thorn times uacute ucirc ugrave uml uuml yacute yen yuml".split(
+    " "
+  )
+);
 
 type ImageRenderEnv = {
   currentDocument?: vscode.Uri;
@@ -28,7 +35,19 @@ function rewriteImgSrc(
 }
 
 function decodeHtmlEntities(value: string, decodeHtmlEntity: (entity: string) => string): string {
-  return value.replace(htmlEntityPattern, (entity) => decodeHtmlEntity(entity));
+  return value.replace(htmlEntityPattern, (entity, offset: number) => {
+    if (entity.endsWith(";")) return decodeHtmlEntity(entity);
+    if (entity.startsWith("&#")) return decodeHtmlEntity(`${entity};`);
+
+    const nextCharacter = value[offset + entity.length];
+    if (
+      !legacyHtmlEntityNames.has(entity.slice(1)) ||
+      (nextCharacter !== undefined && /[=0-9A-Za-z]/.test(nextCharacter))
+    ) {
+      return entity;
+    }
+    return decodeHtmlEntity(`${entity};`);
+  });
 }
 
 function serializeAttributeValue(value: string, quote: string): string {

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -1,53 +1,25 @@
 import * as vscode from "vscode";
 import type MarkdownIt from "markdown-it";
+import { decodeHTMLAttribute } from "entities/lib/decode.js";
 
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const projectRootSrcAttributePattern =
   /(<img(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+src[\t\n\f\r ]*=[\t\n\f\r ]*)(?:(["'])(\/(?!\/)[^"']+)\2|(\/(?!\/)[^\t\n\f\r "'`=<>]+))/i;
-const htmlEntityPattern = /&(?:#[xX][\da-fA-F]+;?|#\d+;?|[a-zA-Z][a-zA-Z0-9]{1,31};?)/g;
-// WHATWG named character references that may omit their trailing semicolon:
-// https://html.spec.whatwg.org/entities.json
-const legacyHtmlEntityNames = new Set(
-  "AElig AMP Aacute Acirc Agrave Aring Atilde Auml COPY Ccedil ETH Eacute Ecirc Egrave Euml GT Iacute Icirc Igrave Iuml LT Ntilde Oacute Ocirc Ograve Oslash Otilde Ouml QUOT REG THORN Uacute Ucirc Ugrave Uuml Yacute aacute acirc acute aelig agrave amp aring atilde auml brvbar ccedil cedil cent copy curren deg divide eacute ecirc egrave eth euml frac12 frac14 frac34 gt iacute icirc iexcl igrave iquest iuml laquo lt macr micro middot nbsp not ntilde oacute ocirc ograve ordf ordm oslash otilde ouml para plusmn pound quot raquo reg sect shy sup1 sup2 sup3 szlig thorn times uacute ucirc ugrave uml uuml yacute yen yuml".split(
-    " "
-  )
-);
-
 type ImageRenderEnv = {
   currentDocument?: vscode.Uri;
   resourceProvider?: Pick<vscode.Webview, "asWebviewUri">;
 };
 
-function rewriteImgSrc(
-  html: string,
-  env: ImageRenderEnv | undefined,
-  decodeHtmlEntity: (entity: string) => string
-): string {
+function rewriteImgSrc(html: string, env: ImageRenderEnv | undefined): string {
   return html.replace(imageTagPattern, (imageTag) =>
     imageTag.replace(
       projectRootSrcAttributePattern,
       (_match, before, quote = "", quotedSrc, unquotedSrc) => {
-        const src = decodeHtmlEntities(quotedSrc ?? unquotedSrc, decodeHtmlEntity);
+        const src = decodeHTMLAttribute(quotedSrc ?? unquotedSrc);
         return `${before}${serializeAttributeValue(toProjectRootResourceUri(src, env), quote)}`;
       }
     )
   );
-}
-
-function decodeHtmlEntities(value: string, decodeHtmlEntity: (entity: string) => string): string {
-  return value.replace(htmlEntityPattern, (entity, offset: number) => {
-    if (entity.endsWith(";")) return decodeHtmlEntity(entity);
-    if (entity.startsWith("&#")) return decodeHtmlEntity(`${entity};`);
-
-    const nextCharacter = value[offset + entity.length];
-    if (
-      !legacyHtmlEntityNames.has(entity.slice(1)) ||
-      (nextCharacter !== undefined && /[=0-9A-Za-z]/.test(nextCharacter))
-    ) {
-      return entity;
-    }
-    return decodeHtmlEntity(`${entity};`);
-  });
 }
 
 function serializeAttributeValue(value: string, quote: string): string {
@@ -86,9 +58,7 @@ export default function markdownItImageUrl(md: MarkdownIt): MarkdownIt {
 
     md.renderer.rules[ruleName] = (tokens, idx, options, env, self) => {
       if (tokens[idx]) {
-        tokens[idx].content = rewriteImgSrc(tokens[idx].content, env as ImageRenderEnv, (entity) =>
-          md.utils.unescapeAll(entity)
-        );
+        tokens[idx].content = rewriteImgSrc(tokens[idx].content, env as ImageRenderEnv);
       }
       return defaultRender(tokens, idx, options, env, self);
     };

--- a/tests/host/tsdown.config.ts
+++ b/tests/host/tsdown.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   clean: true,
   dts: false,
   deps: {
+    alwaysBundle: ["entities"],
     neverBundle: ["vscode"]
   },
   outputOptions: {

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -163,6 +163,18 @@ describe("markdown-it-github-image-url", () => {
     );
   });
 
+  it("decodes existing HTML entities without applying Markdown backslash escapes", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render(
+      '<img src="/assets/a\\&amp;b.svg?theme=light&amp;size=wide#hero" alt=logo>',
+      renderEnv()
+    );
+
+    expect(html).toBe(
+      '<img src="https://webview.test/workspace/assets/a\\&amp;b.svg?theme=light&amp;size=wide#hero" alt=logo>'
+    );
+  });
+
   it("serializes an unquoted src against the owning folder in a multi-root workspace", () => {
     vscode.workspace.getWorkspaceFolder.mockReturnValueOnce({
       uri: new vscode.MockUri("file", "/second-workspace")

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -40,18 +40,12 @@ const vscode = vi.hoisted(() => {
       parse(value: string): MockUri {
         const match = /^(.*?):(?:\/\/)?([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/.exec(value);
         if (!match?.[1] || match[2] === undefined) throw new Error(`Invalid URI: ${value}`);
-        return new MockUri(
-          match[1],
-          match[2],
-          match[3],
-          match[4],
-          "",
-          match[2].replaceAll("/", "\\")
-        );
+        const path = decodeURIComponent(match[2]);
+        return new MockUri(match[1], path, match[3], match[4], "", path.replaceAll("/", "\\"));
       }
     },
     workspace: {
-      getWorkspaceFolder: () => ({ uri: new MockUri("file", "/workspace") })
+      getWorkspaceFolder: vi.fn(() => ({ uri: new MockUri("file", "/workspace") }))
     }
   };
 });
@@ -59,6 +53,25 @@ const vscode = vi.hoisted(() => {
 vi.mock("vscode", () => ({ ...vscode, default: vscode }));
 
 import githubImageUrl from "../../src/plugins/markdown-it-github-image-url";
+
+function renderEnv(documentPath = "/workspace/README.md") {
+  return {
+    currentDocument: new vscode.MockUri("file", documentPath),
+    resourceProvider: {
+      asWebviewUri(
+        resource: InstanceType<typeof vscode.MockUri>
+      ): InstanceType<typeof vscode.MockUri> {
+        return new vscode.MockUri(
+          "https",
+          resource.path,
+          resource.query,
+          resource.fragment,
+          "webview.test"
+        );
+      }
+    }
+  };
+}
 
 describe("markdown-it-github-image-url", () => {
   it("rewrites absolute image path to relative in HTML img tag", () => {
@@ -74,16 +87,7 @@ describe("markdown-it-github-image-url", () => {
     "resolves a project-root HTML image from a %s using URI path semantics",
     (_case, documentPath) => {
       const md = new MarkdownIt({ html: true }).use(githubImageUrl);
-      const html = md.render('<img src="/assets/logo.svg" alt="logo">', {
-        currentDocument: new vscode.MockUri("file", documentPath),
-        resourceProvider: {
-          asWebviewUri(
-            resource: InstanceType<typeof vscode.MockUri>
-          ): InstanceType<typeof vscode.MockUri> {
-            return new vscode.MockUri("https", resource.path, "", "", "webview.test");
-          }
-        }
-      });
+      const html = md.render('<img src="/assets/logo.svg" alt="logo">', renderEnv(documentPath));
 
       expect(html).toContain('src="https://webview.test/workspace/assets/logo.svg"');
     }
@@ -116,18 +120,86 @@ describe("markdown-it-github-image-url", () => {
   it("rewrites an unquoted project-root src attribute", () => {
     const md = new MarkdownIt({ html: true }).use(githubImageUrl);
     const html = md.render("<img data-src=/lazy.png src=/actual.png alt=logo>");
-    expect(html).toContain("data-src=/lazy.png src=./actual.png alt=logo");
+    expect(html).toBe('<img data-src=/lazy.png src="./actual.png" alt=logo>');
+  });
+
+  it("quotes a rewritten unquoted src when its URI contains a decoded space", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render(
+      "<img src=/assets/my%20logo.svg alt=logo>",
+      renderEnv("/workspace/docs/guide.md")
+    );
+
+    expect(html).toBe('<img src="https://webview.test/workspace/assets/my logo.svg" alt=logo>');
+  });
+
+  it("preserves a single-quoted src while escaping a decoded apostrophe", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render("<img src='/assets/author%27s-logo.svg' alt='logo'>", renderEnv());
+
+    expect(html).toBe(
+      "<img src='https://webview.test/workspace/assets/author&#39;s-logo.svg' alt='logo'>"
+    );
+  });
+
+  it("preserves a double-quoted src while escaping a decoded quotation mark", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render('<img src="/assets/%22logo%22.svg" alt="logo">', renderEnv());
+
+    expect(html).toBe(
+      '<img src="https://webview.test/workspace/assets/&quot;logo&quot;.svg" alt="logo">'
+    );
+  });
+
+  it("preserves query and fragment components in a serialized src", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render(
+      '<img src="/assets/logo.svg?theme=light&size=wide#hero" alt=logo>',
+      renderEnv()
+    );
+
+    expect(html).toBe(
+      '<img src="https://webview.test/workspace/assets/logo.svg?theme=light&amp;size=wide#hero" alt=logo>'
+    );
+  });
+
+  it("serializes an unquoted src against the owning folder in a multi-root workspace", () => {
+    vscode.workspace.getWorkspaceFolder.mockReturnValueOnce({
+      uri: new vscode.MockUri("file", "/second-workspace")
+    });
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render(
+      "<img src=/assets/my%20logo.svg alt=logo>",
+      renderEnv("/second-workspace/docs/guide.md")
+    );
+
+    expect(html).toBe(
+      '<img src="https://webview.test/second-workspace/assets/my logo.svg" alt=logo>'
+    );
+  });
+
+  it("serializes the relative fallback when URI parsing fails", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render("<img src=/assets/bad%ZZ.svg alt=logo>", renderEnv());
+
+    expect(html).toBe('<img src="./assets/bad%ZZ.svg" alt=logo>');
   });
 
   it("preserves protocol-relative image URLs", () => {
     const md = new MarkdownIt({ html: true }).use(githubImageUrl);
     const html = md.render('<img src="//cdn.example.com/a.png">');
-    expect(html).toContain('src="//cdn.example.com/a.png"');
+    expect(html).toBe('<img src="//cdn.example.com/a.png">');
   });
 
   it("preserves unquoted protocol-relative image URLs", () => {
     const md = new MarkdownIt({ html: true }).use(githubImageUrl);
     const html = md.render("<img src=//cdn.example.com/a.png>");
-    expect(html).toContain("src=//cdn.example.com/a.png");
+    expect(html).toBe("<img src=//cdn.example.com/a.png>");
+  });
+
+  it("preserves an unquoted remote image URL", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render("<img src=https://example.com/a.png alt=logo>");
+    expect(html).toBe("<img src=https://example.com/a.png alt=logo>");
   });
 });

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -175,6 +175,15 @@ describe("markdown-it-github-image-url", () => {
     );
   });
 
+  it("preserves browser semantics for a legacy entity without a semicolon", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render('<img src="/assets/a&amp?theme=light#hero" alt=logo>', renderEnv());
+
+    expect(html).toBe(
+      '<img src="https://webview.test/workspace/assets/a&amp;?theme=light#hero" alt=logo>'
+    );
+  });
+
   it("serializes an unquoted src against the owning folder in a multi-root workspace", () => {
     vscode.workspace.getWorkspaceFolder.mockReturnValueOnce({
       uri: new vscode.MockUri("file", "/second-workspace")

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -184,6 +184,20 @@ describe("markdown-it-github-image-url", () => {
     );
   });
 
+  it.each([
+    ["a Windows-1252 compatibility code point", "&#128;", "€"],
+    ["a null code point", "&#0;", "�"],
+    ["a surrogate code point", "&#55296;", "�"],
+    ["an out-of-range code point", "&#1114112;", "�"]
+  ])("preserves browser semantics for %s", (_case, reference, expected) => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render(`<img src="/assets/a${reference}.svg" alt=logo>`, renderEnv());
+
+    expect(html).toBe(
+      `<img src="https://webview.test/workspace/assets/a${expected}.svg" alt=logo>`
+    );
+  });
+
   it("serializes an unquoted src against the owning folder in a multi-root workspace", () => {
     vscode.workspace.getWorkspaceFolder.mockReturnValueOnce({
       uri: new vscode.MockUri("file", "/second-workspace")

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -15,9 +15,9 @@ export default defineConfig({
   clean: false,
   publint: true,
   deps: {
-    alwaysBundle: ["unicode-case-folding"],
+    alwaysBundle: ["entities/lib/decode.js", "unicode-case-folding"],
     neverBundle: ["vscode"],
-    onlyBundle: ["unicode-case-folding"]
+    onlyBundle: ["entities", "unicode-case-folding"]
   },
   plugins: [
     visualizer({


### PR DESCRIPTION
## 根因

Raw HTML 图片的项目根路径原本直接沿用输入属性的 quoting 与字符串形式。未加引号的 `%20` 路径经 VS Code URI 转换后可能包含空格，浏览器会截断属性；已经转义的 HTML character references 还可能被再次转义。此前的局部 entity decoder 又没有实现 HTML 对 legacy semicolonless references 与 numeric compatibility/error code points 的完整规则，例如 `&#128;` 会变成字面文本而不是 `€`。

首版完整 attribute decoder 虽修正语义，但把完整 named-entity trie 带入 extension bundle，并使 Web host smoke bundle externalize `entities`，分别触发 package-size 与 Web CI。

## 修改内容

- 项目根图片仍通过 VS Code `RenderEnv`、workspace folder 与 `asWebviewUri` 重写；remote、protocol-relative 与无宿主 fallback 行为保持不变。
- 重写后的 `src` 始终生成合法 quoted attribute，并保留原单/双引号风格、正确转义 delimiter 与 `&`。
- named references 复用 MarkdownIt 自带 decoder；numeric references 仅 bundle `entities` 的 code-point compatibility/error mapping，覆盖 HTML attribute 语义而不携带完整 named trie。
- Web host smoke bundle 显式内联 `entities`；desktop/Web extension 与 VSIX 均保持 self-contained，不依赖外部 `node_modules`。

## TDD 证据

- 初始 unquoted `%20` RED：最终属性包含裸空格，Chromium 会把图片 URL 截断；修复后输出 quoted URL。
- existing entity RED：`&amp;` 被输出为 `&amp;amp;`；修复后只做一次语义解码与一次属性序列化。
- legacy semicolonless RED：合法 `&amp` 仍被重复转义；修复后保持 attribute-context 语义。
- numeric RED：`&#128;` 实际输出 `&amp;#128;`；修复后 Windows-1252 remap、null、surrogate、out-of-range 四类 oracle 均通过。
- Web host RED：`Cannot load module 'entities'`；smoke bundle 内联依赖后完整 `test:host:web` 通过。

## 兼容性与影响

- 不提高最低 VS Code 版本；extension runtime 仍支持 desktop 与 Web。
- extension bundle 为 105.66 kB，未包含完整 named trie；生产 bundle 与 host smoke bundle均无外部 `entities` import/require。
- VSIX 为 90,370 B，相对基线 87,878 B 增加 2,492 B（+2.84%），低于 20% 门槛。
- `CHANGELOG.md` 继续使用现有 Raw HTML image 条目，文案与已验证能力一致。

## VSIX 清单审计

- 基线与当前均为 24 个文件；added/removed 均为 0。
- forbidden-pattern 命中为 0：无 `node_modules/`、`src/`、`tests/`、`scripts/`、`.github/`、`.vscode/`、`.cache/`、source map、日志、临时文件或工具配置。
- 当前内容仅含 VSIX manifests、许可/README/changelog、extension manifest 与本地化资源、图标、运行时 JS/CSS 及 GitHub Markdown 主题 CSS。

## 验证

- targeted/public RenderEnv seam + full suite：50 files / 349 tests passed
- `nub run test:coverage`
- `pnpm audit --prod`：No known vulnerabilities
- `nubx tsc --noEmit`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nub run build`
- `nub run verify:parity`：受控用例 zero diff
- `nub run test:host:web`
- pinned desktop preview：同一 profile 连续两次通过
- `nub run package` + baseline package audit：24 files / +2.84% / PASS
- pre-commit hook：format、lint、50 files / 349 tests 全部通过
