### PR TITLE
test(host): cover high-contrast preview themes

### DIFF
--- a/scripts/host/preview.ts
+++ b/scripts/host/preview.ts
@@ -26,7 +26,7 @@ type ThemeExpectation = {
   mode: "auto" | "dark" | "light" | "vscode";
   light: string;
   dark: string;
-  body?: "vscode-dark" | "vscode-light";
+  body?: "vscode-dark" | "vscode-light" | "vscode-high-contrast" | "vscode-high-contrast-light";
 };
 
 async function assertThemeRendering(page: Page): Promise<void> {
@@ -104,13 +104,20 @@ async function assertThemeRendering(page: Page): Promise<void> {
     darkPalette
   );
 
+  await selectColorTheme(page, "Default High Contrast", {
+    mode: "auto",
+    light: "light_high_contrast",
+    dark: "dark_tritanopia",
+    body: "vscode-high-contrast"
+  });
+
   await selectQuickPick(page, "GitHub Markdown: Change Theme Mode", "VS Code theme");
   await refreshPreview(page);
   await waitForThemedPreview(page, {
     mode: "vscode",
     light: "light_high_contrast",
     dark: "dark_tritanopia",
-    body: "vscode-dark"
+    body: "vscode-high-contrast"
   });
   if (copyButtonAvailable) await assertCodeCopyButtonTheme(page, "VS Code theme");
 }
@@ -233,7 +240,7 @@ async function selectColorTheme(
   page: Page,
   option: string,
   expectation: ThemeExpectation,
-  expectedPalette: MermaidPalette
+  expectedPalette?: MermaidPalette
 ): Promise<MermaidPalette> {
   let lastError: unknown;
 

--- a/tests/scripts/host/preview.test.ts
+++ b/tests/scripts/host/preview.test.ts
@@ -114,7 +114,7 @@ function createPreviewFrame({
 
 type ThemePreviewState = {
   activeCommand: string | undefined;
-  body: "vscode-dark" | "vscode-light";
+  body: "vscode-dark" | "vscode-light" | "vscode-high-contrast" | "vscode-high-contrast-light";
   copyButtonAvailable: boolean;
   copyButtonEvaluations: number;
   dark: string;
@@ -250,6 +250,12 @@ function applyQuickPick(
     return;
   }
   if (command === "Preferences: Color Theme") {
+    if (option === "Default High Contrast") {
+      state.body = "vscode-high-contrast";
+      state.palette = darkPalette;
+      state.pendingPalette = darkPalette;
+      return;
+    }
     const isLight = option === "Light Modern";
     state.body = isLight ? "vscode-light" : "vscode-dark";
     state.palette = isLight ? darkPalette : lightPalette;


### PR DESCRIPTION
## Summary

- exercise System mode under the real high-contrast workbench signal
- keep VS Code mode assertions aligned with the active high-contrast host
- extend the host-preview test double for the new scenario

Closes #1281

## Checks

- pnpm exec vitest run tests/scripts/host/preview.test.ts
- pnpm exec oxfmt --check scripts/host/preview.ts tests/scripts/host/preview.test.ts
- pnpm exec oxlint scripts/host/preview.ts tests/scripts/host/preview.test.ts
- git diff --check

Note: the repository hook could not run in the isolated worktree because nub/nubx are not on PATH; the equivalent pnpm checks above passed.