### PR TITLE
chore(deps): pin host-provided MarkdownIt

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,12 @@
     {
       "groupName": "oxc",
       "matchPackageNames": ["ox**"]
+    },
+    {
+      "description": "Update MarkdownIt only with the pinned VS Code preview host",
+      "enabled": false,
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["markdown-it", "@types/markdown-it"]
     }
   ],
   "autoApprove": true,

--- a/tests/scripts/host/versions.test.ts
+++ b/tests/scripts/host/versions.test.ts
@@ -34,4 +34,24 @@ describe("hostVersions", () => {
 
     expect(workflow).not.toContain(`vscode: ${hostVersions.pinnedPreview.desktopVersion}`);
   });
+
+  it("keeps Renovate from changing dependencies supplied by the pinned preview host", () => {
+    const renovate = JSON.parse(
+      readFileSync(new URL("../../../.github/renovate.json", import.meta.url), "utf8")
+    ) as {
+      packageRules?: Array<{
+        description?: string;
+        enabled?: boolean;
+        matchManagers?: string[];
+        matchPackageNames?: string[];
+      }>;
+    };
+
+    expect(renovate.packageRules).toContainEqual({
+      description: "Update MarkdownIt only with the pinned VS Code preview host",
+      enabled: false,
+      matchManagers: ["npm"],
+      matchPackageNames: ["markdown-it", "@types/markdown-it"]
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- disable automatic Renovate updates for markdown-it and its type package
- document that both versions move only with the pinned VS Code preview host
- lock the Renovate rule to the same host-version contract test

## Why

The extension runs inside VS Code and must match the MarkdownIt version bundled by the pinned preview host. Independent dependency updates are intentionally rejected by the existing host contract.

## Verification

- nub run test
- nubx oxfmt --check on touched files
- nubx oxlint on the touched TypeScript test