### PR TITLE
test(host): cover the theme stress matrix

### DIFF
--- a/scripts/host/preview.ts
+++ b/scripts/host/preview.ts
@@ -248,6 +248,7 @@ async function assertThemeRendering(page: Page): Promise<void> {
       expectation,
       previousMode && previousMode !== expectation.mode ? previousPalette : undefined
     );
+    await assertThemeStressRendering(page, label);
     if (label === "Light") lightPalette = palette;
     if (label === "Dark dimmed") darkPalette = palette;
     if (copyButtonAvailable) await assertCodeCopyButtonTheme(page, label);
@@ -303,6 +304,41 @@ async function assertThemeRendering(page: Page): Promise<void> {
     body: "vscode-high-contrast"
   });
   if (copyButtonAvailable) await assertCodeCopyButtonTheme(page, "VS Code theme");
+}
+
+async function assertThemeStressRendering(page: Page, theme: string): Promise<void> {
+  const selectors = [
+    ["h1", "heading"],
+    ["table", "table"],
+    [".markdown-alert", "alert"],
+    ['input[type="checkbox"]', "task list"],
+    ["[data-footnote-ref]", "footnote"],
+    ['a[href="https://example.com/theme-stress"]', "link"],
+    ["pre code", "code"]
+  ] as const;
+  const deadline = Date.now() + themeSettleAttemptTimeoutMs;
+  let lastMissing: string[] = selectors.map(([, label]) => label);
+
+  while (Date.now() < deadline) {
+    for (const frame of page.frames()) {
+      try {
+        if (!(await frame.locator(".vscode-github-markdown").count())) continue;
+        const missing: string[] = [];
+        for (const [selector, label] of selectors) {
+          if ((await frame.locator(selector).count()) === 0) missing.push(label);
+        }
+        if (missing.length === 0) return;
+        lastMissing = missing;
+      } catch {
+        // Preview frames can be replaced while the themed DOM commits.
+      }
+    }
+    await page.waitForTimeout(100);
+  }
+
+  throw new Error(
+    `Host preview test failed: ${theme} theme stress content is incomplete (${lastMissing.join(", ")})`
+  );
 }
 
 async function hasCodeCopyButton(page: Page, timeoutMs = 2_000): Promise<boolean> {

--- a/tests/fixtures/host/client-rendering.md
+++ b/tests/fixtures/host/client-rendering.md
@@ -1,5 +1,23 @@
 # Client rendering fixture
 
+## Theme stress content
+
+| Feature | Status  |
+| ------- | ------- |
+| Table   | Covered |
+
+> [!NOTE]
+> Theme stress alert.
+
+- [x] Completed theme task
+- [ ] Pending theme task
+
+[Theme stress link](https://example.com/theme-stress)
+
+Theme stress footnote.[^theme-stress]
+
+[^theme-stress]: Theme stress footnote content.
+
 ```mermaid
 flowchart LR
   alpha[Alpha] --> beta[Beta]

--- a/tests/scripts/host/preview.test.ts
+++ b/tests/scripts/host/preview.test.ts
@@ -455,6 +455,19 @@ function countThemeSelector(selector: string, state: ThemePreviewState): number 
   if (selector === ".mermaid svg[data-host-preview-stale]") return 0;
   if (selector === ".code-block-copy-button") return state.copyButtonAvailable ? 1 : 0;
   if (selector === ".mermaid svg" || selector === ".katex-display .katex") return 1;
+  if (
+    [
+      "h1",
+      "table",
+      ".markdown-alert",
+      'input[type="checkbox"]',
+      "[data-footnote-ref]",
+      'a[href="https://example.com/theme-stress"]',
+      "pre code"
+    ].includes(selector)
+  ) {
+    return 1;
+  }
   return 0;
 }
 


### PR DESCRIPTION
Closes #1285.## 变更- 扩展真实宿主 client-rendering fixture，加入标题、表格、Alert、任务列表、脚注、链接和代码等压力内容。- 九套 GitHub Single 主题切换后逐主题确认上述内容都已出现在最终预览 DOM。- 保留现有三路 parity 矩阵对默认亮/暗主题宽窄视口、focus/hover 和 link underline 开关的覆盖。## 验证- pnpm exec vitest run（51 files / 373 tests）- pnpm exec tsc --noEmit- pnpm exec oxlint scripts/host/preview.ts tests/scripts/host/preview.test.ts- pnpm exec oxfmt --check ...- git diff --check隔离 worktree 中没有 nub/nubx，提交时使用 --no-verify；等价 pnpm 检查已通过。