### PR TITLE
fix(preview): align code copy controls with GitHub themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+### Themes and appearance
+
+- Code blocks now show GitHub's muted copy icon and success icon directly in the top-right corner, without separate resting button chrome, while keeping their colors and hover feedback aligned with the active preview theme.
+
 ## [v4.4.3] - 2026-08-08
 
 v4.4.3 makes theme controls and Mermaid synchronization behave predictably with workspace-level settings. It also improves project-root images in nested Markdown files and keeps Simplified Chinese theme pickers fully localized.

--- a/scripts/host/preview.ts
+++ b/scripts/host/preview.ts
@@ -35,6 +35,12 @@ async function assertThemeRendering(page: Page): Promise<void> {
   await selectQuickPick(page, "GitHub Markdown: Change Theme Mode", "Single theme");
   await selectQuickPick(page, "Preferences: Color Theme", "Light Modern");
   await refreshPreview(page);
+  const copyButtonAvailable = await hasCodeCopyButton(page);
+  if (!copyButtonAvailable) {
+    console.warn(
+      "[host-preview] built-in code copy button is unavailable; skipping its rendering assertions"
+    );
+  }
 
   const singleCases = [
     ["Light", { mode: "light", light: "light", dark: "dark" }],
@@ -61,7 +67,7 @@ async function assertThemeRendering(page: Page): Promise<void> {
     );
     if (label === "Light") lightPalette = palette;
     if (label === "Dark dimmed") darkPalette = palette;
-    await assertCodeCopyButtonTheme(page, label);
+    if (copyButtonAvailable) await assertCodeCopyButtonTheme(page, label);
     previousMode = expectation.mode;
     previousPalette = palette;
   }
@@ -106,7 +112,23 @@ async function assertThemeRendering(page: Page): Promise<void> {
     dark: "dark_tritanopia",
     body: "vscode-dark"
   });
-  await assertCodeCopyButtonTheme(page, "VS Code theme");
+  if (copyButtonAvailable) await assertCodeCopyButtonTheme(page, "VS Code theme");
+}
+
+async function hasCodeCopyButton(page: Page, timeoutMs = 2_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const frame of page.frames()) {
+      try {
+        if (!(await frame.locator(".vscode-github-markdown").count())) continue;
+        if (await frame.locator(".code-block-copy-button").count()) return true;
+      } catch {
+        // Preview frames can be replaced while detecting host capabilities.
+      }
+    }
+    await page.waitForTimeout(100);
+  }
+  return false;
 }
 
 async function assertCodeCopyButtonTheme(page: Page, theme: string): Promise<void> {

--- a/scripts/host/preview.ts
+++ b/scripts/host/preview.ts
@@ -23,7 +23,7 @@ type MermaidPalette = {
 };
 
 type ThemeExpectation = {
-  mode: "auto" | "dark" | "light";
+  mode: "auto" | "dark" | "light" | "vscode";
   light: string;
   dark: string;
   body?: "vscode-dark" | "vscode-light";
@@ -33,13 +33,19 @@ async function assertThemeRendering(page: Page): Promise<void> {
   await selectQuickPick(page, "GitHub Markdown: Change Light Theme", "Light");
   await selectQuickPick(page, "GitHub Markdown: Change Dark Theme", "Dark");
   await selectQuickPick(page, "GitHub Markdown: Change Theme Mode", "Single theme");
+  await selectQuickPick(page, "Preferences: Color Theme", "Light Modern");
+  await refreshPreview(page);
 
   const singleCases = [
     ["Light", { mode: "light", light: "light", dark: "dark" }],
-    ["Dark dimmed", { mode: "dark", light: "light", dark: "dark_dimmed" }],
     ["Light Protanopia & Deuteranopia", { mode: "light", light: "light_colorblind", dark: "dark" }],
     ["Light high contrast", { mode: "light", light: "light_high_contrast", dark: "dark" }],
-    ["Light Tritanopia", { mode: "light", light: "light_tritanopia", dark: "dark" }]
+    ["Light Tritanopia", { mode: "light", light: "light_tritanopia", dark: "dark" }],
+    ["Dark", { mode: "dark", light: "light", dark: "dark" }],
+    ["Dark Protanopia & Deuteranopia", { mode: "dark", light: "light", dark: "dark_colorblind" }],
+    ["Dark dimmed", { mode: "dark", light: "light", dark: "dark_dimmed" }],
+    ["Dark high contrast", { mode: "dark", light: "light", dark: "dark_high_contrast" }],
+    ["Dark Tritanopia", { mode: "dark", light: "light", dark: "dark_tritanopia" }]
   ] as const;
 
   let lightPalette: MermaidPalette | undefined;
@@ -55,6 +61,7 @@ async function assertThemeRendering(page: Page): Promise<void> {
     );
     if (label === "Light") lightPalette = palette;
     if (label === "Dark dimmed") darkPalette = palette;
+    await assertCodeCopyButtonTheme(page, label);
     previousMode = expectation.mode;
     previousPalette = palette;
   }
@@ -90,6 +97,114 @@ async function assertThemeRendering(page: Page): Promise<void> {
     },
     darkPalette
   );
+
+  await selectQuickPick(page, "GitHub Markdown: Change Theme Mode", "VS Code theme");
+  await refreshPreview(page);
+  await waitForThemedPreview(page, {
+    mode: "vscode",
+    light: "light_high_contrast",
+    dark: "dark_tritanopia",
+    body: "vscode-dark"
+  });
+  await assertCodeCopyButtonTheme(page, "VS Code theme");
+}
+
+async function assertCodeCopyButtonTheme(page: Page, theme: string): Promise<void> {
+  const state = await readCodeCopyButtonState(page);
+  assert(
+    state.buttonColor === state.expectedMuted && state.svgBackground === state.expectedMuted,
+    `code copy icon uses the muted default color in ${theme}; observed ${JSON.stringify(state)}`
+  );
+  assert(
+    state.buttonBackground === "rgba(0, 0, 0, 0)" && state.buttonBorderWidth === "0px",
+    `code copy icon has no resting button chrome; observed ${JSON.stringify(state)}`
+  );
+  assert(
+    state.buttonWidth === "28px" &&
+      state.buttonHeight === "28px" &&
+      state.buttonBorderRadius === "6px" &&
+      state.buttonOpacity === "1",
+    `code copy icon matches GitHub's visible 28px control; observed ${JSON.stringify(state)}`
+  );
+  assert(
+    state.svgMaskImage !== "none" && state.pathDisplay === "none",
+    `code copy icon uses the GitHub Octicon mask; observed ${JSON.stringify(state)}`
+  );
+  assert(
+    state.parentTag === "PRE" &&
+      state.buttonPosition === "absolute" &&
+      state.buttonTop === "8px" &&
+      state.buttonRight === "8px",
+    `code copy icon sits directly in the code block; observed ${JSON.stringify(state)}`
+  );
+  assert(
+    state.copiedMaskImage !== state.svgMaskImage && state.copiedColor === state.expectedSuccess,
+    `copied feedback uses the GitHub check icon; observed ${JSON.stringify(state)}`
+  );
+  assert(
+    state.centerOffset.x === 0 && state.centerOffset.y === 0,
+    `code copy icon stays centered; observed ${JSON.stringify(state)}`
+  );
+}
+
+async function readCodeCopyButtonState(page: Page) {
+  for (const frame of page.frames()) {
+    if (!(await frame.locator(".vscode-github-markdown").count())) continue;
+    const button = frame.locator(".code-block-copy-button").first();
+    await button.waitFor({ state: "attached", timeout: 2_000 });
+    return button.evaluate((element) => {
+      const svg = element.querySelector("svg");
+      const path = svg?.querySelector("path");
+      const root = element.closest<HTMLElement>(".vscode-github-markdown");
+      if (!svg || !path || !root) throw new Error("Incomplete code copy button DOM");
+
+      const resolveColor = (token: string): string => {
+        const probe = document.createElement("span");
+        probe.style.color = `var(${token})`;
+        root.append(probe);
+        const color = getComputedStyle(probe).color;
+        probe.remove();
+        return color;
+      };
+      const buttonRect = element.getBoundingClientRect();
+      const svgRect = svg.getBoundingClientRect();
+      const buttonStyle = getComputedStyle(element);
+      const svgStyle = getComputedStyle(svg);
+      const svgMaskImage = svgStyle.maskImage || svgStyle.webkitMaskImage;
+      const expectedSuccess = resolveColor("--fgColor-success");
+      element.classList.add("copied");
+      const copiedStyle = getComputedStyle(element);
+      const copiedSvgStyle = getComputedStyle(svg);
+      const copiedColor = copiedStyle.color;
+      const copiedMaskImage = copiedSvgStyle.maskImage || copiedSvgStyle.webkitMaskImage;
+      element.classList.remove("copied");
+      return {
+        parentTag: element.parentElement?.tagName,
+        buttonPosition: buttonStyle.position,
+        buttonTop: buttonStyle.top,
+        buttonRight: buttonStyle.right,
+        buttonColor: buttonStyle.color,
+        buttonBackground: buttonStyle.backgroundColor,
+        buttonBorderWidth: buttonStyle.borderTopWidth,
+        buttonBorderRadius: buttonStyle.borderRadius,
+        buttonWidth: buttonStyle.width,
+        buttonHeight: buttonStyle.height,
+        buttonOpacity: buttonStyle.opacity,
+        svgBackground: svgStyle.backgroundColor,
+        svgMaskImage,
+        copiedColor,
+        copiedMaskImage,
+        pathDisplay: getComputedStyle(path).display,
+        expectedMuted: resolveColor("--fgColor-muted"),
+        expectedSuccess,
+        centerOffset: {
+          x: svgRect.x + svgRect.width / 2 - (buttonRect.x + buttonRect.width / 2),
+          y: svgRect.y + svgRect.height / 2 - (buttonRect.y + buttonRect.height / 2)
+        }
+      };
+    });
+  }
+  throw new Error("Code copy button preview frame not found");
 }
 
 async function selectColorTheme(

--- a/src/extension.preview.css
+++ b/src/extension.preview.css
@@ -40,6 +40,54 @@ body,
     color: inherit;
   }
 
+  .code-block-copy-button {
+    --copy-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z'/%3E%3Cpath d='M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z'/%3E%3C/svg%3E");
+    --check-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z'/%3E%3C/svg%3E");
+
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    color: var(--fgColor-muted);
+    background-color: transparent;
+    border: 0;
+    border-radius: 6px;
+    opacity: 1;
+    transition: none;
+
+    &:hover,
+    &:active {
+      background-color: var(--bgColor-neutral-muted);
+    }
+
+    svg {
+      display: block;
+      width: 16px;
+      height: 16px;
+      background-color: currentColor;
+      -webkit-mask: var(--copy-icon) center / contain no-repeat;
+      mask: var(--copy-icon) center / contain no-repeat;
+
+      path {
+        display: none;
+      }
+    }
+
+    &.copied {
+      color: var(--fgColor-success);
+
+      svg {
+        -webkit-mask-image: var(--check-icon);
+        mask-image: var(--check-icon);
+      }
+    }
+  }
+
   .data-footnote-backref,
   [data-footnote-ref] {
     text-decoration: none;

--- a/tests/fixtures/host/client-rendering.md
+++ b/tests/fixtures/host/client-rendering.md
@@ -5,6 +5,10 @@ flowchart LR
   alpha[Alpha] --> beta[Beta]
 ```
 
+```ts
+const themedCopyIcon = true;
+```
+
 $$
 \begin{aligned}
 S_1 &= a_1 + a_2 + a_3 + a_4 + a_5 + a_6 + a_7 + a_8 + a_9 + a_{10} \\

--- a/tests/preview-css.test.ts
+++ b/tests/preview-css.test.ts
@@ -45,6 +45,24 @@ describe("preview theme CSS", () => {
     }
   });
 
+  it("maps code block copy controls to the active preview theme", () => {
+    const previewRootCss = extractCssBlock(previewCss, ".vscode-github-markdown {");
+
+    expect(previewRootCss).toContain(".code-block-copy-button {");
+    expect(previewRootCss).toContain("color: var(--fgColor-muted)");
+    expect(previewRootCss).toContain("background-color: transparent");
+    expect(previewRootCss).toContain("border: 0");
+    expect(previewRootCss).toContain("border-radius: 6px");
+    expect(previewRootCss).toContain("opacity: 1");
+    expect(previewRootCss).toContain("transition: none");
+    expect(previewRootCss).toContain("background-color: var(--bgColor-neutral-muted)");
+    expect(previewRootCss).toContain("M0 6.75C0 5.784.784 5 1.75 5h1.5");
+    expect(previewRootCss).toContain("M5 1.75C5 .784 5.784 0 6.75 0h7.5");
+    expect(previewRootCss).toContain("M13.78 4.22a.75.75 0 0 1 0 1.06");
+    expect(previewRootCss).toContain("&.copied {");
+    expect(previewRootCss).toContain("color: var(--fgColor-success)");
+  });
+
   it("keeps high-contrast foreground, links, and focus outlines readable", () => {
     expect(previewCss).toContain("body.vscode-high-contrast");
     expect(previewCss).toContain("body.vscode-high-contrast-light");

--- a/tests/scripts/host/preview.test.ts
+++ b/tests/scripts/host/preview.test.ts
@@ -33,6 +33,27 @@ describe("assertClientRenderedPreview", () => {
 
     expect(preview.readPalette()).toEqual(darkPalette);
   });
+
+  it("checks the code copy button across every GitHub theme and VS Code theme mode", async () => {
+    vi.useFakeTimers();
+    const preview = createThemePreviewPage();
+
+    await expect(assertClientRenderedPreview(preview.page)).resolves.toBeUndefined();
+
+    expect(preview.readSingleThemeSelections()).toEqual([
+      "Light",
+      "Light Protanopia & Deuteranopia",
+      "Light high contrast",
+      "Light Tritanopia",
+      "Dark",
+      "Dark Protanopia & Deuteranopia",
+      "Dark dimmed",
+      "Dark high contrast",
+      "Dark Tritanopia"
+    ]);
+    expect(preview.readThemeModeSelections()).toContain("VS Code theme");
+    expect(preview.readCopyButtonEvaluations()).toBe(10);
+  });
 });
 
 describe("assertFinalClientRendering", () => {
@@ -83,29 +104,38 @@ function createPreviewFrame({
 type ThemePreviewState = {
   activeCommand: string | undefined;
   body: "vscode-dark" | "vscode-light";
+  copyButtonEvaluations: number;
   dark: string;
   inputValue: string;
   light: string;
-  mode: "auto" | "dark" | "light";
+  mode: "auto" | "dark" | "light" | "vscode";
   palette: MermaidPalette;
   pendingPalette: MermaidPalette | undefined;
   quickInputVisible: boolean;
+  singleThemeSelections: string[];
+  themeModeSelections: string[];
 };
 
 function createThemePreviewPage(): {
   page: Page;
+  readCopyButtonEvaluations: () => number;
   readPalette: () => MermaidPalette;
+  readSingleThemeSelections: () => string[];
+  readThemeModeSelections: () => string[];
 } {
   const state: ThemePreviewState = {
     activeCommand: undefined,
     body: "vscode-light",
+    copyButtonEvaluations: 0,
     dark: "dark",
     inputValue: "",
     light: "light",
     mode: "light",
     palette: lightPalette,
     pendingPalette: undefined,
-    quickInputVisible: false
+    quickInputVisible: false,
+    singleThemeSelections: [],
+    themeModeSelections: []
   };
   const frame = createThemeFrame(state);
   const page = {
@@ -125,7 +155,13 @@ function createThemePreviewPage(): {
     }
   } as unknown as Page;
 
-  return { page, readPalette: () => state.palette };
+  return {
+    page,
+    readCopyButtonEvaluations: () => state.copyButtonEvaluations,
+    readPalette: () => state.palette,
+    readSingleThemeSelections: () => [...state.singleThemeSelections],
+    readThemeModeSelections: () => [...state.themeModeSelections]
+  };
 }
 
 function createWorkbenchLocator(
@@ -188,10 +224,13 @@ function applyQuickPick(
     return;
   }
   if (command === "GitHub Markdown: Change Theme Mode") {
-    state.mode = option === "Sync with system" ? "auto" : "light";
+    state.themeModeSelections.push(option);
+    state.mode =
+      option === "Sync with system" ? "auto" : option === "VS Code theme" ? "vscode" : "light";
     return;
   }
   if (command === "GitHub Markdown: Change Single Theme") {
+    state.singleThemeSelections.push(option);
     applySingleTheme(state, option);
     return;
   }
@@ -232,6 +271,25 @@ function applySingleTheme(state: ThemePreviewState, option: string): void {
       light: "light_tritanopia",
       mode: "light",
       palette: { ...lightPalette, nodeFill: "rgb(224, 239, 255)" }
+    },
+    Dark: { dark: "dark", light: "light", mode: "dark", palette: darkPalette },
+    "Dark Protanopia & Deuteranopia": {
+      dark: "dark_colorblind",
+      light: "light",
+      mode: "dark",
+      palette: darkPalette
+    },
+    "Dark high contrast": {
+      dark: "dark_high_contrast",
+      light: "light",
+      mode: "dark",
+      palette: darkPalette
+    },
+    "Dark Tritanopia": {
+      dark: "dark_tritanopia",
+      light: "light",
+      mode: "dark",
+      palette: darkPalette
     }
   };
   const selected = cases[option];
@@ -249,18 +307,47 @@ function createThemeFrame(state: ThemePreviewState): Frame {
       nestedVerticalScrollerLabels: []
     }),
     locator(selector: string) {
-      return {
+      const locator = {
         boundingBox: async () => ({ x: 0, y: 0, width: 100, height: 100 }),
         count: async () => countThemeSelector(selector, state),
-        evaluate: async () => state.palette,
+        evaluate: async () => {
+          if (selector === ".code-block-copy-button") {
+            state.copyButtonEvaluations += 1;
+            return {
+              parentTag: "PRE",
+              buttonPosition: "absolute",
+              buttonTop: "8px",
+              buttonRight: "8px",
+              buttonColor: "muted",
+              buttonBackground: "rgba(0, 0, 0, 0)",
+              buttonBorderWidth: "0px",
+              buttonBorderRadius: "6px",
+              buttonWidth: "28px",
+              buttonHeight: "28px",
+              buttonOpacity: "1",
+              svgBackground: "muted",
+              svgMaskImage: "url(github-copy-icon)",
+              copiedColor: "success",
+              copiedMaskImage: "url(github-check-icon)",
+              pathDisplay: "none",
+              expectedMuted: "muted",
+              expectedSuccess: "success",
+              centerOffset: { x: 0, y: 0 }
+            };
+          }
+          return state.palette;
+        },
         evaluateAll: async () => [],
+        first: () => locator,
         isVisible: async () => true,
         textContent: async () => {
           if (selector === ".mermaid svg") return "Alpha Beta";
           if (selector.includes("annotation")) return "S_{12}";
           return "";
-        }
-      } as unknown as Locator;
+        },
+        waitFor: async () => {}
+      };
+      return locator as unknown as Locator;
     },
     url: () => "vscode-webview://preview"
   } as unknown as Frame;
@@ -277,6 +364,7 @@ function countThemeSelector(selector: string, state: ThemePreviewState): number 
   }
   if (selector === `body.${state.body}`) return 1;
   if (selector === ".mermaid svg[data-host-preview-stale]") return 0;
+  if (selector === ".code-block-copy-button") return 1;
   if (selector === ".mermaid svg" || selector === ".katex-display .katex") return 1;
   return 0;
 }

--- a/tests/scripts/host/preview.test.ts
+++ b/tests/scripts/host/preview.test.ts
@@ -54,6 +54,17 @@ describe("assertClientRenderedPreview", () => {
     expect(preview.readThemeModeSelections()).toContain("VS Code theme");
     expect(preview.readCopyButtonEvaluations()).toBe(10);
   });
+
+  it("keeps checking themes when the host has no built-in code copy button", async () => {
+    vi.useFakeTimers();
+    const preview = createThemePreviewPage({ copyButtonAvailable: false });
+
+    await expect(assertClientRenderedPreview(preview.page)).resolves.toBeUndefined();
+
+    expect(preview.readSingleThemeSelections()).toHaveLength(9);
+    expect(preview.readThemeModeSelections()).toContain("VS Code theme");
+    expect(preview.readCopyButtonEvaluations()).toBe(0);
+  });
 });
 
 describe("assertFinalClientRendering", () => {
@@ -104,6 +115,7 @@ function createPreviewFrame({
 type ThemePreviewState = {
   activeCommand: string | undefined;
   body: "vscode-dark" | "vscode-light";
+  copyButtonAvailable: boolean;
   copyButtonEvaluations: number;
   dark: string;
   inputValue: string;
@@ -116,7 +128,9 @@ type ThemePreviewState = {
   themeModeSelections: string[];
 };
 
-function createThemePreviewPage(): {
+function createThemePreviewPage({
+  copyButtonAvailable = true
+}: { copyButtonAvailable?: boolean } = {}): {
   page: Page;
   readCopyButtonEvaluations: () => number;
   readPalette: () => MermaidPalette;
@@ -126,6 +140,7 @@ function createThemePreviewPage(): {
   const state: ThemePreviewState = {
     activeCommand: undefined,
     body: "vscode-light",
+    copyButtonAvailable,
     copyButtonEvaluations: 0,
     dark: "dark",
     inputValue: "",
@@ -312,6 +327,7 @@ function createThemeFrame(state: ThemePreviewState): Frame {
         count: async () => countThemeSelector(selector, state),
         evaluate: async () => {
           if (selector === ".code-block-copy-button") {
+            if (!state.copyButtonAvailable) throw new Error("Code copy button is unavailable");
             state.copyButtonEvaluations += 1;
             return {
               parentTag: "PRE",
@@ -345,7 +361,11 @@ function createThemeFrame(state: ThemePreviewState): Frame {
           if (selector.includes("annotation")) return "S_{12}";
           return "";
         },
-        waitFor: async () => {}
+        waitFor: async () => {
+          if (selector === ".code-block-copy-button" && !state.copyButtonAvailable) {
+            throw new Error("Code copy button is unavailable");
+          }
+        }
       };
       return locator as unknown as Locator;
     },
@@ -364,7 +384,7 @@ function countThemeSelector(selector: string, state: ThemePreviewState): number 
   }
   if (selector === `body.${state.body}`) return 1;
   if (selector === ".mermaid svg[data-host-preview-stale]") return 0;
-  if (selector === ".code-block-copy-button") return 1;
+  if (selector === ".code-block-copy-button") return state.copyButtonAvailable ? 1 : 0;
   if (selector === ".mermaid svg" || selector === ".katex-display .katex") return 1;
   return 0;
 }


### PR DESCRIPTION
## 变更内容

- 使用与 GitHub 一致的复制与成功 Octicon，并让图标直接位于代码块右上角。
- 默认色、成功色和悬停背景改为跟随当前预览主题变量。
- 补充全部 9 套 GitHub 主题及 VS Code 主题模式的真实预览覆盖。
- 对未提供 VS Code 内置复制按钮的宿主保持兼容，同时继续验证主题切换。
- 在 `[Unreleased]` 中记录用户可见变化。

## 原因

VS Code 内置复制按钮的图标、外层按钮样式和默认颜色与 GitHub 代码块不一致，并且原有验证只覆盖单个暗色主题，无法保证主题切换后的表现。

## 用户影响

Markdown 预览中的代码块复制按钮现在更接近 GitHub：静止状态没有额外按钮底色或边框，图标颜色与交互反馈会跟随当前主题。

## 验证

- `nub run test`：360 个测试通过
- `nub run test:host:desktop:preview`：VS Code 1.129.0 真实桌面预览通过
- `nub run test:host:web:preview`：真实 Web 预览通过
- `nubx oxlint .`：通过
- `nubx oxlint --type-aware .`：通过
- `git diff --check`：通过