### PR TITLE
ci(host): add VS Code Insiders canary

### DIFF
--- a/.github/workflows/host-canary.yml
+++ b/.github/workflows/host-canary.yml
@@ -1,0 +1,60 @@
+name: VS Code host canary
+
+on:
+  schedule:
+    - cron: "43 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: vscode-host-canary
+  cancel-in-progress: true
+
+jobs:
+  insiders:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Test VS Code Insiders host compatibility
+        id: smoke
+        continue-on-error: true
+        env:
+          VSCODE_TEST_VERSION: insiders
+        run: xvfb-run -a nub run test:host:desktop
+
+      - name: Create or update the deduplicated host canary issue
+        if: always() && steps.smoke.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: "[Host canary] VS Code Insiders compatibility changed"
+          ISSUE_BODY: |
+            The scheduled VS Code Insiders host smoke test failed.
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          issue_number="$(gh issue list \
+            --state open \
+            --search "${ISSUE_TITLE} in:title" \
+            --json number,title \
+            --jq 'map(select(.title == env.ISSUE_TITLE))[0].number // ""')"
+          if [[ -n "${issue_number}" ]]; then
+            gh issue comment "${issue_number}" --body "${ISSUE_BODY}"
+          else
+            gh issue create \
+              --title "${ISSUE_TITLE}" \
+              --body "${ISSUE_BODY}" \
+              --label needs-triage
+          fi
+
+      - name: Preserve the host canary result
+        if: always() && steps.smoke.outcome == 'failure'
+        run: exit 1

--- a/tests/scripts/host/canary-workflow.test.ts
+++ b/tests/scripts/host/canary-workflow.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  new URL("../../../.github/workflows/host-canary.yml", import.meta.url),
+  "utf8"
+);
+
+describe("VS Code host canary", () => {
+  it("runs the existing desktop host seam against Insiders on a schedule", () => {
+    expect(workflow).toContain("schedule:");
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).not.toContain("pull_request:");
+    expect(workflow).toContain("VSCODE_TEST_VERSION: insiders");
+    expect(workflow).toContain("xvfb-run -a nub run test:host:desktop");
+  });
+
+  it("reports a deduplicated issue before preserving the failed conclusion", () => {
+    expect(workflow).toContain("continue-on-error: true");
+    expect(workflow).toContain("[Host canary] VS Code Insiders compatibility changed");
+    expect(workflow).toContain("gh issue comment");
+    expect(workflow).toContain("gh issue create");
+    expect(workflow).toContain("steps.smoke.outcome == 'failure'");
+    expect(workflow).toContain("run: exit 1");
+  });
+});


### PR DESCRIPTION
## Summary

- run the existing desktop host smoke interface against VS Code Insiders every day
- create or update one needs-triage issue when the canary fails
- preserve the failed workflow conclusion after reporting it

## Verification

- nub run test
- VSCODE_TEST_VERSION=insiders nub run test:host:desktop
- nubx oxfmt --check on touched files
- nubx oxlint on the workflow contract test