### PR TITLE
fix(release): verify changelog before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Verify Markdown parity baseline
         run: pnpm run verify:parity
 
+      - name: Verify release changelog
+        run: nub run verify:release
+
       - name: Upload Markdown parity images
         if: failure()
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+## [v4.5.1] - 2026-09-01
+
+v4.5.1 preserves Markdown preview compatibility with VS Code's built-in Markdown parser. No settings changes are required.
+
+### Installation and compatibility
+
+- Markdown previews continue to use the parser provided by VS Code, preventing an additional bundled parser version from changing preview behavior.
+
 ## [v4.5.0] - 2026-08-26
 
 v4.5.0 improves GitHub Markdown preview fidelity and reliability across nested images, accessibility, Mermaid synchronization, and Marketplace installation.
@@ -180,6 +188,7 @@ v4 is a new extension rather than an in-place update of `lzm0x219.vscode-markdow
 - v4 supports VS Code 1.74 or later and continues to enhance the built-in Markdown preview instead of opening a separate preview editor.
 - Commands and settings are available in English and Simplified Chinese according to the VS Code display language.
 
+[v4.5.1]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.5.0...v4.5.1
 [v4.5.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.4...v4.5.0
 [v4.4.4]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.3...v4.4.4
 [v4.4.3]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.2...v4.4.3
@@ -191,4 +200,4 @@ v4 is a new extension rather than an in-place update of `lzm0x219.vscode-markdow
 [v4.1.1]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.1.0...v4.1.1
 [v4.1.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.0.0...v4.1.0
 [v4.0.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v3.1.0...v4.0.0
-[Unreleased]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.5.0...HEAD
+[Unreleased]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.5.1...HEAD

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "verify:parity": "nub scripts/parity/index.ts check",
     "verify:parity:remote": "nub scripts/parity/index.ts remote",
     "verify:parity:report": "nub scripts/parity/index.ts report",
+    "verify:release": "nub scripts/release/verify-index.ts",
     "probe:drift": "nub scripts/drift/index.ts",
     "drill:drift": "nub scripts/drift/drill-index.ts",
     "i18n-export": "nubx vscode-l10n-dev export --outDir ./l10n ./src",

--- a/scripts/release/verify-index.ts
+++ b/scripts/release/verify-index.ts
@@ -1,0 +1,15 @@
+import { readFile } from "node:fs/promises";
+import { project } from "../shared/project";
+import { extractRelease } from "./changelog";
+
+const [manifestSource, changelog] = await Promise.all([
+  readFile(project.paths.packageJson, "utf8"),
+  readFile(project.paths.changelog, "utf8")
+]);
+const manifest = JSON.parse(manifestSource) as { version?: unknown };
+if (typeof manifest.version !== "string") {
+  throw new Error("Cannot verify release notes: package.json version is missing");
+}
+
+extractRelease(changelog, manifest.version);
+console.log(`Release changelog contains v${manifest.version}`);

--- a/tests/scripts/release/verification-workflow.test.ts
+++ b/tests/scripts/release/verification-workflow.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("release changelog verification", () => {
+  it("runs the release-note contract before changes can merge", () => {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../../../package.json", import.meta.url), "utf8")
+    ) as { scripts?: Record<string, string> };
+    const workflow = readFileSync(
+      new URL("../../../.github/workflows/ci.yml", import.meta.url),
+      "utf8"
+    );
+
+    expect(manifest.scripts?.["verify:release"]).toBe("nub scripts/release/verify-index.ts");
+    expect(workflow).toContain("run: nub run verify:release");
+  });
+});


### PR DESCRIPTION
## Summary

- add the curated v4.5.1 changelog section
- verify that the manifest version has matching release notes during ordinary CI
- reuse the same release-note extraction contract used by publication

## Verification

- nub run test
- nub run build
- nub run verify:release
- nubx oxfmt --check on touched files
- nubx oxlint on touched TypeScript files