### PR TITLE
fix(deps): update entities to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "release:note": "nub scripts/release/index.ts"
   },
   "dependencies": {
-    "entities": "4.5.0",
+    "entities": "8.0.0",
     "unicode-case-folding": "1.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,8 +208,8 @@ importers:
   .:
     dependencies:
       entities:
-        specifier: 4.5.0
-        version: 4.5.0
+        specifier: 8.0.0
+        version: 8.0.0
       unicode-case-folding:
         specifier: 1.1.1
         version: 1.1.1
@@ -1799,6 +1799,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -4837,6 +4841,8 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import type MarkdownIt from "markdown-it";
-import { decodeCodePoint } from "entities/lib/decode.js";
+import { replaceCodePoint } from "entities/decode";
 
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const projectRootSrcAttributePattern =
@@ -37,7 +37,7 @@ function decodeHtmlAttribute(value: string, decodeNamedEntity: (value: string) =
     if (reference.startsWith("&#")) {
       const hexadecimal = reference[2]?.toLowerCase() === "x";
       const digits = reference.slice(hexadecimal ? 3 : 2, reference.endsWith(";") ? -1 : undefined);
-      return decodeCodePoint(Number.parseInt(digits, hexadecimal ? 16 : 10));
+      return String.fromCodePoint(replaceCodePoint(Number.parseInt(digits, hexadecimal ? 16 : 10)));
     }
 
     if (reference.endsWith(";")) return decodeNamedEntity(reference);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   clean: false,
   publint: true,
   deps: {
-    alwaysBundle: ["entities/lib/decode.js", "unicode-case-folding"],
+    alwaysBundle: ["entities/decode", "unicode-case-folding"],
     neverBundle: ["vscode"],
     onlyBundle: ["entities", "unicode-case-folding"]
   },


### PR DESCRIPTION
## 背景

项目为 Raw HTML 图片属性的 numeric character reference 使用 `entities` code-point compatibility/error mapping。直接依赖仍固定在 `4.5.0`，而 npm latest 已是 `8.0.0`；v8 同时移除了旧的 `entities/lib/decode.js` export 与 `decodeCodePoint` API。

## 修改

- 将直接 production dependency 从 `entities@4.5.0` 更新到 `entities@8.0.0`。
- 迁移到公开 subpath `entities/decode` 与 `replaceCodePoint`，再通过 `String.fromCodePoint` 保持既有字符串结果。
- 更新 tsdown 的 explicit bundle subpath；extension 与 Web host smoke bundle 继续 self-contained。
- 不改变 named/legacy entity、quoted/unquoted Raw HTML 图片或 VS Code RenderEnv 行为。

## TDD 证据

- RED：仅更新依赖后，`tsc` 精确失败：`TS2307: Cannot find module 'entities/lib/decode.js'`；build 同步失败。
- GREEN：迁移公开 v8 API 后，public `MarkdownIt.render(rawHtml, RenderEnv)` 定向测试 23/23；Windows-1252 remap、null、surrogate、out-of-range numeric references 保持浏览器语义。

## 兼容性

- v8 要求 Node `>=20.19.0`，项目固定开发运行时为 Node `24.19.0`。
- npm 依赖完全 bundle 到 extension；VSIX 不包含 `node_modules`，最低 VS Code `^1.74.0` 不会直接加载 v8 package。
- extension bundle 为 106.30 kB，生产与 host bundle 均无外部 `entities` import/require。
- 这是内部依赖/API 迁移，无新增用户可见结果；按 changelog admission rules 有意省略 `CHANGELOG.md`。

## 验证

- targeted public RenderEnv seam：1 file / 23 tests passed
- full/pre-commit：50 files / 357 tests passed
- `nub run test:coverage`
- `nubx tsc --noEmit`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `pnpm audit --prod`：No known vulnerabilities
- `nub run build`
- `nub run verify:parity`
- `nub run test:host:web`
- VS Code 1.129 desktop preview：同一 profile 连续两次通过

## VSIX 审计

- baseline：90,623 B；current：90,551 B；变化 `-72 B (-0.08%)`，package audit PASS。
- baseline/current 均为 24 个文件，added/removed 均为空。
- forbidden-pattern 命中为 0：无 `node_modules`、源码、测试、脚本、缓存、source map、日志、临时文件或工具配置。
