### PR TITLE
test: lock upstream drift and release gate contracts

### DIFF
--- a/tests/scripts/build/github-css.test.ts
+++ b/tests/scripts/build/github-css.test.ts
@@ -130,6 +130,22 @@ describe("GitHub CSS assets", () => {
 
       expect(snapshot.capturedAt).toBe("2026-07-26T00:00:00.000Z");
       expect(snapshot.fixtureCommit).toBe("a".repeat(40));
+      expect(snapshot.extractor).toEqual({
+        package: "generate-github-markdown-css",
+        version: "6.6.0",
+        entryPage: "https://github.com/sindresorhus/generate-github-markdown-css"
+      });
+      expect(snapshot.themes).toEqual([
+        "light",
+        "light_colorblind",
+        "light_high_contrast",
+        "light_tritanopia",
+        "dark",
+        "dark_colorblind",
+        "dark_dimmed",
+        "dark_high_contrast",
+        "dark_tritanopia"
+      ]);
       expect(snapshot.assets).toMatchObject([
         {
           url: "https://github.githubassets.com/assets/primer-123abc.css",
@@ -145,6 +161,25 @@ describe("GitHub CSS assets", () => {
         }
       ]);
       expect(snapshot.assets.every(({ sha256 }) => /^[\da-f]{64}$/.test(sha256))).toBe(true);
+      expect(snapshot.filtering).toEqual({
+        input: {
+          mediaRules: 2,
+          dataSelectors: ["data-preview"],
+          classSelectors: ["unknown"]
+        },
+        output: {
+          mediaRules: 0,
+          dataSelectors: ["data-color-mode", "data-dark-theme", "data-light-theme"],
+          classSelectors: [
+            "vscode-dark",
+            "vscode-github-markdown",
+            "vscode-high-contrast",
+            "vscode-high-contrast-light",
+            "vscode-light"
+          ]
+        },
+        excluded: { mediaRules: 2, dataSelectors: 1, classSelectors: 1 }
+      });
       expect(snapshot.filtering.excluded).toMatchObject({ mediaRules: 2, dataSelectors: 1 });
     } finally {
       globalThis.fetch = originalFetch;

--- a/tests/scripts/drift/probe.test.ts
+++ b/tests/scripts/drift/probe.test.ts
@@ -37,6 +37,30 @@ const snapshot: GithubCssSnapshot = {
 };
 
 describe("upstream drift probe", () => {
+  it("treats the 30-hour freshness boundary as fresh and missing history as missing", async () => {
+    const boundary = await createDriftReport({
+      now: new Date("2026-07-26T12:00:00.000Z"),
+      lastSuccessAt: "2026-07-25T06:00:00.000Z",
+      captureSnapshot: async () => snapshot,
+      verifyRemoteParity: async () => {}
+    });
+    const missing = await createDriftReport({
+      now: new Date("2026-07-26T12:00:00.000Z"),
+      captureSnapshot: async () => snapshot,
+      verifyRemoteParity: async () => {}
+    });
+
+    expect(boundary.successfulProbeFreshness).toMatchObject({
+      status: "fresh",
+      thresholdHours: maximumSuccessfulProbeAgeHours,
+      ageHours: 30
+    });
+    expect(missing.successfulProbeFreshness).toEqual({
+      status: "missing",
+      thresholdHours: maximumSuccessfulProbeAgeHours
+    });
+  });
+
   it("reports successful comparison with cache and stale-result freshness", async () => {
     const report = await createDriftReport({
       now: new Date("2026-07-26T12:00:00.000Z"),


### PR DESCRIPTION
Closes #1286.## 变更- 固定 GitHub CSS 快照的 extractor 版本、入口页、九套主题和输入/输出/排除统计，防止 provenance 字段或过滤信号静默回退。- 固定漂移探针 30 小时 freshness SLO 的边界行为：正好 30 小时仍为 fresh，无历史结果为 missing。- 现有每日/手动探针、三方 parity 报告、发布门禁、审计 override 和模拟恢复演练保持不变；本 PR 将关键验收契约转成回归测试。## 验证- pnpm exec vitest run（51 files / 374 tests）- pnpm exec tsc --noEmit- pnpm exec oxlint ...- pnpm exec oxfmt --check ...- git diff --check本 PR 仅增加契约测试，无用户可见行为变化，因此未新增 CHANGELOG 条目。