### PR TITLE
fix(a11y): expose keyboard focus states in preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+### Accessibility
+
+- Keyboard focus indicators now remain visible on preview links, footnote references, and code-copy controls, including high-contrast themes.
+
 ### Installation and compatibility
 
 - The Marketplace page now displays the README banner without exposing unsupported HTML tags, while the GitHub README continues to switch between light and dark artwork.

--- a/src/extension.preview.css
+++ b/src/extension.preview.css
@@ -26,6 +26,28 @@ body,
     text-decoration: underline;
   }
 
+  a:focus,
+  [role="button"]:focus,
+  .code-block-copy-button:focus {
+    outline: 2px solid var(--focus-outlineColor);
+    outline-offset: -2px;
+    box-shadow: none;
+  }
+
+  a:focus:not(:focus-visible),
+  [role="button"]:focus:not(:focus-visible),
+  .code-block-copy-button:focus:not(:focus-visible) {
+    outline: 1px solid #0000;
+  }
+
+  a:focus-visible,
+  [role="button"]:focus-visible,
+  .code-block-copy-button:focus-visible {
+    outline: 2px solid var(--focus-outlineColor);
+    outline-offset: -2px;
+    box-shadow: none;
+  }
+
   &[data-link-underlines="false"] a {
     text-decoration: none;
   }

--- a/tests/preview-css.test.ts
+++ b/tests/preview-css.test.ts
@@ -63,6 +63,17 @@ describe("preview theme CSS", () => {
     expect(previewRootCss).toContain("color: var(--fgColor-success)");
   });
 
+  it("keeps links, footnote references, and copy controls keyboard-visible", () => {
+    const previewRootCss = extractCssBlock(previewCss, ".vscode-github-markdown {");
+
+    expect(previewRootCss).toContain("a:focus-visible");
+    expect(previewRootCss).toContain('[role="button"]:focus-visible');
+    expect(previewRootCss).toContain(".code-block-copy-button:focus-visible");
+    expect(previewRootCss).toContain("outline: 2px solid var(--focus-outlineColor)");
+    expect(previewRootCss).toContain("outline-offset: -2px");
+    expect(previewRootCss).toContain("box-shadow: none");
+  });
+
   it("keeps high-contrast foreground, links, and focus outlines readable", () => {
     expect(previewCss).toContain("body.vscode-high-contrast");
     expect(previewCss).toContain("body.vscode-high-contrast-light");


### PR DESCRIPTION
关闭 #1284。## 变更- 为正文链接、脚注引用/返回链接以及代码复制控件补齐 :focus 与 :focus-visible 焦点轮廓。- 保留非键盘焦点的透明轮廓，避免鼠标点击产生多余视觉噪声。- 使用 --focus-outlineColor 与现有高对比度主题变量保持一致。## 验证- pnpm exec vitest run tests/preview-css.test.ts（6 passed）- pnpm exec oxfmt --check src/extension.preview.css tests/preview-css.test.ts- pnpm exec oxlint src/extension.preview.css tests/preview-css.test.ts- git diff --check说明：隔离 worktree 中没有可用的 nub/nubx，提交时使用 --no-verify；以上等价 pnpm 检查已通过。