### PR TITLE
fix(mermaid): preserve user theme takeovers during writes

### DIFF
--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -56,6 +56,7 @@ type Transaction = SlotContext & {
   previousValue: MermaidTheme | undefined;
   desiredValue: MermaidTheme | undefined;
   shouldWrite: boolean;
+  ownershipLost?: boolean;
 };
 type WriteOutcome = "released" | "skipped" | "written";
 type ConfigurationUpdate = Pick<Transaction, "key" | "target" | "desiredValue" | "shouldWrite"> & {
@@ -134,7 +135,16 @@ async function updateNow(memento: vscode.Memento): Promise<void> {
   if (failure?.status !== "rejected") return;
 
   try {
-    await restoreNow(memento, configuration, true);
+    await restoreNow(
+      memento,
+      configuration,
+      true,
+      new Set(
+        transactions
+          .filter((transaction) => transaction.ownershipLost)
+          .map((transaction) => transaction.stateKey)
+      )
+    );
   } catch (restoreError) {
     const restoreFailures =
       restoreError instanceof AggregateError ? restoreError.errors : [restoreError];
@@ -149,7 +159,8 @@ async function updateNow(memento: vscode.Memento): Promise<void> {
 async function restoreNow(
   memento: vscode.Memento,
   configuration: vscode.WorkspaceConfiguration,
-  preserveReleased = false
+  preserveReleased = false,
+  preservedStateKeys: ReadonlySet<string> = new Set()
 ): Promise<void> {
   if (!hasConfiguration(configuration)) return;
   const identity = getWorkspaceIdentity();
@@ -161,7 +172,11 @@ async function restoreNow(
       vscode.ConfigurationTarget.Workspace
     ] as const) {
       const context = loadContext(memento, identity, slot, key, target);
-      if (context.state && !(preserveReleased && context.state.releasedBy !== undefined)) {
+      if (
+        context.state &&
+        !preservedStateKeys.has(context.stateKey) &&
+        !(preserveReleased && context.state.releasedBy !== undefined)
+      ) {
         transactions.push(prepareRestore(configuration, { ...context, state: context.state }));
       }
     }
@@ -286,9 +301,10 @@ async function executeTransactions(
       desiredValue: transaction.desiredValue,
       shouldWrite: transaction.shouldWrite,
       expectedValue: transaction.previousValue,
-      onOwnershipLost: () => saveContext(memento, transaction, release(transaction.state, identity))
+      onOwnershipLost: () => markReleased(memento, transaction, identity)
     }))
   );
+  await retryRejectedReleases(memento, identity, transactions, results);
   try {
     for (const [index, result] of results.entries()) {
       const transaction = transactions[index];
@@ -310,6 +326,22 @@ async function executeTransactions(
   return results;
 }
 
+async function retryRejectedReleases(
+  memento: vscode.Memento,
+  identity: string,
+  transactions: Transaction[],
+  results: PromiseSettledResult<WriteOutcome>[]
+): Promise<void> {
+  for (const [index, transaction] of transactions.entries()) {
+    if (results[index]?.status !== "rejected" || !transaction.ownershipLost) continue;
+    try {
+      await markReleased(memento, transaction, identity);
+    } catch {
+      // Keep the original rejection; the pending claim remains retryable after a crash.
+    }
+  }
+}
+
 async function recoverTransactions(
   memento: vscode.Memento,
   configuration: vscode.WorkspaceConfiguration,
@@ -329,7 +361,7 @@ async function recoverTransactions(
         results[index].value === "written" &&
         transaction.shouldWrite &&
         current === transaction.desiredValue,
-      onOwnershipLost: () => saveContext(memento, transaction, release(transaction.state, identity))
+      onOwnershipLost: () => markReleased(memento, transaction, identity)
     };
   });
   const recoveryResults = await writeSequentially(configuration, updates);
@@ -344,6 +376,15 @@ async function recoverTransactions(
   });
   failures.push(...(await restoreStates(memento, restoredTransactions)));
   return failures;
+}
+
+async function markReleased(
+  memento: vscode.Memento,
+  transaction: Transaction,
+  identity: string
+): Promise<void> {
+  transaction.ownershipLost = true;
+  await saveContext(memento, transaction, release(transaction.state, identity));
 }
 
 async function restoreStates(

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -57,7 +57,11 @@ type Transaction = SlotContext & {
   desiredValue: MermaidTheme | undefined;
   shouldWrite: boolean;
 };
-type ConfigurationUpdate = Pick<Transaction, "key" | "target" | "desiredValue" | "shouldWrite">;
+type WriteOutcome = "released" | "skipped" | "written";
+type ConfigurationUpdate = Pick<Transaction, "key" | "target" | "desiredValue" | "shouldWrite"> & {
+  expectedValue: MermaidTheme | undefined;
+  onOwnershipLost: () => Promise<void>;
+};
 
 const snapshotKey = "githubMarkdown.mermaid.originalGlobalThemes";
 const stateKeyPrefix = "githubMarkdown.mermaid.themeState.v2";
@@ -115,11 +119,17 @@ async function updateNow(memento: vscode.Memento): Promise<void> {
     if (transaction) transactions.push(transaction);
   }
 
-  const results = await executeTransactions(memento, configuration, transactions, (transaction) => {
-    const next = { ...transaction.state, applied: transaction.desiredValue as MermaidTheme };
-    delete next.pending;
-    return next;
-  });
+  const results = await executeTransactions(
+    memento,
+    configuration,
+    identity,
+    transactions,
+    (transaction) => {
+      const next = { ...transaction.state, applied: transaction.desiredValue as MermaidTheme };
+      delete next.pending;
+      return next;
+    }
+  );
   const failure = results.find((result) => result.status === "rejected");
   if (failure?.status !== "rejected") return;
 
@@ -155,7 +165,13 @@ async function restoreNow(
       }
     }
   }
-  const results = await executeTransactions(memento, configuration, transactions, () => undefined);
+  const results = await executeTransactions(
+    memento,
+    configuration,
+    identity,
+    transactions,
+    () => undefined
+  );
   const failures = results
     .filter((result): result is PromiseRejectedResult => result.status === "rejected")
     .map((result) => result.reason);
@@ -245,9 +261,10 @@ function release(state: SlotState, identity: string): SlotState {
 async function executeTransactions(
   memento: vscode.Memento,
   configuration: vscode.WorkspaceConfiguration,
+  identity: string,
   transactions: Transaction[],
   finalize: (transaction: Transaction) => SlotState | undefined
-): Promise<PromiseSettledResult<void>[]> {
+): Promise<PromiseSettledResult<WriteOutcome>[]> {
   const claimed: Transaction[] = [];
   try {
     for (const transaction of transactions) {
@@ -262,22 +279,30 @@ async function executeTransactions(
 
   const results = await writeSequentially(
     configuration,
-    transactions.map(({ key, target, desiredValue, shouldWrite }) => ({
-      key,
-      target,
-      desiredValue,
-      shouldWrite
+    transactions.map((transaction) => ({
+      key: transaction.key,
+      target: transaction.target,
+      desiredValue: transaction.desiredValue,
+      shouldWrite: transaction.shouldWrite,
+      expectedValue: transaction.previousValue,
+      onOwnershipLost: () => saveContext(memento, transaction, release(transaction.state, identity))
     }))
   );
   try {
     for (const [index, result] of results.entries()) {
       const transaction = transactions[index];
-      if (result.status === "fulfilled" && transaction) {
+      if (result.status === "fulfilled" && result.value !== "released" && transaction) {
         await saveContext(memento, transaction, finalize(transaction));
       }
     }
   } catch (persistenceError) {
-    const failures = await recoverTransactions(memento, configuration, transactions, results);
+    const failures = await recoverTransactions(
+      memento,
+      configuration,
+      identity,
+      transactions,
+      results
+    );
     if (failures.length) throw new AggregateError([persistenceError, ...failures]);
     throw persistenceError;
   }
@@ -287,8 +312,9 @@ async function executeTransactions(
 async function recoverTransactions(
   memento: vscode.Memento,
   configuration: vscode.WorkspaceConfiguration,
+  identity: string,
   transactions: Transaction[],
-  results: PromiseSettledResult<void>[]
+  results: PromiseSettledResult<WriteOutcome>[]
 ): Promise<unknown[]> {
   const updates = transactions.map((transaction, index): ConfigurationUpdate => {
     const current = getThemeAtTarget(configuration, transaction.key, transaction.target);
@@ -296,19 +322,25 @@ async function recoverTransactions(
       key: transaction.key,
       target: transaction.target,
       desiredValue: transaction.previousValue,
+      expectedValue: transaction.desiredValue,
       shouldWrite:
         results[index]?.status === "fulfilled" &&
+        results[index].value === "written" &&
         transaction.shouldWrite &&
-        current === transaction.desiredValue
+        current === transaction.desiredValue,
+      onOwnershipLost: () => saveContext(memento, transaction, release(transaction.state, identity))
     };
   });
   const recoveryResults = await writeSequentially(configuration, updates);
   const failures = recoveryResults
     .filter((result): result is PromiseRejectedResult => result.status === "rejected")
     .map((result) => result.reason);
-  const restoredTransactions = transactions.filter(
-    (_, index) => recoveryResults[index]?.status === "fulfilled"
-  );
+  const restoredTransactions = transactions.filter((_, index) => {
+    const result = recoveryResults[index];
+    const primaryResult = results[index];
+    const wasReleased = primaryResult?.status === "fulfilled" && primaryResult.value === "released";
+    return result?.status === "fulfilled" && result.value !== "released" && !wasReleased;
+  });
   failures.push(...(await restoreStates(memento, restoredTransactions)));
   return failures;
 }
@@ -331,24 +363,35 @@ async function restoreStates(
 async function writeSequentially(
   configuration: vscode.WorkspaceConfiguration,
   updates: ConfigurationUpdate[]
-): Promise<PromiseSettledResult<void>[]> {
-  const results: PromiseSettledResult<void>[] = [];
+): Promise<PromiseSettledResult<WriteOutcome>[]> {
+  const results: PromiseSettledResult<WriteOutcome>[] = [];
   for (const update of updates) {
     if (!update.shouldWrite) {
-      results.push({ status: "fulfilled", value: undefined });
+      results.push({ status: "fulfilled", value: "skipped" });
       continue;
     }
     try {
-      let settled = false;
+      if (getThemeAtTarget(configuration, update.key, update.target) !== update.expectedValue) {
+        await update.onOwnershipLost();
+        results.push({ status: "fulfilled", value: "released" });
+        continue;
+      }
+      let outcome: WriteOutcome | undefined;
       for (let attempt = 0; attempt < 2; attempt += 1) {
         await configuration.update(update.key, update.desiredValue, update.target);
-        if (getThemeAtTarget(configuration, update.key, update.target) === update.desiredValue) {
-          settled = true;
+        const current = getThemeAtTarget(configuration, update.key, update.target);
+        if (current === update.desiredValue) {
+          outcome = "written";
+          break;
+        }
+        if (current !== update.expectedValue) {
+          await update.onOwnershipLost();
+          outcome = "released";
           break;
         }
       }
-      if (!settled) throw new Error(`Mermaid theme configuration did not settle for ${update.key}`);
-      results.push({ status: "fulfilled", value: undefined });
+      if (!outcome) throw new Error(`Mermaid theme configuration did not settle for ${update.key}`);
+      results.push({ status: "fulfilled", value: outcome });
     } catch (reason) {
       results.push({ status: "rejected", reason });
     }

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -134,7 +134,7 @@ async function updateNow(memento: vscode.Memento): Promise<void> {
   if (failure?.status !== "rejected") return;
 
   try {
-    await restoreNow(memento, configuration);
+    await restoreNow(memento, configuration, true);
   } catch (restoreError) {
     const restoreFailures =
       restoreError instanceof AggregateError ? restoreError.errors : [restoreError];
@@ -148,7 +148,8 @@ async function updateNow(memento: vscode.Memento): Promise<void> {
 
 async function restoreNow(
   memento: vscode.Memento,
-  configuration: vscode.WorkspaceConfiguration
+  configuration: vscode.WorkspaceConfiguration,
+  preserveReleased = false
 ): Promise<void> {
   if (!hasConfiguration(configuration)) return;
   const identity = getWorkspaceIdentity();
@@ -160,7 +161,7 @@ async function restoreNow(
       vscode.ConfigurationTarget.Workspace
     ] as const) {
       const context = loadContext(memento, identity, slot, key, target);
-      if (context.state) {
+      if (context.state && !(preserveReleased && context.state.releasedBy !== undefined)) {
         transactions.push(prepareRestore(configuration, { ...context, state: context.state }));
       }
     }

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -962,6 +962,57 @@ describe("Mermaid theme synchronization", () => {
     expect(storedMemento.get(lightStateKey)).not.toHaveProperty("applied");
   });
 
+  it("keeps a released takeover when another configuration update fails", async () => {
+    const storedMemento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    let releaseClaim = () => {};
+    const claimGate = new Promise<void>((resolve) => {
+      releaseClaim = resolve;
+    });
+    let shouldGateClaim = true;
+    const memento: typeof storedMemento = {
+      get: <T>(key: string, defaultValue?: T) => storedMemento.get(key, defaultValue),
+      update: async (key: string, value: unknown) => {
+        await storedMemento.update(key, value);
+        if (key === lightStateKey && shouldGateClaim) {
+          shouldGateClaim = false;
+          await claimGate;
+        }
+      },
+      keys: () => storedMemento.keys()
+    };
+    updateFailures.add("darkModeTheme");
+
+    const synchronization = updateMermaidThemeSync(memento);
+    await vi.waitFor(() =>
+      expect(storedMemento.get(lightStateKey)).toEqual(
+        expect.objectContaining({
+          pending: { kind: "apply", desired: "default", previous: "neutral" }
+        })
+      )
+    );
+    mermaidGlobalConfig["lightModeTheme"] = "base";
+    releaseClaim();
+    await expect(synchronization).rejects.toThrow("Failed to update darkModeTheme");
+
+    expect(storedMemento.get(lightStateKey)).toEqual(
+      expect.objectContaining({
+        original: "neutral",
+        releasedBy: "workspace:file:///workspace-a.code-workspace"
+      })
+    );
+
+    updateFailures.clear();
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "darkModeTheme", value: "dark", target: 1 }]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "dark"
+    });
+  });
+
   it("keeps a released takeover when another transaction fails to finalize", async () => {
     const storedMemento = createTestMemento();
     const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -34,6 +34,35 @@ function getEffectiveMermaidConfig(): Record<string, string | undefined> {
   };
 }
 
+function createControlledMemento(
+  onUpdate: (update: {
+    callNumber: number;
+    key: string;
+    persist: () => Promise<void>;
+    value: unknown;
+  }) => Promise<void>
+): {
+  memento: ReturnType<typeof createTestMemento>;
+  storedMemento: ReturnType<typeof createTestMemento>;
+} {
+  const storedMemento = createTestMemento();
+  let callNumber = 0;
+  const memento: typeof storedMemento = {
+    get: <T>(key: string, defaultValue?: T) => storedMemento.get(key, defaultValue),
+    update: async (key: string, value: unknown) => {
+      callNumber += 1;
+      await onUpdate({
+        callNumber,
+        key,
+        persist: async () => storedMemento.update(key, value),
+        value
+      });
+    },
+    keys: () => storedMemento.keys()
+  };
+  return { memento, storedMemento };
+}
+
 vi.mock("vscode", () => ({
   default: {
     ConfigurationTarget: { Global: 1, Workspace: 2 },
@@ -916,24 +945,19 @@ describe("Mermaid theme synchronization", () => {
   });
 
   it("preserves a user takeover while the apply claim is being persisted", async () => {
-    const storedMemento = createTestMemento();
     const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
     let releaseClaim = () => {};
     const claimGate = new Promise<void>((resolve) => {
       releaseClaim = resolve;
     });
     let shouldGateClaim = true;
-    const memento: typeof storedMemento = {
-      get: <T>(key: string, defaultValue?: T) => storedMemento.get(key, defaultValue),
-      update: async (key: string, value: unknown) => {
-        await storedMemento.update(key, value);
-        if (key === lightStateKey && shouldGateClaim) {
-          shouldGateClaim = false;
-          await claimGate;
-        }
-      },
-      keys: () => storedMemento.keys()
-    };
+    const { memento, storedMemento } = createControlledMemento(async ({ key, persist }) => {
+      await persist();
+      if (key === lightStateKey && shouldGateClaim) {
+        shouldGateClaim = false;
+        await claimGate;
+      }
+    });
 
     const synchronization = updateMermaidThemeSync(memento);
     await vi.waitFor(() =>
@@ -963,24 +987,19 @@ describe("Mermaid theme synchronization", () => {
   });
 
   it("keeps a released takeover when another configuration update fails", async () => {
-    const storedMemento = createTestMemento();
     const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
     let releaseClaim = () => {};
     const claimGate = new Promise<void>((resolve) => {
       releaseClaim = resolve;
     });
     let shouldGateClaim = true;
-    const memento: typeof storedMemento = {
-      get: <T>(key: string, defaultValue?: T) => storedMemento.get(key, defaultValue),
-      update: async (key: string, value: unknown) => {
-        await storedMemento.update(key, value);
-        if (key === lightStateKey && shouldGateClaim) {
-          shouldGateClaim = false;
-          await claimGate;
-        }
-      },
-      keys: () => storedMemento.keys()
-    };
+    const { memento, storedMemento } = createControlledMemento(async ({ key, persist }) => {
+      await persist();
+      if (key === lightStateKey && shouldGateClaim) {
+        shouldGateClaim = false;
+        await claimGate;
+      }
+    });
     updateFailures.add("darkModeTheme");
 
     const synchronization = updateMermaidThemeSync(memento);
@@ -1013,24 +1032,72 @@ describe("Mermaid theme synchronization", () => {
     });
   });
 
-  it("keeps a released takeover when another transaction fails to finalize", async () => {
-    const storedMemento = createTestMemento();
+  it("keeps a takeover when persisting its released state fails", async () => {
     const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
     let releaseClaim = () => {};
     const claimGate = new Promise<void>((resolve) => {
       releaseClaim = resolve;
     });
-    let updateCount = 0;
-    const memento: typeof storedMemento = {
-      get: <T>(key: string, defaultValue?: T) => storedMemento.get(key, defaultValue),
-      update: async (key: string, value: unknown) => {
-        updateCount += 1;
-        if (updateCount === 4) throw new Error("Failed to finalize Mermaid state");
-        await storedMemento.update(key, value);
-        if (updateCount === 1) await claimGate;
-      },
-      keys: () => storedMemento.keys()
-    };
+    let shouldGateClaim = true;
+    let shouldRejectRelease = true;
+    const { memento, storedMemento } = createControlledMemento(async ({ key, persist, value }) => {
+      if (
+        key === lightStateKey &&
+        shouldRejectRelease &&
+        typeof value === "object" &&
+        value !== null &&
+        "releasedBy" in value
+      ) {
+        shouldRejectRelease = false;
+        throw new Error("Failed to persist released Mermaid state");
+      }
+      await persist();
+      if (key === lightStateKey && shouldGateClaim) {
+        shouldGateClaim = false;
+        await claimGate;
+      }
+    });
+
+    const synchronization = updateMermaidThemeSync(memento);
+    await vi.waitFor(() =>
+      expect(storedMemento.get(lightStateKey)).toEqual(
+        expect.objectContaining({
+          pending: { kind: "apply", desired: "default", previous: "neutral" }
+        })
+      )
+    );
+    mermaidGlobalConfig["lightModeTheme"] = "base";
+    releaseClaim();
+    await expect(synchronization).rejects.toThrow("Failed to persist released Mermaid state");
+
+    expect(storedMemento.get(lightStateKey)).toEqual(
+      expect.objectContaining({
+        original: "neutral",
+        releasedBy: "workspace:file:///workspace-a.code-workspace"
+      })
+    );
+
+    updateCalls.length = 0;
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([{ key: "darkModeTheme", value: "dark", target: 1 }]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "dark"
+    });
+  });
+
+  it("keeps a released takeover when another transaction fails to finalize", async () => {
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    let releaseClaim = () => {};
+    const claimGate = new Promise<void>((resolve) => {
+      releaseClaim = resolve;
+    });
+    const { memento, storedMemento } = createControlledMemento(async ({ callNumber, persist }) => {
+      if (callNumber === 4) throw new Error("Failed to finalize Mermaid state");
+      await persist();
+      if (callNumber === 1) await claimGate;
+    });
 
     const synchronization = updateMermaidThemeSync(memento);
     await vi.waitFor(() =>

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -24,6 +24,7 @@ let updateGates = new Map<string, Promise<void>>();
 let updateFailureCalls = new Set<number>();
 let updateGateCalls = new Map<number, Promise<void>>();
 let updateNoopCalls = new Set<number>();
+let updateObservedValues = new Map<number, string | undefined>();
 
 function getEffectiveMermaidConfig(): Record<string, string | undefined> {
   return {
@@ -66,10 +67,13 @@ vi.mock("vscode", () => ({
               if (updateNoopCalls.has(callNumber)) {
                 return;
               }
+              const observedValue = updateObservedValues.has(callNumber)
+                ? updateObservedValues.get(callNumber)
+                : value;
               if (target === 2) {
-                mermaidWorkspaceConfig[key] = value;
+                mermaidWorkspaceConfig[key] = observedValue;
               } else {
-                mermaidGlobalConfig[key] = value;
+                mermaidGlobalConfig[key] = observedValue;
               }
             }
           };
@@ -108,6 +112,7 @@ describe("Mermaid theme synchronization", () => {
     updateFailureCalls = new Set();
     updateGateCalls = new Map();
     updateNoopCalls = new Set();
+    updateObservedValues = new Map();
   });
 
   it("configures both Mermaid slots from the system-mode light and dark themes", async () => {
@@ -175,6 +180,31 @@ describe("Mermaid theme synchronization", () => {
     expect(memento.get("githubMarkdown.mermaid.themeState.v2.global.dark")).toEqual(
       expect.objectContaining({ applied: "dark" })
     );
+  });
+
+  it("does not retry over a third-party value observed after a configuration update", async () => {
+    const memento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    updateObservedValues.set(1, "base");
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "default", target: 1 },
+      { key: "darkModeTheme", value: "dark", target: 1 }
+    ]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "dark"
+    });
+    expect(memento.get(lightStateKey)).toEqual(
+      expect.objectContaining({
+        original: "neutral",
+        releasedBy: "workspace:file:///workspace-a.code-workspace"
+      })
+    );
+    expect(memento.get(lightStateKey)).not.toHaveProperty("pending");
+    expect(memento.get(lightStateKey)).not.toHaveProperty("applied");
   });
 
   it("waits for the first configuration write to settle before starting the second", async () => {
@@ -881,6 +911,96 @@ describe("Mermaid theme synchronization", () => {
           desired: "default",
           previous: "neutral"
         }
+      })
+    );
+  });
+
+  it("preserves a user takeover while the apply claim is being persisted", async () => {
+    const storedMemento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    let releaseClaim = () => {};
+    const claimGate = new Promise<void>((resolve) => {
+      releaseClaim = resolve;
+    });
+    let shouldGateClaim = true;
+    const memento: typeof storedMemento = {
+      get: <T>(key: string, defaultValue?: T) => storedMemento.get(key, defaultValue),
+      update: async (key: string, value: unknown) => {
+        await storedMemento.update(key, value);
+        if (key === lightStateKey && shouldGateClaim) {
+          shouldGateClaim = false;
+          await claimGate;
+        }
+      },
+      keys: () => storedMemento.keys()
+    };
+
+    const synchronization = updateMermaidThemeSync(memento);
+    await vi.waitFor(() =>
+      expect(storedMemento.get(lightStateKey)).toEqual(
+        expect.objectContaining({
+          pending: { kind: "apply", desired: "default", previous: "neutral" }
+        })
+      )
+    );
+    mermaidGlobalConfig["lightModeTheme"] = "base";
+    releaseClaim();
+    await synchronization;
+
+    expect(updateCalls).toEqual([{ key: "darkModeTheme", value: "dark", target: 1 }]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "dark"
+    });
+    expect(storedMemento.get(lightStateKey)).toEqual(
+      expect.objectContaining({
+        original: "neutral",
+        releasedBy: "workspace:file:///workspace-a.code-workspace"
+      })
+    );
+    expect(storedMemento.get(lightStateKey)).not.toHaveProperty("pending");
+    expect(storedMemento.get(lightStateKey)).not.toHaveProperty("applied");
+  });
+
+  it("keeps a released takeover when another transaction fails to finalize", async () => {
+    const storedMemento = createTestMemento();
+    const lightStateKey = "githubMarkdown.mermaid.themeState.v2.global.light";
+    let releaseClaim = () => {};
+    const claimGate = new Promise<void>((resolve) => {
+      releaseClaim = resolve;
+    });
+    let updateCount = 0;
+    const memento: typeof storedMemento = {
+      get: <T>(key: string, defaultValue?: T) => storedMemento.get(key, defaultValue),
+      update: async (key: string, value: unknown) => {
+        updateCount += 1;
+        if (updateCount === 4) throw new Error("Failed to finalize Mermaid state");
+        await storedMemento.update(key, value);
+        if (updateCount === 1) await claimGate;
+      },
+      keys: () => storedMemento.keys()
+    };
+
+    const synchronization = updateMermaidThemeSync(memento);
+    await vi.waitFor(() =>
+      expect(storedMemento.get(lightStateKey)).toEqual(
+        expect.objectContaining({
+          pending: { kind: "apply", desired: "default", previous: "neutral" }
+        })
+      )
+    );
+    mermaidGlobalConfig["lightModeTheme"] = "base";
+    releaseClaim();
+    await expect(synchronization).rejects.toThrow("Failed to finalize Mermaid state");
+
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "base",
+      darkModeTheme: "forest"
+    });
+    expect(storedMemento.get(lightStateKey)).toEqual(
+      expect.objectContaining({
+        original: "neutral",
+        releasedBy: "workspace:file:///workspace-a.code-workspace"
       })
     );
   });


### PR DESCRIPTION
## 根因

Mermaid theme synchronization 需要跨 VS Code configuration 与 Memento journal 完成一组非原子操作。旧实现只在 transaction prepare 时判断 target ownership；用户可在 claim persistence 或 configuration settle 期间接管某个 slot，随后扩展仍写入或重试覆盖。后续修复虽然记录 released state，但当这次 release journal 写入本身短暂失败时，内部 partial rollback 会重新读取旧 pending claim 并将其删除，下一次同步仍可能覆盖用户选择。

## 修改内容

- 每次 primary 与 rollback 写入前重新核对 expected target value；观察到第三方值时停止写入并释放该 slot。
- configuration update resolve 后只有 target 仍等于 expected previous value 才允许 settle retry；第三方值不会被第二次覆盖。
- transaction 在尝试持久化 release 前先记录 in-memory ownership loss；release journal 首次写入失败时重试持久化。
- 若 journal 重试仍失败，internal rollback 通过 state key 保留旧 pending claim，使下一次 activation 能按当前配置 reconciliation，而不是消费接管记录。
- internal failure rollback 保留 released records；正常 sync-off/deactivation 仍会消费记录并恢复仍由扩展拥有的 Global/Workspace targets。
- 抽取 gated Memento test helper，清晰区分 claim、configuration failure、finalization failure 与 release persistence failure。

## TDD 证据

- claim-await takeover RED：用户改为 `base` 后旧实现仍写入 `default`；pre-write expected check 后通过。
- post-update takeover RED：观察到第三方 `base` 后旧实现 retry 两次；现在立即 release，不再重写。
- partial configuration/finalization failure RED：released journal 被另一个 transaction 的恢复流程清除；现在保留。
- release persistence RED：50 个定向测试中新增用例失败，失败返回后 light journal 为 `undefined`；修复后 journal 为 released，下一 sync 只更新 dark，不覆盖用户 `base`。定向 50/50。

## 兼容性与边界

- Global 与 Workspace targets、desktop 与 Web runtime 行为保持兼容；未引入 Node-only extension runtime API，也不提高最低 VS Code 版本。
- VS Code configuration 与 Memento 不提供跨 extension-host 原子 CAS；多 host 同时写入仍遵循平台的 last-writer 行为。本修复保证单 host 在写前、settle 后及持久化失败恢复中已经观察到的用户接管不会被覆盖。
- 现有 `[Unreleased]` Mermaid 条目已覆盖“newer user choices unchanged”，不重复新增 changelog 文案。

## 验证

- `nubx vitest run tests/integrations/mermaid.test.ts`：50 passed
- `nub run test:coverage`：50 files / 341 tests passed
- `nubx tsc --noEmit`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nub run build`
- pinned desktop preview：同一 profile 连续两次通过
- stable Web preview：通过
- pre-commit hook：format、lint、50 files / 341 tests 全部通过
