### PR TITLE
fix: 修复 Marketplace README 横幅渲染

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ artifacts/
 .vscode-test-web/
 
 *.vsix
+README.marketplace.md

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -32,6 +32,7 @@ pnpm-lock.yaml
 pnpm-workspace.yaml
 release-please-config.json
 release-CHANGELOG.txt
+README.md
 scripts/**
 src/**
 tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+### Installation and compatibility
+
+- The Marketplace page now displays the README banner without exposing unsupported HTML tags, while the GitHub README continues to switch between light and dark artwork.
+
 ## [v4.4.4] - 2026-08-13
 
 v4.4.4 makes code block copy controls match GitHub more closely across preview themes.

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "test:host:web:preview": "nub run build && nub scripts/host/web-preview.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "package": "nubx vsce package --no-dependencies",
+    "package": "nub scripts/package/index.ts",
     "release:note": "nub scripts/release/index.ts"
   },
   "dependencies": {

--- a/scripts/package/index.ts
+++ b/scripts/package/index.ts
@@ -1,0 +1,42 @@
+import { spawn } from "node:child_process";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const projectRoot = process.cwd();
+const sourcePath = join(projectRoot, "README.md");
+const marketplacePath = join(projectRoot, "README.marketplace.md");
+const picturePattern = /^  <picture>\n(?:    <source[^\n]*>\n)+    (<img[^\n]*>)\n  <\/picture>$/gm;
+
+const source = await readFile(sourcePath, "utf8");
+const pictures = [...source.matchAll(picturePattern)];
+if (pictures.length !== 1) {
+  throw new Error(`Expected exactly one theme-aware README picture, found ${pictures.length}`);
+}
+
+const marketplaceReadme = source.replace(picturePattern, (_, image: string) => `  ${image}`);
+await writeFile(marketplacePath, marketplaceReadme);
+
+try {
+  await run("nubx", [
+    "vsce",
+    "package",
+    "--no-dependencies",
+    "--readme-path",
+    "README.marketplace.md",
+    ...process.argv.slice(2)
+  ]);
+} finally {
+  await rm(marketplacePath, { force: true });
+}
+
+function run(command: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd: projectRoot, stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else
+        reject(new Error(`${command} exited with ${signal ? `signal ${signal}` : `code ${code}`}`));
+    });
+  });
+}


### PR DESCRIPTION
## 变更

- 保留 GitHub README 的 `<picture>/<source>` 深浅主题横幅。
- 打包时从 `README.md` 临时生成 Marketplace 版本，将主题图片降级为受支持的单个 `<img>`。
- 通过 `--readme-path` 将兼容版本写入 VSIX，并在打包结束或失败后清理临时文件。
- 排除 VSIX 中的源 `README.md`，避免它与自定义 README 映射后的 `extension/readme.md` 发生大小写路径冲突。
- 在 `[Unreleased]` 中记录 Marketplace 页面可见的修复。

## 原因

VS Code Marketplace 不支持 README 中的 `<picture>/<source>` 写法，会把标签直接显示为文本。直接改成单图又会让 GitHub README 失去深浅主题切换，因此在打包边界生成兼容版本。

## 影响

GitHub 仓库继续按深浅主题显示对应横幅；Marketplace 页面只显示兼容的静态横幅，不再暴露 HTML 标签。扩展运行时代码和支持的 VS Code 版本不变。

## 验证

- `mise exec -- nubx oxfmt --check README.md README.zh-CN.md CHANGELOG.md package.json scripts/package/index.ts`
- `mise exec -- nubx oxlint scripts/package/index.ts`
- `mise exec -- nubx oxlint --type-aware scripts/package/index.ts`
- 使用新脚本真实生成 VSIX，确认 `extension/readme.md` 不含 `<picture>/<source>`，只含一个横幅 `<img>`，且临时 README 被清理。
- 当前包审计通过：91,695 B。
- `git diff --check`