### PR TITLE
fix: handle Mermaid renderer extension lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This file records notable changes that people can observe or act on when using t
 
 - The Marketplace page now displays the README banner without exposing unsupported HTML tags, while the GitHub README continues to switch between light and dark artwork.
 
+### Mermaid
+
+- Mermaid theme synchronization now follows companion renderer installation and removal while the extension is active, and restores only the settings it still owns when no renderer is available.
+
 ## [v4.4.4] - 2026-08-13
 
 v4.4.4 makes code block copy controls match GitHub more closely across preview themes.

--- a/src/events.ts
+++ b/src/events.ts
@@ -3,11 +3,7 @@ import { section } from "./configuration";
 import { updateMermaidThemeSync } from "./integrations/mermaid";
 
 export function registerMarkdownPreviewEvents(memento: vscode.Memento): vscode.Disposable {
-  return vscode.workspace.onDidChangeConfiguration(async (e) => {
-    if (!e.affectsConfiguration(section.namespace)) {
-      return;
-    }
-
+  const syncAndRefresh = async (): Promise<void> => {
     try {
       await updateMermaidThemeSync(memento);
     } catch (error) {
@@ -19,5 +15,20 @@ export function registerMarkdownPreviewEvents(memento: vscode.Memento): vscode.D
     } catch (error) {
       console.error("[github-markdown] Failed to refresh preview:", error);
     }
+  };
+
+  const configurationSubscription = vscode.workspace.onDidChangeConfiguration(async (e) => {
+    if (!e.affectsConfiguration(section.namespace)) {
+      return;
+    }
+    await syncAndRefresh();
   });
+  const extensionSubscription = vscode.extensions.onDidChange(syncAndRefresh);
+
+  return {
+    dispose: () => {
+      configurationSubscription.dispose();
+      extensionSubscription.dispose();
+    }
+  };
 }

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -93,11 +93,18 @@ export function restoreMermaidThemeSync(
 
 async function updateNow(memento: vscode.Memento): Promise<void> {
   const configuration = getOriginConfiguration();
+  // A renderer can be removed or disabled while this extension remains active.
+  // Release values that this extension still owns so a later reinstall starts
+  // from the user's current settings instead of inheriting stale state.
+  if (!hasMermaidExtension()) {
+    await restoreNow(memento, configuration);
+    return;
+  }
   if (!getMermaidSyncTheme()) {
     await restoreNow(memento, configuration);
     return;
   }
-  if (!hasMermaidExtension() || !hasConfiguration(configuration)) return;
+  if (!hasConfiguration(configuration)) return;
 
   const identity = getWorkspaceIdentity();
   await migrateSnapshot(memento, identity);

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -8,6 +8,7 @@ const harness = vi.hoisted(() => ({
   configurationListener: undefined as
     | ((event: { affectsConfiguration(section: string): boolean }) => Promise<void>)
     | undefined,
+  extensionListener: undefined as (() => Promise<void>) | undefined,
   executeError: undefined as Error | undefined,
   executeCalls: [] as string[],
   errorMessages: [] as string[],
@@ -17,6 +18,7 @@ const harness = vi.hoisted(() => ({
   localizedMessages: {} as Record<string, string>,
   markdownConfig: {} as Record<string, string | boolean>,
   markdownWorkspaceConfig: {} as Record<string, string | boolean>,
+  mermaidExtensionIds: new Set<string>(["vscode.mermaid-markdown-features"]),
   mermaidGlobalConfig: {} as Record<string, string | undefined>,
   mermaidUpdateError: undefined as Error | undefined,
   mermaidUpdates: [] as { key: string; value: string | undefined; target: number }[],
@@ -32,7 +34,11 @@ vi.mock("vscode", () => ({
   default: {
     ConfigurationTarget: { Global: 1, Workspace: 2 },
     extensions: {
-      getExtension: (id: string) => (id === "vscode.mermaid-markdown-features" ? {} : undefined)
+      getExtension: (id: string) => (harness.mermaidExtensionIds.has(id) ? {} : undefined),
+      onDidChange: (listener: () => Promise<void>) => {
+        harness.extensionListener = listener;
+        return { dispose: vi.fn() };
+      }
     },
     commands: {
       registerCommand: (id: string, handler: () => Promise<void>) => {
@@ -191,6 +197,7 @@ describe("extension lifecycle", () => {
   beforeEach(() => {
     harness.commandHandlers.clear();
     harness.configurationListener = undefined;
+    harness.extensionListener = undefined;
     harness.executeError = undefined;
     harness.executeCalls.length = 0;
     harness.errorMessages.length = 0;
@@ -211,6 +218,7 @@ describe("extension lifecycle", () => {
       "mermaid.syncTheme": true
     };
     harness.markdownWorkspaceConfig = {};
+    harness.mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features"]);
     harness.mermaidGlobalConfig = {
       lightModeTheme: "neutral",
       darkModeTheme: "forest"
@@ -234,6 +242,7 @@ describe("extension lifecycle", () => {
       "vscode-github-markdown.changeDarkTheme"
     ]);
     expect(harness.configurationListener).toBeTypeOf("function");
+    expect(harness.extensionListener).toBeTypeOf("function");
     expect(context.subscriptions).toHaveLength(5);
     expect(harness.mermaidUpdates).toHaveLength(2);
     expect(api).toEqual(expect.objectContaining({ extendMarkdownIt }));
@@ -255,6 +264,39 @@ describe("extension lifecycle", () => {
     expect(harness.mermaidUpdates).toEqual([
       { key: "lightModeTheme", value: "neutral", target: 1 },
       { key: "darkModeTheme", value: "forest", target: 1 }
+    ]);
+    expect(harness.executeCalls).toEqual(["markdown.preview.refresh"]);
+  });
+
+  it("restores Mermaid settings when its renderer is removed while this extension stays active", async () => {
+    const context = createContext();
+    await activate(context);
+    harness.mermaidUpdates.length = 0;
+    harness.executeCalls.length = 0;
+    harness.mermaidExtensionIds.clear();
+
+    await harness.extensionListener?.();
+
+    expect(harness.mermaidUpdates).toEqual([
+      { key: "lightModeTheme", value: "neutral", target: 1 },
+      { key: "darkModeTheme", value: "forest", target: 1 }
+    ]);
+    expect(harness.executeCalls).toEqual(["markdown.preview.refresh"]);
+  });
+
+  it("synchronizes Mermaid when a renderer is installed after activation", async () => {
+    const context = createContext();
+    harness.mermaidExtensionIds.clear();
+    await activate(context);
+    harness.mermaidUpdates.length = 0;
+    harness.executeCalls.length = 0;
+    harness.mermaidExtensionIds.add("bierner.markdown-mermaid");
+
+    await harness.extensionListener?.();
+
+    expect(harness.mermaidUpdates).toEqual([
+      { key: "lightModeTheme", value: "default", target: 1 },
+      { key: "darkModeTheme", value: "dark", target: 1 }
     ]);
     expect(harness.executeCalls).toEqual(["markdown.preview.refresh"]);
   });

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -309,6 +309,41 @@ describe("Mermaid theme synchronization", () => {
     expect(updateCalls).toHaveLength(2);
   });
 
+  it("uses one shared configuration when both Mermaid renderers are installed", async () => {
+    const memento = createTestMemento();
+    mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features", "bierner.markdown-mermaid"]);
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "default", target: 1 },
+      { key: "darkModeTheme", value: "dark", target: 1 }
+    ]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "default",
+      darkModeTheme: "dark"
+    });
+  });
+
+  it("restores owned settings when every Mermaid renderer disappears", async () => {
+    const memento = createTestMemento();
+    await updateMermaidThemeSync(memento);
+    mermaidExtensionIds.clear();
+    updateCalls.length = 0;
+
+    await updateMermaidThemeSync(memento);
+
+    expect(updateCalls).toEqual([
+      { key: "lightModeTheme", value: "neutral", target: 1 },
+      { key: "darkModeTheme", value: "forest", target: 1 }
+    ]);
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "forest"
+    });
+    expect(memento.keys()).toEqual([]);
+  });
+
   it("restores the user's global Mermaid settings when synchronization is disabled", async () => {
     const memento = createTestMemento();
 


### PR DESCRIPTION
Closes #1280

## Behavior changes

- Subscribe to VS Code extension install/remove events so Mermaid synchronization follows renderer availability while this extension remains active.
- Restore only Mermaid settings still owned by this extension when all supported renderers disappear, preserving user takeovers and allowing a later reinstall to recapture current settings.
- Keep built-in `vscode.mermaid-markdown-features`, legacy `bierner.markdown-mermaid`, both together, and no renderer behavior predictable.

## Acceptance

- [x] Built-in, legacy, both, and neither renderer states covered.
- [x] Dynamic renderer removal restores owned settings and refreshes the preview.
- [x] Dynamic renderer installation reapplies the active theme and refreshes the preview.
- [x] Existing workspace, multi-window, takeover, rapid-switch, failure-recovery, and deactivation coverage remains green.

## Checks

- `pnpm exec oxfmt src/events.ts src/integrations/mermaid.ts tests/extension.test.ts tests/integrations/mermaid.test.ts`
- `pnpm exec oxlint src/events.ts src/integrations/mermaid.ts tests/extension.test.ts tests/integrations/mermaid.test.ts`
- `pnpm exec oxlint --type-aware src/events.ts src/integrations/mermaid.ts tests/extension.test.ts tests/integrations/mermaid.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run` (50 files, 364 tests)
- `mise exec -- pnpm run build`
- `VSCODE_TEST_VERSION=1.129.0 mise exec -- pnpm run test:host:desktop`
- `mise exec -- pnpm run test:host:desktop:preview`
- `mise exec -- pnpm run test:host:web:preview`

The real-host tests completed successfully; VS Code 1.129.0 logs its known packaged-app NODE_OPTION and Mermaid proposal warnings, and the host preview skips the unavailable built-in code-copy button assertion.