### PR TITLE
fix(markdown): resolve project-root image sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This file records notable changes that people can observe or act on when using t
 
 - Mermaid theme synchronization now follows companion renderer installation and removal while the extension is active, and restores only the settings it still owns when no renderer is available.
 
+### Markdown preview
+
+- Project-root paths in Markdown images and responsive HTML image candidates now resolve in nested documents and VS Code Webviews, while relative, external, protocol-relative, data, and lazy-loading URLs remain unchanged.
+
 ## [v4.4.4] - 2026-08-13
 
 v4.4.4 makes code block copy controls match GitHub more closely across preview themes.

--- a/scripts/host/client-rendering.ts
+++ b/scripts/host/client-rendering.ts
@@ -54,6 +54,29 @@ async function assertClientRenderingInFrame(preview: Frame): Promise<void> {
     .textContent();
   assert(katexSource?.includes("S_{12}"), "KaTeX preserves the complete fixture expression");
 
+  for (const alt of ["Root Markdown image", "Relative Markdown image", "Root HTML image"]) {
+    const image = preview.locator(`img[alt="${alt}"]`);
+    if ((await image.count()) === 0 || typeof image.waitFor !== "function") continue;
+    await image.waitFor({ state: "visible", timeout: 10_000 });
+    const imageState = await image.evaluate((element) => {
+      const image = element as HTMLImageElement;
+      return { complete: image.complete, naturalWidth: image.naturalWidth };
+    });
+    assert(
+      imageState.complete && imageState.naturalWidth > 0,
+      `${alt} loads in the final Webview preview (${JSON.stringify(imageState)})`
+    );
+  }
+
+  const source = preview.locator("source[srcset]");
+  if ((await source.count()) > 0 && typeof source.getAttribute === "function") {
+    const srcset = await source.first().getAttribute("srcset");
+    assert(
+      srcset !== null && !/^\s*\/images\/local-image\.svg(?:\s|,|$)/.test(srcset),
+      `Project-root srcset candidates are rewritten in the final Webview preview (${srcset})`
+    );
+  }
+
   const overflow = await preview.evaluate(() => {
     const pageScroller = document.scrollingElement;
     const nestedVerticalScrollers = [

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -3,8 +3,11 @@ import type MarkdownIt from "markdown-it";
 import { replaceCodePoint } from "entities/decode";
 
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
+const responsiveImageTagPattern = /<(?:img|source)(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const projectRootSrcAttributePattern =
   /(<img(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+src[\t\n\f\r ]*=[\t\n\f\r ]*)(?:(["'])(\/(?!\/)[^"']+)\2|(\/(?!\/)[^\t\n\f\r "'`=<>]+))/i;
+const projectRootSrcsetAttributePattern =
+  /(<(?:img|source)(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+srcset[\t\n\f\r ]*=[\t\n\f\r ]*)(?:(['"])([^"']*)\2|([^\t\n\f\r "'`=<>]+))/i;
 const htmlEntityPattern = /&(?:#[xX][\da-fA-F]+;?|#\d+;?|[a-zA-Z][a-zA-Z0-9]{1,31};?)/g;
 const legacyHtmlEntityNames = new Set(
   "AElig AMP Aacute Acirc Agrave Aring Atilde Auml COPY Ccedil ETH Eacute Ecirc Egrave Euml GT Iacute Icirc Igrave Iuml LT Ntilde Oacute Ocirc Ograve Oslash Otilde Ouml QUOT REG THORN Uacute Ucirc Ugrave Uuml Yacute aacute acirc acute aelig agrave amp aring atilde auml brvbar ccedil cedil cent copy curren deg divide eacute ecirc egrave eth euml frac12 frac14 frac34 gt iacute icirc iexcl igrave iquest iuml laquo lt macr micro middot nbsp not ntilde oacute ocirc ograve ordf ordm oslash otilde ouml para plusmn pound quot raquo reg sect shy sup1 sup2 sup3 szlig thorn times uacute ucirc ugrave uml uuml yacute yen yuml".split(
@@ -30,6 +33,28 @@ function rewriteImgSrc(
       }
     )
   );
+}
+
+function rewriteImgSrcset(
+  html: string,
+  env: ImageRenderEnv | undefined,
+  decodeNamedEntity: (value: string) => string
+): string {
+  return html.replace(responsiveImageTagPattern, (imageTag) =>
+    imageTag.replace(
+      projectRootSrcsetAttributePattern,
+      (_match, before, quote = "", quotedSrcset, unquotedSrcset) => {
+        const srcset = decodeHtmlAttribute(quotedSrcset ?? unquotedSrcset, decodeNamedEntity);
+        return `${before}${serializeAttributeValue(rewriteSrcset(srcset, env), quote)}`;
+      }
+    )
+  );
+}
+
+function rewriteSrcset(srcset: string, env: ImageRenderEnv | undefined): string {
+  return srcset.replace(/(^\s*|,\s*)(\/(?!\/)[^\s,]+)/g, (_match, separator, src) => {
+    return `${separator}${toProjectRootResourceUri(src, env)}`;
+  });
 }
 
 function decodeHtmlAttribute(value: string, decodeNamedEntity: (value: string) => string): string {
@@ -82,6 +107,10 @@ function toProjectRootResourceUri(src: string, env: ImageRenderEnv | undefined):
   }
 }
 
+function isProjectRootPath(src: string): boolean {
+  return src.startsWith("/") && !src.startsWith("//");
+}
+
 export default function markdownItImageUrl(md: MarkdownIt): MarkdownIt {
   for (const ruleName of ["html_block", "html_inline"] as const) {
     const defaultRender =
@@ -95,9 +124,27 @@ export default function markdownItImageUrl(md: MarkdownIt): MarkdownIt {
           env as ImageRenderEnv,
           md.utils.unescapeAll
         );
+        tokens[idx].content = rewriteImgSrcset(
+          tokens[idx].content,
+          env as ImageRenderEnv,
+          md.utils.unescapeAll
+        );
       }
       return defaultRender(tokens, idx, options, env, self);
     };
   }
+
+  const defaultImageRender =
+    md.renderer.rules.image ??
+    ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options));
+  md.renderer.rules.image = (tokens, idx, options, env, self) => {
+    const token = tokens[idx];
+    const src = token?.attrGet("src");
+    if (token && src && isProjectRootPath(src)) {
+      token.attrSet("src", toProjectRootResourceUri(src, env as ImageRenderEnv));
+    }
+    return defaultImageRender(tokens, idx, options, env, self);
+  };
+
   return md;
 }

--- a/tests/fixtures/host/client-rendering.md
+++ b/tests/fixtures/host/client-rendering.md
@@ -9,6 +9,15 @@ flowchart LR
 const themedCopyIcon = true;
 ```
 
+![Root Markdown image](/images/local-image.svg)
+
+![Relative Markdown image](images/local-image.svg)
+
+<picture>
+  <source srcset="/images/local-image.svg 1x, /images/local-image.svg?variant=2 2x">
+  <img src="/images/local-image.svg" alt="Root HTML image">
+</picture>
+
 $$
 \begin{aligned}
 S_1 &= a_1 + a_2 + a_3 + a_4 + a_5 + a_6 + a_7 + a_8 + a_9 + a_{10} \\

--- a/tests/fixtures/host/images/local-image.svg
+++ b/tests/fixtures/host/images/local-image.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="40" viewBox="0 0 120 40">
+  <rect width="120" height="40" fill="#0969da" />
+  <text x="60" y="25" fill="white" font-family="sans-serif" font-size="12" text-anchor="middle">local image</text>
+</svg>

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -111,6 +111,62 @@ describe("markdown-it-github-image-url", () => {
     expect(html).toContain(`src="./assets/logo.svg"`);
   });
 
+  it("rewrites Markdown images with project-root paths from nested documents", () => {
+    const md = new MarkdownIt().use(githubImageUrl);
+    const html = md.render(
+      "![logo](/assets/logo.svg?theme=light#hero)",
+      renderEnv("/workspace/docs/guide.md")
+    );
+
+    expect(html).toBe(
+      '<p><img src="https://webview.test/workspace/assets/logo.svg?theme=light#hero" alt="logo"></p>\n'
+    );
+  });
+
+  it("rewrites project-root candidates in responsive image srcset attributes", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render(
+      '<picture><source data-srcset="/lazy.webp 1x" srcset="/assets/hero.webp?theme=light&amp;size=wide#top 1x, https://cdn.example.com/hero.webp 2x, ../hero.webp 3x, //cdn.example.com/hero.webp 4x"><img srcset="/assets/fallback.webp 1x, /assets/fallback@2x.webp 2x" src="/assets/fallback.webp" alt="hero"></picture>',
+      renderEnv("/workspace/docs/guide.md")
+    );
+
+    expect(html).toBe(
+      '<p><picture><source data-srcset="/lazy.webp 1x" srcset="https://webview.test/workspace/assets/hero.webp?theme=light&amp;size=wide#top 1x, https://cdn.example.com/hero.webp 2x, ../hero.webp 3x, //cdn.example.com/hero.webp 4x"><img srcset="https://webview.test/workspace/assets/fallback.webp 1x, https://webview.test/workspace/assets/fallback@2x.webp 2x" src="https://webview.test/workspace/assets/fallback.webp" alt="hero"></picture></p>\n'
+    );
+  });
+
+  it("preserves srcset whitespace while resolving a leading project-root candidate", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render(
+      '<source srcset="  /assets/hero.webp 1x, /assets/hero@2x.webp 2x">',
+      renderEnv("/workspace/docs/guide.md")
+    );
+
+    expect(html).toBe(
+      '<source srcset="  https://webview.test/workspace/assets/hero.webp 1x, https://webview.test/workspace/assets/hero@2x.webp 2x">'
+    );
+  });
+
+  it("leaves relative, protocol-relative, external, and data image URLs unchanged", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render(
+      [
+        "![relative](../images/photo.png)",
+        "![protocol-relative](//cdn.example.com/photo.png)",
+        "![external](https://cdn.example.com/photo.png)",
+        '<img src="data:image/svg+xml,%3Csvg%3E%3C/svg%3E" alt="data">',
+        '<img data-src="/lazy.png" src="//cdn.example.com/photo.png">'
+      ].join("\n"),
+      renderEnv("/workspace/docs/guide.md")
+    );
+
+    expect(html).toContain('src="../images/photo.png"');
+    expect(html).toContain('src="//cdn.example.com/photo.png"');
+    expect(html).toContain('src="https://cdn.example.com/photo.png"');
+    expect(html).toContain('src="data:image/svg+xml,%3Csvg%3E%3C/svg%3E"');
+    expect(html).toContain('data-src="/lazy.png" src="//cdn.example.com/photo.png"');
+  });
+
   it("rewrites only the src attribute on raw HTML images", () => {
     const md = new MarkdownIt({ html: true }).use(githubImageUrl);
     const html = md.render('<img data-src="/lazy.png" src="/actual.png">');

--- a/tests/scripts/host/preview.test.ts
+++ b/tests/scripts/host/preview.test.ts
@@ -113,6 +113,8 @@ function createPreviewFrame({
 } = {}): Frame {
   return {
     locator(selector: string) {
+      const imageLocator = createImageLocator(selector);
+      if (imageLocator) return imageLocator;
       return {
         count: async () => 1,
         textContent: async () => {
@@ -130,6 +132,26 @@ function createPreviewFrame({
     evaluate: async () => overflow,
     url: () => "vscode-webview://preview"
   } as unknown as Frame;
+}
+
+function createImageLocator(selector: string): Locator | undefined {
+  if (selector.startsWith('img[alt="')) {
+    return {
+      count: async () => 1,
+      evaluate: async (read: (element: HTMLImageElement) => unknown) =>
+        read({ complete: true, naturalWidth: 120 } as HTMLImageElement),
+      waitFor: async () => {}
+    } as unknown as Locator;
+  }
+  if (selector === "source[srcset]") {
+    const sourceLocator = {
+      count: async () => 1,
+      first: () => sourceLocator,
+      getAttribute: async () => "https://webview.test/images/local-image.svg 1x"
+    } as unknown as Locator;
+    return sourceLocator;
+  }
+  return undefined;
 }
 
 type ThemePreviewState = {
@@ -348,6 +370,8 @@ function createThemeFrame(state: ThemePreviewState): Frame {
       nestedVerticalScrollerLabels: []
     }),
     locator(selector: string) {
+      const imageLocator = createImageLocator(selector);
+      if (imageLocator) return imageLocator;
       const locator = {
         boundingBox: async () => ({ x: 0, y: 0, width: 100, height: 100 }),
         count: async () => countThemeSelector(selector, state),


### PR DESCRIPTION
Closes #1283

## 行为变化
- Markdown 图片的项目根路径会按当前工作区解析，兼容根目录与嵌套目录文档。
- HTML `img` 及 `picture/source`、`img` 的 `srcset` 项目根候选会转换为 Webview 可加载的资源 URI，并保留查询串、片段和候选描述。
- 相对路径、外部 URL、协议相对 URL、`data:` URL、`data-src`/`data-srcset` 保持不变；URI 解析失败时保留可见的相对路径回退。

## 验收
- [x] 覆盖 Markdown 图片、HTML `img`、`picture/source srcset`、相对路径和项目根路径。
- [x] 覆盖根目录与嵌套目录文档，并在真实桌面/Web VS Code Webview 验证本地图片实际加载。
- [x] 查询串、片段、协议相对地址、`data-src` 等非目标内容保持原样。
- [x] 解析失败保留可诊断的相对路径回退，不扩大目标 URL 改写范围。

## 已运行检查
- `pnpm exec tsc --noEmit`
- `pnpm exec oxlint src/plugins/markdown-it-github-image-url.ts tests/plugins/image-url.test.ts scripts/host/client-rendering.ts`
- `pnpm exec vitest run`（50 files / 364 tests）
- `mise x -- nub run test:host:desktop:preview`
- `mise x -- nub run test:host:web:preview`