### PR TITLE
fix(build): keep MarkdownIt v15 out of runtime bundle

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,9 +118,6 @@ jobs:
       - name: Verify Markdown parity baseline
         run: pnpm run verify:parity
 
-      - name: Build
-        run: nub run build
-
       - name: Generate release notes
         run: nub run release:note
 

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,6 +10,8 @@
 .oxlintrc.json
 .pnpm-store/**
 .pnpm-store
+.playwright-cli/**
+.playwright-cli
 .release-please-manifest.json
 .serena/**
 .serena

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "is-in-ci": "2.0.0",
     "lefthook": "2.1.10",
     "lightningcss": "1.33.0",
-    "markdown-it": "14.3.0",
+    "markdown-it": "15.0.0",
     "oxfmt": "0.65.0",
     "oxlint": "1.80.0",
     "oxlint-tsgolint": "7.0.2001",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "unicode-case-folding": "1.1.1"
   },
   "devDependencies": {
-    "@types/markdown-it": "14.2.0",
     "@types/node": "24.13.3",
     "@types/pngjs": "6.0.5",
     "@types/vscode": "1.74.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "test:host:web:preview": "nub run build && nub scripts/host/web-preview.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "package": "nub scripts/package/index.ts",
+    "package": "nub run build && nub scripts/package/index.ts",
     "release:note": "nub scripts/release/index.ts"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: 1.33.0
         version: 1.33.0
       markdown-it:
-        specifier: 14.3.0
-        version: 14.3.0
+        specifier: 15.0.0
+        version: 15.0.0
       node:
         specifier: runtime:24.19.0
         version: runtime:24.19.0
@@ -1434,6 +1434,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  argparse@3.0.1:
+    resolution: {integrity: sha512-nM4mHF/KM1v59ZNKX7zfusQz5wUAxR511YG8Vo6TyiV4aqhu++rbJW4v04xsWhpSsHFj66flT8P7znVpyO20xQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2370,6 +2373,9 @@ packages:
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
+  linkify-it@6.1.0:
+    resolution: {integrity: sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -2424,6 +2430,10 @@ packages:
 
   markdown-it@14.3.0:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
+  markdown-it@15.0.0:
+    resolution: {integrity: sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -3313,6 +3323,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  uc.micro@3.0.0:
+    resolution: {integrity: sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==}
 
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
@@ -4500,6 +4513,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  argparse@3.0.1: {}
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.5:
@@ -5408,6 +5423,10 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  linkify-it@6.1.0:
+    dependencies:
+      uc.micro: 3.0.0
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -5461,6 +5480,15 @@ snapshots:
       mdurl: 2.1.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+
+  markdown-it@15.0.0:
+    dependencies:
+      argparse: 3.0.1
+      entities: 8.0.0
+      linkify-it: 6.1.0
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 3.0.0
 
   math-intrinsics@1.1.0: {}
 
@@ -6327,6 +6355,8 @@ snapshots:
       '@typescript/typescript-win32-x64': 7.0.2
 
   uc.micro@2.1.0: {}
+
+  uc.micro@3.0.0: {}
 
   unconfig-core@7.5.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,9 +214,6 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
     devDependencies:
-      '@types/markdown-it':
-        specifier: 14.2.0
-        version: 14.2.0
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -1001,15 +998,6 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
-
-  '@types/linkify-it@5.0.0':
-    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
-
-  '@types/markdown-it@14.2.0':
-    resolution: {integrity: sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==}
-
-  '@types/mdurl@2.0.0':
-    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
@@ -4130,15 +4118,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
-
-  '@types/linkify-it@5.0.0': {}
-
-  '@types/markdown-it@14.2.0':
-    dependencies:
-      '@types/linkify-it': 5.0.0
-      '@types/mdurl': 2.0.0
-
-  '@types/mdurl@2.0.0': {}
 
   '@types/node@24.13.3':
     dependencies:

--- a/scripts/build/extension-bundle.ts
+++ b/scripts/build/extension-bundle.ts
@@ -1,0 +1,23 @@
+import { readFile } from "node:fs/promises";
+
+const staticRequirePattern = /\brequire\s*\(\s*(["'])([^"']+)\1\s*\)/g;
+const allowedExternalModules = new Set(["vscode"]);
+
+export function findUnexpectedExternalModules(source: string): string[] {
+  const externalModules = new Set<string>();
+  for (const match of source.matchAll(staticRequirePattern)) {
+    const moduleName = match[2];
+    if (moduleName && !allowedExternalModules.has(moduleName)) externalModules.add(moduleName);
+  }
+  return [...externalModules].sort();
+}
+
+export function assertExtensionBundleDependencies(source: string): void {
+  const unexpected = findUnexpectedExternalModules(source);
+  if (unexpected.length === 0) return;
+  throw new Error(`Unexpected external modules in extension bundle: ${unexpected.join(", ")}`);
+}
+
+export async function verifyExtensionBundle(path: string): Promise<void> {
+  assertExtensionBundleDependencies(await readFile(path, "utf8"));
+}

--- a/scripts/build/index.ts
+++ b/scripts/build/index.ts
@@ -2,6 +2,7 @@ import { rm } from "node:fs/promises";
 import { runLocalBinary } from "../shared/process";
 import { project } from "../shared/project";
 import { buildCss, formatCssBuild } from "./css";
+import { verifyExtensionBundle } from "./extension-bundle";
 import { shouldOpenVisualizer } from "./options";
 
 process.env["VISUALIZER_OPEN"] = String(shouldOpenVisualizer(process.argv.slice(2)));
@@ -10,5 +11,6 @@ await rm(project.paths.dist, { recursive: true, force: true });
 console.log("Building extension...");
 
 const [, css] = await Promise.all([runLocalBinary("tsdown", ["--minify"]), buildCss()]);
+await verifyExtensionBundle(project.paths.extensionBundle);
 console.log(formatCssBuild(css));
 console.log("Build complete");

--- a/scripts/package-audit/audit.ts
+++ b/scripts/package-audit/audit.ts
@@ -47,6 +47,7 @@ const forbiddenPackageFiles = new Set([
   "extension/assets/readme-banner.jpg",
   "extension/release-CHANGELOG.txt"
 ]);
+const forbiddenPackagePathPrefixes = ["extension/.playwright-cli/", "extension/.serena/"];
 
 export function auditPackageComparison(
   baseline: PackageSnapshot,
@@ -116,7 +117,10 @@ function auditMaximumPackageSize(current: PackageSnapshot): PackageAuditViolatio
 function auditForbiddenPackageFiles(current: PackageSnapshot): PackageAuditViolation[] {
   const violations: PackageAuditViolation[] = [];
   for (const path of Object.keys(current.entries).sort()) {
-    if (path.startsWith("extension/.serena/") || forbiddenPackageFiles.has(path)) {
+    if (
+      forbiddenPackagePathPrefixes.some((prefix) => path.startsWith(prefix)) ||
+      forbiddenPackageFiles.has(path)
+    ) {
       violations.push({ rule: "forbidden-file", path });
     }
   }

--- a/scripts/shared/project.ts
+++ b/scripts/shared/project.ts
@@ -9,6 +9,7 @@ export const project = {
   root,
   paths: {
     dist: join(root, "dist"),
+    extensionBundle: join(root, "dist", "extension.js"),
     packageJson: join(root, "package.json"),
     previewCssSource: join(root, "src", "extension.preview.css"),
     previewCssOutput: join(root, "dist", "extension.preview.css"),

--- a/scripts/verify/markdown.ts
+++ b/scripts/verify/markdown.ts
@@ -1,4 +1,4 @@
-import MarkdownIt from "markdown-it";
+import MarkdownIt, { type MarkdownIt as MarkdownItInstance } from "markdown-it";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import githubAlerts from "../../src/plugins/markdown-it-github-alerts";
@@ -30,7 +30,7 @@ export function verifyMarkdownCompatibility(): void {
   verifyMermaidBoundary();
 }
 
-function verifyDirectionality(markdown: MarkdownIt): void {
+function verifyDirectionality(markdown: MarkdownItInstance): void {
   const html = markdown.render(
     '# العربية\n\nMixed English العربية.\n\n- عنصر عربي\n\n`code العربية`\n\n```text\nblock العربية\n```\n\n<p dir="rtl">explicit العربية</p>\n'
   );
@@ -41,7 +41,7 @@ function verifyDirectionality(markdown: MarkdownIt): void {
   assert.match(html, /<p dir="rtl">explicit العربية<\/p>/, "explicit direction");
 }
 
-function verifyTagfilter(markdown: MarkdownIt): void {
+function verifyTagfilter(markdown: MarkdownItInstance): void {
   const html = markdown.render(
     "<strong>allowed</strong> <title>title</title> <textarea>textarea</textarea> <style>style</style> <xmp>xmp</xmp> <iframe>iframe</iframe> <noembed>noembed</noembed> <noframes>noframes</noframes> <script>script</script> <plaintext>plaintext</plaintext>\n"
   );
@@ -66,7 +66,7 @@ function verifyTagfilter(markdown: MarkdownIt): void {
   }
 }
 
-function verifyStrikethrough(markdown: MarkdownIt): void {
+function verifyStrikethrough(markdown: MarkdownItInstance): void {
   const html = markdown.render(
     "~~Hi~~ Hello, ~there~ world!\n\n\\~escaped\\~ `~code~` ~~ ~open ~~~not~~~\n"
   );
@@ -82,7 +82,7 @@ function verifyStrikethrough(markdown: MarkdownIt): void {
   );
 }
 
-function verifyTaskLists(markdown: MarkdownIt): void {
+function verifyTaskLists(markdown: MarkdownItInstance): void {
   const html = markdown.render(
     "- [x] #739\n- [ ] [https://github.com/octo-org/octo-repo/issues/740](https://github.com/octo-org/octo-repo/issues/740)\n"
   );
@@ -96,7 +96,7 @@ function verifyTaskLists(markdown: MarkdownIt): void {
   assert.match(html, /aria-label="Incomplete task"> <a href=/, "incomplete linked task item");
 }
 
-function verifyFootnotes(markdown: MarkdownIt): void {
+function verifyFootnotes(markdown: MarkdownItInstance): void {
   const html = markdown.render(
     "Here is a footnote[^1].\n\nHere is the same footnote[^1].\n\nAnother footnote[^2].\n\n[^1]: My *reference*.\n\n[^2]:\n    To add line breaks within a footnote, add 2 spaces to the end of a line.\n    This is a second line.\n"
   );
@@ -118,7 +118,7 @@ function verifyFootnotes(markdown: MarkdownIt): void {
   assert.doesNotMatch(wrapped, /<li[^>]*>[\s\S]*vscode-github-markdown/, "wrapped footnotes");
 }
 
-function verifyAlerts(markdown: MarkdownIt): void {
+function verifyAlerts(markdown: MarkdownItInstance): void {
   const html = markdown.render(
     "> [!NOTE]\n> Useful information that users should know, even when skimming content.\n"
   );
@@ -127,7 +127,7 @@ function verifyAlerts(markdown: MarkdownIt): void {
   assert.doesNotMatch(html, /<blockquote|markdown-alert-body/, "GitHub-compatible alert structure");
 }
 
-function verifyEmoji(markdown: MarkdownIt): void {
+function verifyEmoji(markdown: MarkdownItInstance): void {
   const html = markdown.render("Ship it :rocket: :+1: :warning: :shipit: :artist: :unknown:\n");
   assert.match(
     html,
@@ -157,7 +157,7 @@ function verifyMermaidBoundary(): void {
   );
 }
 
-function wrapRender(markdown: MarkdownIt): MarkdownIt {
+function wrapRender(markdown: MarkdownItInstance): MarkdownItInstance {
   const render = markdown.renderer.render.bind(markdown.renderer);
   markdown.renderer.render = (...args) =>
     `<div class="vscode-github-markdown">${render(...args)}</div>`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import vscode from "vscode";
-import { type MarkdownIt } from "markdown-it";
+import type { MarkdownIt } from "markdown-it";
 import { registerThemeCommands } from "./commands";
 import { registerMarkdownPreviewEvents } from "./events";
 import { restoreMermaidThemeSync, updateMermaidThemeSync } from "./integrations/mermaid";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import vscode from "vscode";
-import type MarkdownIt from "markdown-it";
+import { type MarkdownIt } from "markdown-it";
 import { registerThemeCommands } from "./commands";
 import { registerMarkdownPreviewEvents } from "./events";
 import { restoreMermaidThemeSync, updateMermaidThemeSync } from "./integrations/mermaid";

--- a/src/markdown-it.ts
+++ b/src/markdown-it.ts
@@ -1,4 +1,4 @@
-import type MarkdownIt from "markdown-it";
+import { type MarkdownIt } from "markdown-it";
 import alerts from "./plugins/markdown-it-github-alerts";
 import directionality from "./plugins/markdown-it-github-directionality";
 import emoji from "./plugins/markdown-it-github-emoji";

--- a/src/markdown-it.ts
+++ b/src/markdown-it.ts
@@ -1,4 +1,4 @@
-import { type MarkdownIt } from "markdown-it";
+import type { MarkdownIt } from "markdown-it";
 import alerts from "./plugins/markdown-it-github-alerts";
 import directionality from "./plugins/markdown-it-github-directionality";
 import emoji from "./plugins/markdown-it-github-emoji";

--- a/src/plugins/markdown-it-github-alerts.ts
+++ b/src/plugins/markdown-it-github-alerts.ts
@@ -1,4 +1,4 @@
-import type MarkdownIt from "markdown-it";
+import { type MarkdownIt } from "markdown-it";
 import type { MarkdownToken, MarkdownState } from "./shared";
 
 const alertTitles = {

--- a/src/plugins/markdown-it-github-alerts.ts
+++ b/src/plugins/markdown-it-github-alerts.ts
@@ -1,4 +1,4 @@
-import { type MarkdownIt } from "markdown-it";
+import type { MarkdownIt } from "markdown-it";
 import type { MarkdownToken, MarkdownState } from "./shared";
 
 const alertTitles = {

--- a/src/plugins/markdown-it-github-directionality.ts
+++ b/src/plugins/markdown-it-github-directionality.ts
@@ -1,4 +1,4 @@
-import type MarkdownIt from "markdown-it";
+import { type MarkdownIt } from "markdown-it";
 import type { MarkdownToken } from "./shared";
 
 const automaticDirectionRules = [
@@ -14,7 +14,12 @@ export default function markdownItGitHubDirectionality(md: MarkdownIt): Markdown
     wrapRendererRule(md, ruleName, normalizeAutomaticDirection);
   }
   wrapRendererRule(md, "blockquote_open", (token) => {
-    if (token.tag === "div" && token.attrGet("class")?.split(/\s+/).includes("markdown-alert")) {
+    const className = token.attrGet("class");
+    if (
+      token.tag === "div" &&
+      typeof className === "string" &&
+      className.split(/\s+/).includes("markdown-alert")
+    ) {
       normalizeAutomaticDirection(token);
     }
   });
@@ -44,7 +49,8 @@ function wrapRendererRule(
 }
 
 function normalizeAutomaticDirection(token: MarkdownToken): void {
-  const directions = token.attrGet("dir")?.split(/\s+/) ?? [];
+  const direction = token.attrGet("dir");
+  const directions = typeof direction === "string" ? direction.split(/\s+/) : [];
   const explicitDirection = directions.find(
     (direction) => direction === "ltr" || direction === "rtl"
   );

--- a/src/plugins/markdown-it-github-directionality.ts
+++ b/src/plugins/markdown-it-github-directionality.ts
@@ -1,4 +1,4 @@
-import { type MarkdownIt } from "markdown-it";
+import type { MarkdownIt } from "markdown-it";
 import type { MarkdownToken } from "./shared";
 
 const automaticDirectionRules = [

--- a/src/plugins/markdown-it-github-emoji.ts
+++ b/src/plugins/markdown-it-github-emoji.ts
@@ -1,4 +1,4 @@
-import type MarkdownIt from "markdown-it";
+import { type MarkdownIt } from "markdown-it";
 import type { MarkdownToken, MarkdownState } from "./shared";
 import { githubImageEmojiByAlias, githubUnicodeEmojiByAlias } from "../generated/github-emojis";
 

--- a/src/plugins/markdown-it-github-emoji.ts
+++ b/src/plugins/markdown-it-github-emoji.ts
@@ -1,4 +1,4 @@
-import { type MarkdownIt } from "markdown-it";
+import type { MarkdownIt } from "markdown-it";
 import type { MarkdownToken, MarkdownState } from "./shared";
 import { githubImageEmojiByAlias, githubUnicodeEmojiByAlias } from "../generated/github-emojis";
 

--- a/src/plugins/markdown-it-github-footnotes.ts
+++ b/src/plugins/markdown-it-github-footnotes.ts
@@ -1,5 +1,5 @@
 import { l10n } from "vscode";
-import { type MarkdownIt, type StateBlock } from "markdown-it";
+import type { MarkdownIt, StateBlock } from "markdown-it";
 import { caseFold } from "unicode-case-folding";
 import type { MarkdownToken, MarkdownState } from "./shared";
 

--- a/src/plugins/markdown-it-github-footnotes.ts
+++ b/src/plugins/markdown-it-github-footnotes.ts
@@ -1,6 +1,5 @@
 import { l10n } from "vscode";
-import type MarkdownIt from "markdown-it";
-import type StateBlock from "markdown-it/lib/rules_block/state_block.mjs";
+import { type MarkdownIt, type StateBlock } from "markdown-it";
 import { caseFold } from "unicode-case-folding";
 import type { MarkdownToken, MarkdownState } from "./shared";
 

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
+import type { MarkdownIt } from "markdown-it";
 import { replaceCodePoint } from "entities/decode";
-import { type MarkdownIt } from "markdown-it";
 
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const responsiveImageTagPattern = /<(?:img|source)(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
-import type MarkdownIt from "markdown-it";
 import { replaceCodePoint } from "entities/decode";
+import { type MarkdownIt } from "markdown-it";
 
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const responsiveImageTagPattern = /<(?:img|source)(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
@@ -135,12 +135,12 @@ export default function markdownItImageUrl(md: MarkdownIt): MarkdownIt {
   }
 
   const defaultImageRender =
-    md.renderer.rules.image ??
+    md.renderer.rules["image"] ??
     ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options));
-  md.renderer.rules.image = (tokens, idx, options, env, self) => {
+  md.renderer.rules["image"] = (tokens, idx, options, env, self) => {
     const token = tokens[idx];
     const src = token?.attrGet("src");
-    if (token && src && isProjectRootPath(src)) {
+    if (token && typeof src === "string" && isProjectRootPath(src)) {
       token.attrSet("src", toProjectRootResourceUri(src, env as ImageRenderEnv));
     }
     return defaultImageRender(tokens, idx, options, env, self);

--- a/src/plugins/markdown-it-github-strikethrough.ts
+++ b/src/plugins/markdown-it-github-strikethrough.ts
@@ -1,6 +1,4 @@
-import type MarkdownIt from "markdown-it";
-import type StateInline from "markdown-it/lib/rules_inline/state_inline.mjs";
-import type { Delimiter } from "markdown-it/lib/rules_inline/state_inline.mjs";
+import { type Delimiter, type MarkdownIt, type StateInline } from "markdown-it";
 
 const tildeCharacter = 0x7e;
 const singleTildeDelimiter = 0x1007e;
@@ -41,7 +39,7 @@ function postProcessStrikethrough(state: StateInline): boolean {
   applyStrikethroughTokens(state, state.delimiters);
 
   for (const metadata of state.tokens_meta) {
-    if (metadata) {
+    if (metadata?.delimiters) {
       applyStrikethroughTokens(state, metadata.delimiters);
     }
   }

--- a/src/plugins/markdown-it-github-strikethrough.ts
+++ b/src/plugins/markdown-it-github-strikethrough.ts
@@ -1,4 +1,4 @@
-import { type Delimiter, type MarkdownIt, type StateInline } from "markdown-it";
+import type { Delimiter, MarkdownIt, StateInline } from "markdown-it";
 
 const tildeCharacter = 0x7e;
 const singleTildeDelimiter = 0x1007e;

--- a/src/plugins/markdown-it-github-tagfilter.ts
+++ b/src/plugins/markdown-it-github-tagfilter.ts
@@ -1,4 +1,4 @@
-import { type MarkdownIt } from "markdown-it";
+import type { MarkdownIt } from "markdown-it";
 
 const disallowedRawHtmlTag =
   /<(?=\/?(?:title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext)(?:[\t\n\f\r />]|$))/gi;

--- a/src/plugins/markdown-it-github-tagfilter.ts
+++ b/src/plugins/markdown-it-github-tagfilter.ts
@@ -1,4 +1,4 @@
-import type MarkdownIt from "markdown-it";
+import { type MarkdownIt } from "markdown-it";
 
 const disallowedRawHtmlTag =
   /<(?=\/?(?:title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext)(?:[\t\n\f\r />]|$))/gi;

--- a/src/plugins/markdown-it-github-task-lists.ts
+++ b/src/plugins/markdown-it-github-task-lists.ts
@@ -1,5 +1,5 @@
 import { l10n } from "vscode";
-import { type MarkdownIt } from "markdown-it";
+import type { MarkdownIt } from "markdown-it";
 import type { MarkdownToken, MarkdownState } from "./shared";
 
 const taskListMarkerPattern = /^[ \t]*\[( |x|X)\][ \t]+/;

--- a/src/plugins/markdown-it-github-task-lists.ts
+++ b/src/plugins/markdown-it-github-task-lists.ts
@@ -1,5 +1,5 @@
 import { l10n } from "vscode";
-import type MarkdownIt from "markdown-it";
+import { type MarkdownIt } from "markdown-it";
 import type { MarkdownToken, MarkdownState } from "./shared";
 
 const taskListMarkerPattern = /^[ \t]*\[( |x|X)\][ \t]+/;
@@ -69,7 +69,7 @@ function applyTaskLists(state: MarkdownState) {
 
 function attrJoinOnce(token: MarkdownToken, name: string, value: string) {
   const current = token.attrGet(name);
-  if (current?.split(/\s+/).includes(value)) {
+  if (typeof current === "string" && current.split(/\s+/).includes(value)) {
     return;
   }
 

--- a/src/plugins/markdown-it-github-theme.ts
+++ b/src/plugins/markdown-it-github-theme.ts
@@ -1,4 +1,4 @@
-import type MarkdownIt from "markdown-it";
+import { type MarkdownIt } from "markdown-it";
 import { getLinkUnderlines } from "../accessibility";
 import { getThemeColorMode, getCurrentLightTheme, getCurrentDarkTheme } from "../theme";
 

--- a/src/plugins/markdown-it-github-theme.ts
+++ b/src/plugins/markdown-it-github-theme.ts
@@ -1,4 +1,4 @@
-import { type MarkdownIt } from "markdown-it";
+import type { MarkdownIt } from "markdown-it";
 import { getLinkUnderlines } from "../accessibility";
 import { getThemeColorMode, getCurrentLightTheme, getCurrentDarkTheme } from "../theme";
 

--- a/src/plugins/shared.ts
+++ b/src/plugins/shared.ts
@@ -1,4 +1,4 @@
-import { type MarkdownIt } from "markdown-it";
+import type { MarkdownIt } from "markdown-it";
 
 export type MarkdownToken = ReturnType<MarkdownIt["parse"]>[number];
 

--- a/src/plugins/shared.ts
+++ b/src/plugins/shared.ts
@@ -1,4 +1,4 @@
-import type MarkdownIt from "markdown-it";
+import { type MarkdownIt } from "markdown-it";
 
 export type MarkdownToken = ReturnType<MarkdownIt["parse"]>[number];
 

--- a/tests/host/smoke.ts
+++ b/tests/host/smoke.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import MarkdownIt from "markdown-it";
+import MarkdownIt, { type MarkdownIt as MarkdownItInstance } from "markdown-it";
 
 type ExtensionApi = {
-  extendMarkdownIt(markdownIt: MarkdownIt): MarkdownIt;
+  extendMarkdownIt(markdownIt: MarkdownItInstance): MarkdownItInstance;
 };
 
 const disallowedRawHtmlTags = [

--- a/tests/plugins/integration.test.ts
+++ b/tests/plugins/integration.test.ts
@@ -1,4 +1,4 @@
-import MarkdownIt from "markdown-it";
+import MarkdownIt, { type MarkdownIt as MarkdownItInstance } from "markdown-it";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("vscode", () => ({
@@ -29,7 +29,7 @@ vi.mock("vscode", () => ({
 
 import { extendMarkdownIt } from "../../src/markdown-it";
 
-function createChain(): MarkdownIt {
+function createChain(): MarkdownItInstance {
   return extendMarkdownIt(new MarkdownIt({ html: true }));
 }
 

--- a/tests/scripts/build/extension-bundle.test.ts
+++ b/tests/scripts/build/extension-bundle.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertExtensionBundleDependencies,
+  findUnexpectedExternalModules
+} from "../../../scripts/build/extension-bundle";
+
+describe("extension bundle dependencies", () => {
+  it("allows the VS Code host dependency", () => {
+    expect(findUnexpectedExternalModules('const vscode = require("vscode");')).toEqual([]);
+  });
+
+  it("reports sorted unique unexpected external modules", () => {
+    const source = [
+      'require("vscode")',
+      'require("markdown-it")',
+      "require('entities')",
+      'require("entities")'
+    ].join(";");
+
+    expect(findUnexpectedExternalModules(source)).toEqual(["entities", "markdown-it"]);
+  });
+
+  it("rejects bundles with unexpected external modules", () => {
+    expect(() => assertExtensionBundleDependencies('require("entities")')).toThrow(
+      "Unexpected external modules in extension bundle: entities"
+    );
+  });
+});

--- a/tests/scripts/package-audit/audit.test.ts
+++ b/tests/scripts/package-audit/audit.test.ts
@@ -77,6 +77,7 @@ describe("auditPackageComparison", () => {
       {
         archiveBytes: 200_000,
         entries: {
+          "extension/.playwright-cli/console.log": 143,
           "extension/.serena/project.yml": 9_375,
           "extension/assets/parity-github.png": 9_879,
           "extension/assets/readme-banner.jpg": 79_611,
@@ -86,6 +87,7 @@ describe("auditPackageComparison", () => {
     );
 
     expect(report.violations).toEqual([
+      { rule: "forbidden-file", path: "extension/.playwright-cli/console.log" },
       { rule: "forbidden-file", path: "extension/.serena/project.yml" },
       { rule: "forbidden-file", path: "extension/assets/parity-github.png" },
       { rule: "forbidden-file", path: "extension/assets/readme-banner.jpg" },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -17,15 +17,7 @@ export default defineConfig({
   deps: {
     alwaysBundle: ["entities/decode", "unicode-case-folding"],
     neverBundle: ["vscode"],
-    onlyBundle: [
-      "entities",
-      "linkify-it",
-      "markdown-it",
-      "mdurl",
-      "punycode.js",
-      "uc.micro",
-      "unicode-case-folding"
-    ]
+    onlyBundle: ["entities", "unicode-case-folding"]
   },
   plugins: [
     visualizer({

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -17,7 +17,15 @@ export default defineConfig({
   deps: {
     alwaysBundle: ["entities/decode", "unicode-case-folding"],
     neverBundle: ["vscode"],
-    onlyBundle: ["entities", "unicode-case-folding"]
+    onlyBundle: [
+      "entities",
+      "linkify-it",
+      "markdown-it",
+      "mdurl",
+      "punycode.js",
+      "uc.micro",
+      "unicode-case-folding"
+    ]
   },
   plugins: [
     visualizer({


### PR DESCRIPTION
## Summary

- update MarkdownIt to v15 and keep its integration imports type-only
- reject unexpected external runtime dependencies in the extension bundle
- rebuild before packaging and exclude local browser artifacts from VSIX files

## Verification

- `nubx oxfmt --check .`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nub run test:coverage` — 52 files, 377 tests passed
- `nub run package` — 89.63 KB
- VSIX audit against official v4.5.0 — 91,786 bytes, +22 bytes (+0.02%)