### PR TITLE
fix(release): allow subscriptionless Azure login

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -243,7 +243,7 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
 
       - name: Verify publisher access
         run: pnpm exec vsce verify-pat lzm0x219 --azure-credential

--- a/tests/scripts/release/publish-workflow.test.ts
+++ b/tests/scripts/release/publish-workflow.test.ts
@@ -27,4 +27,13 @@ describe("manual tag publishing", () => {
     const publishJob = workflow.slice(publishStart, workflow.indexOf("  finalize:"));
     expect(publishJob).toContain("needs: prepare-release");
   });
+
+  it("logs into the Marketplace publisher tenant without requiring an Azure subscription", () => {
+    const publishStart = workflow.indexOf("  publish:");
+    const publishJob = workflow.slice(publishStart, workflow.indexOf("  finalize:"));
+
+    expect(publishJob).toContain("uses: azure/login@v3");
+    expect(publishJob).toContain("allow-no-subscriptions: true");
+    expect(publishJob).not.toContain("subscription-id:");
+  });
 });


### PR DESCRIPTION
## Summary

- log into the Microsoft Entra publisher tenant without requiring an Azure subscription
- remove the unused subscription secret from the Marketplace publishing step
- lock the subscriptionless login contract in the publish workflow test

## Failure addressed

The v4.5.1 publish run reached the Marketplace job but `azure/login@v3` failed with `No subscriptions found`. The publisher uses tenant-level OIDC credentials for `vsce`, so no Azure resource subscription is required.

## Verification

- `nubx vitest run tests/scripts/release/publish-workflow.test.ts tests/scripts/release`
- `nubx oxfmt --check .github/workflows/publish.yml tests/scripts/release/publish-workflow.test.ts`
- `nubx oxlint tests/scripts/release/publish-workflow.test.ts`