### PR TITLE
docs(changelog): prepare v4.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+## [v4.5.0] - 2026-08-26
+
+v4.5.0 improves GitHub Markdown preview fidelity and reliability across nested images, accessibility, Mermaid synchronization, and Marketplace installation.
+
 ### Accessibility
 
 - Keyboard focus indicators now remain visible on preview links, footnote references, and code-copy controls, including high-contrast themes.
@@ -176,6 +180,7 @@ v4 is a new extension rather than an in-place update of `lzm0x219.vscode-markdow
 - v4 supports VS Code 1.74 or later and continues to enhance the built-in Markdown preview instead of opening a separate preview editor.
 - Commands and settings are available in English and Simplified Chinese according to the VS Code display language.
 
+[v4.5.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.4...v4.5.0
 [v4.4.4]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.3...v4.4.4
 [v4.4.3]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.2...v4.4.3
 [v4.4.2]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.1...v4.4.2
@@ -186,4 +191,4 @@ v4 is a new extension rather than an in-place update of `lzm0x219.vscode-markdow
 [v4.1.1]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.1.0...v4.1.1
 [v4.1.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.0.0...v4.1.0
 [v4.0.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v3.1.0...v4.0.0
-[Unreleased]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.4...HEAD
+[Unreleased]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.5.0...HEAD


### PR DESCRIPTION
## Summary\n\n- Promote the curated user-facing entries from [Unreleased] to v4.5.0 dated 2026-08-26.\n- Add the v4.5.0 and updated Unreleased comparison links.\n\n## Validation\n\n- Release-note extraction tests: 9 passed.\n- Formatting check: passed.\n\nThis is the changelog prerequisite for release-please PR #1265.