### PR TITLE
fix(deps): align MarkdownIt with VS Code host

### DIFF
--- a/docs/research/markdown-it-version-alignment.md
+++ b/docs/research/markdown-it-version-alignment.md
@@ -1,0 +1,30 @@
+# MarkdownIt 与 VS Code 宿主版本对齐
+
+核对日期：2026-08-31。这里只采用 VS Code 官方仓库的版本化 manifest、锁文件和实现源码；“stable”按当天官方最新稳定版 `1.135.0` 解释。
+
+## 结论
+
+- `markdown-it@15.0.0` **不对应当前任何受测 VS Code 宿主**。它来自 Renovate 的 [`2e4ca0cf`](https://github.com/lzm0x219/vscode-github-markdown/commit/2e4ca0cf6636b10c4c1996ffdaf9b34eada1131e) 自动升级，随后随 [PR #1301](https://github.com/lzm0x219/vscode-github-markdown/pull/1301) 合入；不是 VS Code 兼容性要求。
+- 项目的最终预览固定宿主 `1.129.0` 和当前稳定版 `1.135.0` 都实际安装 `markdown-it@14.2.0`。因此本项目用于单测、本地一致性渲染和类型检查的主 `devDependency` 应固定为 **`markdown-it@14.2.0`**，并恢复该宿主使用的 **`@types/markdown-it@14.1.2`**。
+- 最低支持宿主 `1.74.0` 使用 `markdown-it@12.3.2`。一个本地依赖无法同时精确等于 12.3.2 和 14.2.0；最低版兼容性应继续由真实 `1.74.0` host smoke 保证。新增插件逻辑不得依赖只在 14.x 存在的运行时 API，必要时应再增加最低版最终预览用例。
+- 不应继续使用 15.x，除非 VS Code 的目标/固定宿主也升级到内置 15.x，或项目明确改为自带独立 MarkdownIt 运行时。当前扩展并非这种架构。
+
+## 版本证据
+
+| 项目对应宿主   | 项目中的选择                                                                                                  | VS Code manifest                                      | VS Code 锁文件实际版本                            |
+| -------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------- |
+| 最低支持桌面版 | `engines.vscode = ^1.74.0`；CI 下载 `1.74.0`                                                                  | `markdown-it: ^12.3.2`；`@types/markdown-it: 12.2.3`  | `markdown-it@12.3.2`                              |
+| 固定最终预览   | 桌面 `1.129.0`；Web commit `125df467…`，即官方 `1.129.0` tag commit                                           | `markdown-it: ^14.2.0`；`@types/markdown-it: ^14.1.2` | `markdown-it@14.2.0`；`@types/markdown-it@14.1.2` |
+| 当前稳定版     | CI 使用动态 `stable`；2026-08-31 对应官方 [1.135.0](https://github.com/microsoft/vscode/releases/tag/1.135.0) | `markdown-it: ^14.2.0`；`@types/markdown-it: ^14.1.2` | `markdown-it@14.2.0`；`@types/markdown-it@14.1.2` |
+
+项目自身的版本和 CI 入口见 [`package.json`](../../package.json#L66-L80)、[`engines.vscode`](../../package.json#L260-L262)、[host matrix](../../.github/workflows/ci.yml#L62-L82) 和 [`hostVersions`](../../scripts/host/versions.ts#L1-L7)。官方版本化证据如下：
+
+- VS Code 1.74.0：[manifest](https://github.com/microsoft/vscode/blob/1.74.0/extensions/markdown-language-features/package.json#L622-L637)、[yarn.lock](https://github.com/microsoft/vscode/blob/1.74.0/extensions/markdown-language-features/yarn.lock#L420-L423)。
+- VS Code 1.129.0：[manifest](https://github.com/microsoft/vscode/blob/1.129.0/extensions/markdown-language-features/package.json#L914-L930)、[package-lock.json](https://github.com/microsoft/vscode/blob/1.129.0/extensions/markdown-language-features/package-lock.json#L1532-L1535)、[类型锁定](https://github.com/microsoft/vscode/blob/1.129.0/extensions/markdown-language-features/package-lock.json#L535-L537)。固定 Web commit 与该 tag 的 commit 均为 [`125df4672b8a6a34975303c6b0baa124e560a4f7`](https://github.com/microsoft/vscode/commit/125df4672b8a6a34975303c6b0baa124e560a4f7)。
+- VS Code 1.135.0：[manifest](https://github.com/microsoft/vscode/blob/1.135.0/extensions/markdown-language-features/package.json#L1792-L1808)、[package-lock.json](https://github.com/microsoft/vscode/blob/1.135.0/extensions/markdown-language-features/package-lock.json#L1562-L1565)、[类型锁定](https://github.com/microsoft/vscode/blob/1.135.0/extensions/markdown-language-features/package-lock.json#L536-L538)。
+
+## 为什么必须按宿主对齐
+
+VS Code 的 Markdown 引擎先从其内置依赖创建 MarkdownIt 实例，再把**同一个实例**逐个交给 `markdown.markdownItPlugins` 贡献者处理：[1.74.0 实现](https://github.com/microsoft/vscode/blob/1.74.0/extensions/markdown-language-features/src/markdownEngine.ts#L120-L131)、[1.135.0 实现](https://github.com/microsoft/vscode/blob/1.135.0/extensions/markdown-language-features/src/markdownEngine.ts#L133-L144)。本扩展也只是导出 `extendMarkdownIt(md)` 并修改传入实例，没有创建或携带生产运行时，见 [`src/extension.ts`](../../src/extension.ts#L10-L23) 和 [`src/markdown-it.ts`](../../src/markdown-it.ts#L12-L22)。
+
+所以本地 `markdown-it` 的职责是模拟宿主用于单元测试和生成基线，而不是决定用户 VS Code 中的实际版本。用 15.x 跑本地测试会制造一个生产宿主不存在的验证环境；固定为 14.2.0 才能与当前稳定/固定预览宿主一致，同时保留 1.74.0 真实宿主测试覆盖旧版兼容边界。

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "unicode-case-folding": "1.1.1"
   },
   "devDependencies": {
+    "@types/markdown-it": "14.1.2",
     "@types/node": "24.13.3",
     "@types/pngjs": "6.0.5",
     "@types/vscode": "1.74.0",
@@ -76,7 +77,7 @@
     "is-in-ci": "2.0.0",
     "lefthook": "2.1.12",
     "lightningcss": "1.33.0",
-    "markdown-it": "15.0.0",
+    "markdown-it": "14.2.0",
     "oxfmt": "0.65.0",
     "oxlint": "1.80.0",
     "oxlint-tsgolint": "7.0.2001",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
     devDependencies:
+      '@types/markdown-it':
+        specifier: 14.1.2
+        version: 14.1.2
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -153,8 +156,8 @@ importers:
         specifier: 1.33.0
         version: 1.33.0
       markdown-it:
-        specifier: 15.0.0
-        version: 15.0.0
+        specifier: 14.2.0
+        version: 14.2.0
       node:
         specifier: runtime:24.19.0
         version: runtime:24.19.0
@@ -901,6 +904,15 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
@@ -1323,9 +1335,6 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-
-  argparse@3.0.1:
-    resolution: {integrity: sha512-nM4mHF/KM1v59ZNKX7zfusQz5wUAxR511YG8Vo6TyiV4aqhu++rbJW4v04xsWhpSsHFj66flT8P7znVpyO20xQ==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -2263,9 +2272,6 @@ packages:
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
-  linkify-it@6.1.0:
-    resolution: {integrity: sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==}
-
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -2318,12 +2324,12 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  markdown-it@14.3.1:
-    resolution: {integrity: sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
-  markdown-it@15.0.0:
-    resolution: {integrity: sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==}
+  markdown-it@14.3.1:
+    resolution: {integrity: sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -3214,9 +3220,6 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
-  uc.micro@3.0.0:
-    resolution: {integrity: sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==}
-
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
@@ -4021,6 +4024,15 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
@@ -4393,8 +4405,6 @@ snapshots:
   ansis@4.3.1: {}
 
   argparse@2.0.1: {}
-
-  argparse@3.0.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -5304,10 +5314,6 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  linkify-it@6.1.0:
-    dependencies:
-      uc.micro: 3.0.0
-
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -5353,7 +5359,7 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  markdown-it@14.3.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
@@ -5362,14 +5368,14 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
-  markdown-it@15.0.0:
+  markdown-it@14.3.1:
     dependencies:
-      argparse: 3.0.1
-      entities: 8.0.0
-      linkify-it: 6.1.0
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
       mdurl: 2.1.0
       punycode.js: 2.3.1
-      uc.micro: 3.0.0
+      uc.micro: 2.1.0
 
   math-intrinsics@1.1.0: {}
 
@@ -6236,8 +6242,6 @@ snapshots:
       '@typescript/typescript-win32-x64': 7.0.2
 
   uc.micro@2.1.0: {}
-
-  uc.micro@3.0.0: {}
 
   unconfig-core@7.5.0:
     dependencies:

--- a/scripts/host/versions.ts
+++ b/scripts/host/versions.ts
@@ -1,8 +1,10 @@
 export const hostVersions = {
   latestStableDesktop: "stable",
-  // Pinning each host also pins its bundled Mermaid and KaTeX renderers.
+  // Pinning each host also pins its bundled MarkdownIt, Mermaid, and KaTeX renderers.
   pinnedPreview: {
     desktopVersion: "1.129.0",
+    markdownItVersion: "14.2.0",
+    markdownItTypesVersion: "14.1.2",
     webCommit: "125df4672b8a6a34975303c6b0baa124e560a4f7"
   }
 } as const;

--- a/scripts/verify/markdown.ts
+++ b/scripts/verify/markdown.ts
@@ -1,4 +1,4 @@
-import MarkdownIt, { type MarkdownIt as MarkdownItInstance } from "markdown-it";
+import MarkdownIt from "markdown-it";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import githubAlerts from "../../src/plugins/markdown-it-github-alerts";
@@ -30,7 +30,7 @@ export function verifyMarkdownCompatibility(): void {
   verifyMermaidBoundary();
 }
 
-function verifyDirectionality(markdown: MarkdownItInstance): void {
+function verifyDirectionality(markdown: MarkdownIt): void {
   const html = markdown.render(
     '# العربية\n\nMixed English العربية.\n\n- عنصر عربي\n\n`code العربية`\n\n```text\nblock العربية\n```\n\n<p dir="rtl">explicit العربية</p>\n'
   );
@@ -41,7 +41,7 @@ function verifyDirectionality(markdown: MarkdownItInstance): void {
   assert.match(html, /<p dir="rtl">explicit العربية<\/p>/, "explicit direction");
 }
 
-function verifyTagfilter(markdown: MarkdownItInstance): void {
+function verifyTagfilter(markdown: MarkdownIt): void {
   const html = markdown.render(
     "<strong>allowed</strong> <title>title</title> <textarea>textarea</textarea> <style>style</style> <xmp>xmp</xmp> <iframe>iframe</iframe> <noembed>noembed</noembed> <noframes>noframes</noframes> <script>script</script> <plaintext>plaintext</plaintext>\n"
   );
@@ -66,7 +66,7 @@ function verifyTagfilter(markdown: MarkdownItInstance): void {
   }
 }
 
-function verifyStrikethrough(markdown: MarkdownItInstance): void {
+function verifyStrikethrough(markdown: MarkdownIt): void {
   const html = markdown.render(
     "~~Hi~~ Hello, ~there~ world!\n\n\\~escaped\\~ `~code~` ~~ ~open ~~~not~~~\n"
   );
@@ -82,7 +82,7 @@ function verifyStrikethrough(markdown: MarkdownItInstance): void {
   );
 }
 
-function verifyTaskLists(markdown: MarkdownItInstance): void {
+function verifyTaskLists(markdown: MarkdownIt): void {
   const html = markdown.render(
     "- [x] #739\n- [ ] [https://github.com/octo-org/octo-repo/issues/740](https://github.com/octo-org/octo-repo/issues/740)\n"
   );
@@ -96,7 +96,7 @@ function verifyTaskLists(markdown: MarkdownItInstance): void {
   assert.match(html, /aria-label="Incomplete task"> <a href=/, "incomplete linked task item");
 }
 
-function verifyFootnotes(markdown: MarkdownItInstance): void {
+function verifyFootnotes(markdown: MarkdownIt): void {
   const html = markdown.render(
     "Here is a footnote[^1].\n\nHere is the same footnote[^1].\n\nAnother footnote[^2].\n\n[^1]: My *reference*.\n\n[^2]:\n    To add line breaks within a footnote, add 2 spaces to the end of a line.\n    This is a second line.\n"
   );
@@ -118,7 +118,7 @@ function verifyFootnotes(markdown: MarkdownItInstance): void {
   assert.doesNotMatch(wrapped, /<li[^>]*>[\s\S]*vscode-github-markdown/, "wrapped footnotes");
 }
 
-function verifyAlerts(markdown: MarkdownItInstance): void {
+function verifyAlerts(markdown: MarkdownIt): void {
   const html = markdown.render(
     "> [!NOTE]\n> Useful information that users should know, even when skimming content.\n"
   );
@@ -127,7 +127,7 @@ function verifyAlerts(markdown: MarkdownItInstance): void {
   assert.doesNotMatch(html, /<blockquote|markdown-alert-body/, "GitHub-compatible alert structure");
 }
 
-function verifyEmoji(markdown: MarkdownItInstance): void {
+function verifyEmoji(markdown: MarkdownIt): void {
   const html = markdown.render("Ship it :rocket: :+1: :warning: :shipit: :artist: :unknown:\n");
   assert.match(
     html,
@@ -157,7 +157,7 @@ function verifyMermaidBoundary(): void {
   );
 }
 
-function wrapRender(markdown: MarkdownItInstance): MarkdownItInstance {
+function wrapRender(markdown: MarkdownIt): MarkdownIt {
   const render = markdown.renderer.render.bind(markdown.renderer);
   markdown.renderer.render = (...args) =>
     `<div class="vscode-github-markdown">${render(...args)}</div>`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import vscode from "vscode";
-import type { MarkdownIt } from "markdown-it";
+import type MarkdownIt from "markdown-it";
 import { registerThemeCommands } from "./commands";
 import { registerMarkdownPreviewEvents } from "./events";
 import { restoreMermaidThemeSync, updateMermaidThemeSync } from "./integrations/mermaid";

--- a/src/markdown-it.ts
+++ b/src/markdown-it.ts
@@ -1,4 +1,4 @@
-import type { MarkdownIt } from "markdown-it";
+import type MarkdownIt from "markdown-it";
 import alerts from "./plugins/markdown-it-github-alerts";
 import directionality from "./plugins/markdown-it-github-directionality";
 import emoji from "./plugins/markdown-it-github-emoji";

--- a/src/plugins/markdown-it-github-alerts.ts
+++ b/src/plugins/markdown-it-github-alerts.ts
@@ -1,4 +1,4 @@
-import type { MarkdownIt } from "markdown-it";
+import type MarkdownIt from "markdown-it";
 import type { MarkdownToken, MarkdownState } from "./shared";
 
 const alertTitles = {

--- a/src/plugins/markdown-it-github-directionality.ts
+++ b/src/plugins/markdown-it-github-directionality.ts
@@ -1,4 +1,4 @@
-import type { MarkdownIt } from "markdown-it";
+import type MarkdownIt from "markdown-it";
 import type { MarkdownToken } from "./shared";
 
 const automaticDirectionRules = [

--- a/src/plugins/markdown-it-github-emoji.ts
+++ b/src/plugins/markdown-it-github-emoji.ts
@@ -1,4 +1,4 @@
-import type { MarkdownIt } from "markdown-it";
+import type MarkdownIt from "markdown-it";
 import type { MarkdownToken, MarkdownState } from "./shared";
 import { githubImageEmojiByAlias, githubUnicodeEmojiByAlias } from "../generated/github-emojis";
 

--- a/src/plugins/markdown-it-github-footnotes.ts
+++ b/src/plugins/markdown-it-github-footnotes.ts
@@ -1,5 +1,6 @@
 import { l10n } from "vscode";
-import type { MarkdownIt, StateBlock } from "markdown-it";
+import type MarkdownIt from "markdown-it";
+import type StateBlock from "markdown-it/lib/rules_block/state_block.mjs";
 import { caseFold } from "unicode-case-folding";
 import type { MarkdownToken, MarkdownState } from "./shared";
 

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import type { MarkdownIt } from "markdown-it";
+import type MarkdownIt from "markdown-it";
 import { replaceCodePoint } from "entities/decode";
 
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;

--- a/src/plugins/markdown-it-github-strikethrough.ts
+++ b/src/plugins/markdown-it-github-strikethrough.ts
@@ -1,4 +1,6 @@
-import type { Delimiter, MarkdownIt, StateInline } from "markdown-it";
+import type MarkdownIt from "markdown-it";
+import type StateInline from "markdown-it/lib/rules_inline/state_inline.mjs";
+import type { Delimiter } from "markdown-it/lib/rules_inline/state_inline.mjs";
 
 const tildeCharacter = 0x7e;
 const singleTildeDelimiter = 0x1007e;

--- a/src/plugins/markdown-it-github-tagfilter.ts
+++ b/src/plugins/markdown-it-github-tagfilter.ts
@@ -1,4 +1,4 @@
-import type { MarkdownIt } from "markdown-it";
+import type MarkdownIt from "markdown-it";
 
 const disallowedRawHtmlTag =
   /<(?=\/?(?:title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext)(?:[\t\n\f\r />]|$))/gi;

--- a/src/plugins/markdown-it-github-task-lists.ts
+++ b/src/plugins/markdown-it-github-task-lists.ts
@@ -1,5 +1,5 @@
 import { l10n } from "vscode";
-import type { MarkdownIt } from "markdown-it";
+import type MarkdownIt from "markdown-it";
 import type { MarkdownToken, MarkdownState } from "./shared";
 
 const taskListMarkerPattern = /^[ \t]*\[( |x|X)\][ \t]+/;

--- a/src/plugins/markdown-it-github-theme.ts
+++ b/src/plugins/markdown-it-github-theme.ts
@@ -1,4 +1,4 @@
-import type { MarkdownIt } from "markdown-it";
+import type MarkdownIt from "markdown-it";
 import { getLinkUnderlines } from "../accessibility";
 import { getThemeColorMode, getCurrentLightTheme, getCurrentDarkTheme } from "../theme";
 

--- a/src/plugins/shared.ts
+++ b/src/plugins/shared.ts
@@ -1,4 +1,4 @@
-import type { MarkdownIt } from "markdown-it";
+import type MarkdownIt from "markdown-it";
 
 export type MarkdownToken = ReturnType<MarkdownIt["parse"]>[number];
 

--- a/tests/host/smoke.ts
+++ b/tests/host/smoke.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import MarkdownIt, { type MarkdownIt as MarkdownItInstance } from "markdown-it";
+import MarkdownIt from "markdown-it";
 
 type ExtensionApi = {
-  extendMarkdownIt(markdownIt: MarkdownItInstance): MarkdownItInstance;
+  extendMarkdownIt(markdownIt: MarkdownIt): MarkdownIt;
 };
 
 const disallowedRawHtmlTags = [

--- a/tests/plugins/integration.test.ts
+++ b/tests/plugins/integration.test.ts
@@ -1,4 +1,4 @@
-import MarkdownIt, { type MarkdownIt as MarkdownItInstance } from "markdown-it";
+import MarkdownIt from "markdown-it";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("vscode", () => ({
@@ -29,7 +29,7 @@ vi.mock("vscode", () => ({
 
 import { extendMarkdownIt } from "../../src/markdown-it";
 
-function createChain(): MarkdownItInstance {
+function createChain(): MarkdownIt {
   return extendMarkdownIt(new MarkdownIt({ html: true }));
 }
 

--- a/tests/scripts/host/versions.test.ts
+++ b/tests/scripts/host/versions.test.ts
@@ -7,8 +7,23 @@ describe("hostVersions", () => {
     expect(hostVersions.latestStableDesktop).toBe("stable");
     expect(hostVersions.pinnedPreview).toEqual({
       desktopVersion: "1.129.0",
+      markdownItVersion: "14.2.0",
+      markdownItTypesVersion: "14.1.2",
       webCommit: "125df4672b8a6a34975303c6b0baa124e560a4f7"
     });
+  });
+
+  it("matches the MarkdownIt dependency to the pinned VS Code preview host", () => {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../../../package.json", import.meta.url), "utf8")
+    ) as { devDependencies?: Record<string, string> };
+
+    expect(manifest.devDependencies?.["markdown-it"]).toBe(
+      hostVersions.pinnedPreview.markdownItVersion
+    );
+    expect(manifest.devDependencies?.["@types/markdown-it"]).toBe(
+      hostVersions.pinnedPreview.markdownItTypesVersion
+    );
   });
 
   it("keeps the pinned desktop version in one source of truth", () => {


### PR DESCRIPTION
## Summary

- align local MarkdownIt with the pinned VS Code preview host: `markdown-it@14.2.0` and `@types/markdown-it@14.1.2`
- restore the v14-compatible type imports while keeping MarkdownIt out of the production bundle
- add a contract test tying dependency versions to the pinned host and document the official VS Code version evidence

## Verification

- `nubx oxfmt --check .`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nub run test:coverage` — 52 files, 378 tests passed
- VS Code `1.129.0` desktop host smoke passed
- VS Code `1.74.0` desktop host smoke passed
- `nub run package` — 89.64 KB