### PR TITLE
fix(host): budget preview IPC paths for long temp dirs

### DIFF
--- a/scripts/host/desktop-preview-profile.ts
+++ b/scripts/host/desktop-preview-profile.ts
@@ -6,7 +6,7 @@ const maximumMacOsIpcSocketPathBytes = 103;
 const macOsIpcSocketName = "1.12-main.sock";
 
 interface DesktopPreviewEnvironment {
-  canonicalTemporaryDirectory: string;
+  canonicalTemporaryDirectory?: string;
   platform: NodeJS.Platform;
   userIdentity: string;
 }
@@ -15,7 +15,7 @@ export function resolveDesktopPreviewDirectories(
   temporaryDirectory: string,
   version: string,
   projectRoot: string,
-  environment: DesktopPreviewEnvironment = desktopPreviewEnvironment(temporaryDirectory)
+  environment: DesktopPreviewEnvironment = desktopPreviewEnvironment()
 ): { extensionsDir: string; userDataDir: string } {
   const path = environment.platform === "win32" ? win32 : posix;
   const dataDir = path.join(temporaryDirectory, "vsgm-host-preview", version);
@@ -24,14 +24,14 @@ export function resolveDesktopPreviewDirectories(
   return {
     extensionsDir: path.join(dataDir, "extensions"),
     userDataDir:
-      environment.platform === "win32" || fitsMacOsIpcSocket(userDataDir)
-        ? userDataDir
-        : path.join(
-            environment.canonicalTemporaryDirectory,
+      environment.platform === "darwin" && !fitsMacOsIpcSocket(userDataDir)
+        ? path.join(
+            environment.canonicalTemporaryDirectory ?? shortTemporaryDirectory(temporaryDirectory),
             `vsgm-${stableId(`${environment.userIdentity}\0${temporaryDirectory}`)}`,
             stableId(version),
             projectId
           )
+        : userDataDir
   };
 }
 
@@ -45,17 +45,15 @@ function fitsMacOsIpcSocket(userDataDir: string): boolean {
   );
 }
 
-function desktopPreviewEnvironment(temporaryDirectory: string): DesktopPreviewEnvironment {
+function desktopPreviewEnvironment(): DesktopPreviewEnvironment {
   return {
-    canonicalTemporaryDirectory: shortTemporaryDirectory(temporaryDirectory, process.platform),
     platform: process.platform,
     userIdentity: typeof process.getuid === "function" ? String(process.getuid()) : "unknown"
   };
 }
 
-function shortTemporaryDirectory(temporaryDirectory: string, platform: NodeJS.Platform): string {
-  const path = platform === "win32" ? win32 : posix;
-  const rootTemporaryDirectory = path.join(path.parse(temporaryDirectory).root, "tmp");
+function shortTemporaryDirectory(temporaryDirectory: string): string {
+  const rootTemporaryDirectory = posix.join(posix.parse(temporaryDirectory).root, "tmp");
   try {
     return realpathSync.native(rootTemporaryDirectory);
   } catch {

--- a/scripts/host/desktop-preview-profile.ts
+++ b/scripts/host/desktop-preview-profile.ts
@@ -1,5 +1,9 @@
 import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { realpathSync } from "node:fs";
+import { join, parse } from "node:path";
+
+const maximumMacOsIpcSocketPathBytes = 103;
+const macOsIpcSocketName = "1.12-main.sock";
 
 export function resolveDesktopPreviewDirectories(
   temporaryDirectory: string,
@@ -7,9 +11,30 @@ export function resolveDesktopPreviewDirectories(
   projectRoot: string
 ): { extensionsDir: string; userDataDir: string } {
   const dataDir = join(temporaryDirectory, "vsgm-host-preview", version);
-  const projectId = createHash("sha256").update(projectRoot).digest("base64url").slice(0, 12);
+  const projectId = stableId(projectRoot);
+  const userDataDir = join(dataDir, projectId);
   return {
     extensionsDir: join(dataDir, "extensions"),
-    userDataDir: join(dataDir, projectId)
+    userDataDir:
+      process.platform === "win32" || fitsMacOsIpcSocket(userDataDir)
+        ? userDataDir
+        : join(shortTemporaryDirectory(temporaryDirectory), "vsgm", stableId(version), projectId)
   };
+}
+
+function stableId(value: string): string {
+  return createHash("sha256").update(value).digest("base64url").slice(0, 12);
+}
+
+function fitsMacOsIpcSocket(userDataDir: string): boolean {
+  return Buffer.byteLength(join(userDataDir, macOsIpcSocketName)) <= maximumMacOsIpcSocketPathBytes;
+}
+
+function shortTemporaryDirectory(temporaryDirectory: string): string {
+  const rootTemporaryDirectory = join(parse(temporaryDirectory).root, "tmp");
+  try {
+    return realpathSync.native(rootTemporaryDirectory);
+  } catch {
+    return rootTemporaryDirectory;
+  }
 }

--- a/scripts/host/desktop-preview-profile.ts
+++ b/scripts/host/desktop-preview-profile.ts
@@ -1,24 +1,37 @@
 import { createHash } from "node:crypto";
 import { realpathSync } from "node:fs";
-import { join, parse } from "node:path";
+import { posix, win32 } from "node:path";
 
 const maximumMacOsIpcSocketPathBytes = 103;
 const macOsIpcSocketName = "1.12-main.sock";
 
+interface DesktopPreviewEnvironment {
+  canonicalTemporaryDirectory: string;
+  platform: NodeJS.Platform;
+  userIdentity: string;
+}
+
 export function resolveDesktopPreviewDirectories(
   temporaryDirectory: string,
   version: string,
-  projectRoot: string
+  projectRoot: string,
+  environment: DesktopPreviewEnvironment = desktopPreviewEnvironment(temporaryDirectory)
 ): { extensionsDir: string; userDataDir: string } {
-  const dataDir = join(temporaryDirectory, "vsgm-host-preview", version);
+  const path = environment.platform === "win32" ? win32 : posix;
+  const dataDir = path.join(temporaryDirectory, "vsgm-host-preview", version);
   const projectId = stableId(projectRoot);
-  const userDataDir = join(dataDir, projectId);
+  const userDataDir = path.join(dataDir, projectId);
   return {
-    extensionsDir: join(dataDir, "extensions"),
+    extensionsDir: path.join(dataDir, "extensions"),
     userDataDir:
-      process.platform === "win32" || fitsMacOsIpcSocket(userDataDir)
+      environment.platform === "win32" || fitsMacOsIpcSocket(userDataDir)
         ? userDataDir
-        : join(shortTemporaryDirectory(temporaryDirectory), "vsgm", stableId(version), projectId)
+        : path.join(
+            environment.canonicalTemporaryDirectory,
+            `vsgm-${stableId(`${environment.userIdentity}\0${temporaryDirectory}`)}`,
+            stableId(version),
+            projectId
+          )
   };
 }
 
@@ -27,11 +40,22 @@ function stableId(value: string): string {
 }
 
 function fitsMacOsIpcSocket(userDataDir: string): boolean {
-  return Buffer.byteLength(join(userDataDir, macOsIpcSocketName)) <= maximumMacOsIpcSocketPathBytes;
+  return (
+    Buffer.byteLength(posix.join(userDataDir, macOsIpcSocketName)) <= maximumMacOsIpcSocketPathBytes
+  );
 }
 
-function shortTemporaryDirectory(temporaryDirectory: string): string {
-  const rootTemporaryDirectory = join(parse(temporaryDirectory).root, "tmp");
+function desktopPreviewEnvironment(temporaryDirectory: string): DesktopPreviewEnvironment {
+  return {
+    canonicalTemporaryDirectory: shortTemporaryDirectory(temporaryDirectory, process.platform),
+    platform: process.platform,
+    userIdentity: typeof process.getuid === "function" ? String(process.getuid()) : "unknown"
+  };
+}
+
+function shortTemporaryDirectory(temporaryDirectory: string, platform: NodeJS.Platform): string {
+  const path = platform === "win32" ? win32 : posix;
+  const rootTemporaryDirectory = path.join(path.parse(temporaryDirectory).root, "tmp");
   try {
     return realpathSync.native(rootTemporaryDirectory);
   } catch {

--- a/tests/scripts/host/desktop-preview-profile.test.ts
+++ b/tests/scripts/host/desktop-preview-profile.test.ts
@@ -30,4 +30,15 @@ describe("resolveDesktopPreviewDirectories", () => {
 
     expect(Buffer.byteLength(`${userDataDir}/1.12-main.sock`)).toBeLessThanOrEqual(103);
   });
+
+  it("keeps the macOS IPC socket within its byte budget for a long temporary directory", () => {
+    const longTemporaryDirectory = "/Users/example/a-very-long-workspace-specific-temp-directory";
+    const { userDataDir } = resolveDesktopPreviewDirectories(
+      longTemporaryDirectory,
+      "1.129.0",
+      "/worktrees/first/project"
+    );
+
+    expect(Buffer.byteLength(`${userDataDir}/1.12-main.sock`)).toBeLessThanOrEqual(103);
+  });
 });

--- a/tests/scripts/host/desktop-preview-profile.test.ts
+++ b/tests/scripts/host/desktop-preview-profile.test.ts
@@ -1,4 +1,4 @@
-import { basename } from "node:path";
+import { basename, posix, win32 } from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveDesktopPreviewDirectories } from "../../../scripts/host/desktop-preview-profile";
 
@@ -25,7 +25,12 @@ describe("resolveDesktopPreviewDirectories", () => {
     const { userDataDir } = resolveDesktopPreviewDirectories(
       macOsTemporaryDirectory,
       "1.129.0",
-      "/worktrees/first/project"
+      "/worktrees/first/project",
+      {
+        canonicalTemporaryDirectory: "/private/tmp",
+        platform: "darwin",
+        userIdentity: "501"
+      }
     );
 
     expect(Buffer.byteLength(`${userDataDir}/1.12-main.sock`)).toBeLessThanOrEqual(103);
@@ -36,9 +41,99 @@ describe("resolveDesktopPreviewDirectories", () => {
     const { userDataDir } = resolveDesktopPreviewDirectories(
       longTemporaryDirectory,
       "1.129.0",
-      "/worktrees/first/project"
+      "/worktrees/first/project",
+      {
+        canonicalTemporaryDirectory: "/private/tmp",
+        platform: "darwin",
+        userIdentity: "501"
+      }
     );
 
     expect(Buffer.byteLength(`${userDataDir}/1.12-main.sock`)).toBeLessThanOrEqual(103);
+  });
+
+  it("isolates fallback profiles between operating-system users", () => {
+    const longTemporaryDirectory = "/Users/example/a-very-long-workspace-specific-temp-directory";
+    const canonicalTemporaryDirectory = "/private/tmp";
+    const firstUser = resolveDesktopPreviewDirectories(
+      longTemporaryDirectory,
+      "1.129.0",
+      "/worktrees/first/project",
+      { canonicalTemporaryDirectory, platform: "darwin", userIdentity: "501" }
+    );
+    const firstUserAgain = resolveDesktopPreviewDirectories(
+      longTemporaryDirectory,
+      "1.129.0",
+      "/worktrees/first/project",
+      { canonicalTemporaryDirectory, platform: "darwin", userIdentity: "501" }
+    );
+    const secondUser = resolveDesktopPreviewDirectories(
+      longTemporaryDirectory,
+      "1.129.0",
+      "/worktrees/first/project",
+      { canonicalTemporaryDirectory, platform: "darwin", userIdentity: "502" }
+    );
+
+    const firstNamespace = posix
+      .relative(canonicalTemporaryDirectory, firstUser.userDataDir)
+      .split(posix.sep)[0];
+    const secondNamespace = posix
+      .relative(canonicalTemporaryDirectory, secondUser.userDataDir)
+      .split(posix.sep)[0];
+    expect(firstNamespace).toMatch(/^vsgm-[0-9A-Za-z_-]+$/);
+    expect(firstNamespace).not.toBe(secondNamespace);
+    expect(firstUser).toEqual(firstUserAgain);
+    expect(firstUser.extensionsDir).toBe(secondUser.extensionsDir);
+  });
+
+  it("applies the short IPC profile only on POSIX platforms", () => {
+    const version = "1.129.0";
+    const projectRoot = "/worktrees/first/project";
+    const longPosixTemporaryDirectory =
+      "/Users/example/a-very-long-workspace-specific-temp-directory";
+    const darwin = resolveDesktopPreviewDirectories(
+      longPosixTemporaryDirectory,
+      version,
+      projectRoot,
+      {
+        canonicalTemporaryDirectory: "/private/tmp",
+        platform: "darwin",
+        userIdentity: "501"
+      }
+    );
+    const linux = resolveDesktopPreviewDirectories(
+      longPosixTemporaryDirectory,
+      version,
+      projectRoot,
+      {
+        canonicalTemporaryDirectory: "/private/tmp",
+        platform: "linux",
+        userIdentity: "501"
+      }
+    );
+
+    const longWindowsTemporaryDirectory = String.raw`C:\Users\example\a-very-long-workspace-specific-temp-directory`;
+    const windows = resolveDesktopPreviewDirectories(
+      longWindowsTemporaryDirectory,
+      version,
+      String.raw`C:\worktrees\first\project`,
+      {
+        canonicalTemporaryDirectory: String.raw`C:\Windows\Temp`,
+        platform: "win32",
+        userIdentity: "501"
+      }
+    );
+
+    expect(Buffer.byteLength(posix.join(darwin.userDataDir, "1.12-main.sock"))).toBeLessThanOrEqual(
+      103
+    );
+    expect(darwin.userDataDir).toMatch(/^\/private\/tmp\/vsgm-[0-9A-Za-z_-]+\//);
+    expect(linux).toEqual(darwin);
+    expect(win32.dirname(windows.userDataDir)).toBe(
+      win32.join(longWindowsTemporaryDirectory, "vsgm-host-preview", version)
+    );
+    expect(windows.extensionsDir).toBe(
+      win32.join(longWindowsTemporaryDirectory, "vsgm-host-preview", version, "extensions")
+    );
   });
 });

--- a/tests/scripts/host/desktop-preview-profile.test.ts
+++ b/tests/scripts/host/desktop-preview-profile.test.ts
@@ -1,4 +1,4 @@
-import { basename, posix, win32 } from "node:path";
+import { basename, posix } from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveDesktopPreviewDirectories } from "../../../scripts/host/desktop-preview-profile";
 
@@ -86,7 +86,7 @@ describe("resolveDesktopPreviewDirectories", () => {
     expect(firstUser.extensionsDir).toBe(secondUser.extensionsDir);
   });
 
-  it("applies the short IPC profile only on POSIX platforms", () => {
+  it("uses the short IPC profile only on macOS", () => {
     const version = "1.129.0";
     const projectRoot = "/worktrees/first/project";
     const longPosixTemporaryDirectory =
@@ -106,7 +106,9 @@ describe("resolveDesktopPreviewDirectories", () => {
       version,
       projectRoot,
       {
-        canonicalTemporaryDirectory: "/private/tmp",
+        get canonicalTemporaryDirectory(): string {
+          throw new Error("Linux must not resolve the macOS short temp directory");
+        },
         platform: "linux",
         userIdentity: "501"
       }
@@ -118,7 +120,9 @@ describe("resolveDesktopPreviewDirectories", () => {
       version,
       String.raw`C:\worktrees\first\project`,
       {
-        canonicalTemporaryDirectory: String.raw`C:\Windows\Temp`,
+        get canonicalTemporaryDirectory(): string {
+          throw new Error("Windows must not resolve the macOS short temp directory");
+        },
         platform: "win32",
         userIdentity: "501"
       }
@@ -127,13 +131,18 @@ describe("resolveDesktopPreviewDirectories", () => {
     expect(Buffer.byteLength(posix.join(darwin.userDataDir, "1.12-main.sock"))).toBeLessThanOrEqual(
       103
     );
-    expect(darwin.userDataDir).toMatch(/^\/private\/tmp\/vsgm-[0-9A-Za-z_-]+\//);
-    expect(linux).toEqual(darwin);
-    expect(win32.dirname(windows.userDataDir)).toBe(
-      win32.join(longWindowsTemporaryDirectory, "vsgm-host-preview", version)
+    expect(darwin.userDataDir).toBe("/private/tmp/vsgm-TMEvqyfJs8Qg/fvPC_ef8LPLl/cYMkdORUhW-W");
+    expect(linux.userDataDir).toBe(
+      "/Users/example/a-very-long-workspace-specific-temp-directory/vsgm-host-preview/1.129.0/cYMkdORUhW-W"
+    );
+    expect(linux.extensionsDir).toBe(
+      "/Users/example/a-very-long-workspace-specific-temp-directory/vsgm-host-preview/1.129.0/extensions"
+    );
+    expect(windows.userDataDir).toBe(
+      String.raw`C:\Users\example\a-very-long-workspace-specific-temp-directory\vsgm-host-preview\1.129.0\NnLlm78TWwha`
     );
     expect(windows.extensionsDir).toBe(
-      win32.join(longWindowsTemporaryDirectory, "vsgm-host-preview", version, "extensions")
+      String.raw`C:\Users\example\a-very-long-workspace-specific-temp-directory\vsgm-host-preview\1.129.0\extensions`
     );
   });
 });


### PR DESCRIPTION
## 根因

桌面 preview profile 虽然把 project 标识缩短到 12 个字符，但 `userDataDir` 仍完整继承 `os.tmpdir()`。当 macOS 开发环境设置了较长的 `TMPDIR` 时，VS Code 的 IPC socket 路径仍可能超过 103-byte 限制，导致 preview host 启动失败。

首版 fallback 还存在两个边界问题：所有 POSIX 用户共享 canonical temp 顶层 `vsgm`，第一个创建该目录的用户可能阻止其他用户进入；同时把 Linux 也切换到 macOS short-temp fallback，破坏了 Linux 自定义 `TMPDIR`/XDG 环境应保留的 version-scoped profile 位置。

## 修改内容

- 在公开的 `resolveDesktopPreviewDirectories` seam 中按完整 socket 路径的 UTF-8 byte length 判断是否超出预算，并注入 platform、user identity 与 canonical temp 供确定性验证；生产 platform 和 uid 仍来自当前 Node host。
- 只有 Darwin 且完整 socket 超预算时才解析 canonical short temp 并切换 `userDataDir`；Linux 和 Windows 完全不读取 short-temp 依赖。
- Darwin fallback 直接在 canonical temp 下使用 `vsgm-<stable user namespace>`。namespace 由 POSIX uid 与原始 `TMPDIR` 的 SHA-256 短标识组成，不暴露 uid、temp 或 project root，也不再创建共享的 `/private/tmp/vsgm` 父目录。
- 同一用户、原始 temp、version 与 project root 得到稳定 profile；不同用户和不同 project root 相互隔离。
- Linux 保留原始 POSIX temporary directory 下的 version-scoped `userDataDir`，维持自定义 `TMPDIR`/XDG 语义；Windows 使用 `path.win32` 并保留原 Windows profile 路径。
- `extensionsDir` 始终保留在原 temporary directory 的 version cache 中，VS Code download cache 也不受影响。

## TDD 证据

- 初始 RED：长 `TMPDIR` 的完整 socket 为 114 bytes；定向测试 `1 failed / 2 passed`。
- 用户 namespace RED：user 501/502 在相同 temp/project/version 下都落入顶层 `vsgm`；定向测试 `1 failed / 3 passed`。
- 用户 namespace GREEN：直接生成不同的 `vsgm-<hash>` 顶层目录，同一用户重复调用稳定；定向测试 `4 passed`。
- platform seam RED：显式 `platform: "win32"` 仍被宿主 POSIX 逻辑错误 fallback，并产生混合分隔符路径；定向测试 `1 failed / 4 passed`。
- platform path GREEN：使用独立 `path.posix`/`path.win32` 语义后，Windows 保留原路径；定向测试 `5 passed`。
- 终审 Linux RED：独立 literal oracle 期望 Linux 保留 `/Users/.../vsgm-host-preview/1.129.0/cYMkdORUhW-W`，实际仍收到 Darwin fallback `/private/tmp/vsgm-TMEvqyfJs8Qg/fvPC_ef8LPLl/cYMkdORUhW-W`；定向测试 `1 failed / 4 passed`。
- 终审 GREEN：Darwin literal 使用 short profile 且 socket `<=103`；Linux/Windows literal 均保留原 version-scoped 路径，并用会抛错的 canonical-temp getter 确认两个平台不读取该依赖；定向测试 `5 passed`。

## 验证

- `nubx vitest run tests/scripts/host/desktop-preview-profile.test.ts`：5 passed
- `nub run test`：50 files / 339 tests passed
- `nubx tsc --noEmit`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nub run build`
- `nub run verify:parity`：受控用例 zero diff；既有 host integration boundaries 在预算内
- 显式长 `TMPDIR` 下 `nub run test:host:desktop:preview`：同一 71-byte socket profile 连续两次通过，第二次复用 VS Code 安装
- `nub run test:host:web:preview`：通过
- pre-commit hook：format、lint、50 files / 339 tests 全部通过

## CHANGELOG

省略。本次仅修复内部 host 验证基础设施，不改变扩展用户可观察行为，符合项目 changelog 对 tests/verification infrastructure 的排除规则。
