### PR TITLE
fix(theme): constrain appearance pickers

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -19,6 +19,7 @@
 .vscode
 AGENTS.md
 ARCHITECTURE.md
+CONTEXT.md
 CONTRIBUTING.md
 artifacts/**
 artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+### Themes and appearance
+
+- Light and dark theme commands now show only palettes that match their appearance slot, while existing JSON settings continue to work unchanged.
+
 ## [v4.5.1] - 2026-09-01
 
 v4.5.1 preserves Markdown preview compatibility with VS Code's built-in Markdown parser. No settings changes are required.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,21 @@
+# Ubiquitous Language
+
+## Theme
+
+A GitHub appearance palette used by Markdown preview.
+
+## Light theme
+
+One of the four themes designed for a light host appearance.
+
+## Dark theme
+
+One of the five themes designed for a dark host appearance.
+
+## Single theme mode
+
+A preview mode that uses one selected theme regardless of the host appearance.
+
+## System theme mode
+
+A preview mode that selects the configured light or dark theme for the current host appearance.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,6 +5,8 @@ import {
   setSingleTheme,
   getThemeModeList,
   getThemeList,
+  getLightThemeList,
+  getDarkThemeList,
   setLightTheme,
   setDarkTheme,
   getSingleTheme,
@@ -15,7 +17,7 @@ import {
 function createThemeCommand<T extends string>(
   commandId: string,
   getList: () => { label: string; value: T }[],
-  getCurrent: () => T,
+  getCurrent: () => string,
   setCurrent: (value: T) => Promise<void>,
   placeholder: string,
   successMessage: (label: string) => string
@@ -63,7 +65,7 @@ export function registerThemeCommands(): vscode.Disposable[] {
     ),
     createThemeCommand(
       "vscode-github-markdown.changeLightTheme",
-      getThemeList,
+      getLightThemeList,
       getLightTheme,
       setLightTheme,
       l10n.t("Select a light theme"),
@@ -71,7 +73,7 @@ export function registerThemeCommands(): vscode.Disposable[] {
     ),
     createThemeCommand(
       "vscode-github-markdown.changeDarkTheme",
-      getThemeList,
+      getDarkThemeList,
       getDarkTheme,
       setDarkTheme,
       l10n.t("Select a dark theme"),

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -5,26 +5,38 @@ export type ThemeMode = "single" | "system" | "vscode";
 
 export type ThemeColorMode = "light" | "dark" | "auto" | "vscode";
 
-export type Theme =
-  | "light"
-  | "light_colorblind"
-  | "light_high_contrast"
-  | "light_tritanopia"
+export type LightTheme = "light" | "light_colorblind" | "light_high_contrast" | "light_tritanopia";
+
+export type DarkTheme =
   | "dark"
   | "dark_colorblind"
   | "dark_dimmed"
   | "dark_high_contrast"
   | "dark_tritanopia";
 
-const lightThemeNames: Set<Theme> = new Set([
+export type Theme = LightTheme | DarkTheme;
+
+export const LightThemeKeys: readonly LightTheme[] = [
   "light",
   "light_colorblind",
   "light_high_contrast",
   "light_tritanopia"
-]);
+] as const;
 
-export function isLightTheme(theme: Theme): boolean {
-  return lightThemeNames.has(theme);
+export const DarkThemeKeys: readonly DarkTheme[] = [
+  "dark",
+  "dark_colorblind",
+  "dark_dimmed",
+  "dark_high_contrast",
+  "dark_tritanopia"
+] as const;
+
+export const ThemeKeys: readonly Theme[] = [...LightThemeKeys, ...DarkThemeKeys];
+
+const lightThemeNames: ReadonlySet<Theme> = new Set(LightThemeKeys);
+
+export function isLightTheme(theme: unknown): theme is LightTheme {
+  return lightThemeNames.has(theme as Theme);
 }
 
 const themeLabels: Record<Theme, () => string> = {
@@ -38,8 +50,6 @@ const themeLabels: Record<Theme, () => string> = {
   dark_high_contrast: () => l10n.t("Dark high contrast"),
   dark_tritanopia: () => l10n.t("Dark Tritanopia")
 } as const;
-
-export const ThemeKeys = Object.keys(themeLabels) as Theme[];
 
 const themeModeLabels: Record<ThemeMode, () => string> = {
   single: () => l10n.t("Single theme"),
@@ -89,7 +99,7 @@ export function getLightTheme(): Theme {
   return getConfiguration().get<Theme>(section.light, "light");
 }
 
-export async function setLightTheme(theme: Theme): Promise<void> {
+export async function setLightTheme(theme: LightTheme): Promise<void> {
   await updateThemeConfiguration(section.light, theme);
 }
 
@@ -97,7 +107,7 @@ export function getDarkTheme(): Theme {
   return getConfiguration().get<Theme>(section.dark, "dark");
 }
 
-export async function setDarkTheme(theme: Theme): Promise<void> {
+export async function setDarkTheme(theme: DarkTheme): Promise<void> {
   await updateThemeConfiguration(section.dark, theme);
 }
 
@@ -144,7 +154,25 @@ export function getThemeList(): {
   label: string;
   value: Theme;
 }[] {
-  return ThemeKeys.map((theme) => ({
+  return themeList(ThemeKeys);
+}
+
+export function getLightThemeList(): {
+  label: string;
+  value: LightTheme;
+}[] {
+  return themeList(LightThemeKeys);
+}
+
+export function getDarkThemeList(): {
+  label: string;
+  value: DarkTheme;
+}[] {
+  return themeList(DarkThemeKeys);
+}
+
+function themeList<T extends Theme>(themes: readonly T[]): { label: string; value: T }[] {
+  return themes.map((theme) => ({
     label: themeLabels[theme](),
     value: theme
   }));

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -154,6 +154,9 @@ const themeItems = [
   { label: "Dark Tritanopia", value: "dark_tritanopia" }
 ];
 
+const lightThemeItems = themeItems.slice(0, 4);
+const darkThemeItems = themeItems.slice(4);
+
 const themeCommandCases = [
   {
     commandId: "vscode-github-markdown.changeThemeMode",
@@ -175,7 +178,7 @@ const themeCommandCases = [
   },
   {
     commandId: "vscode-github-markdown.changeLightTheme",
-    quickPickItems: themeItems,
+    quickPickItems: lightThemeItems,
     placeHolder: "Select a light theme",
     newSelection: { label: "Light high contrast", value: "light_high_contrast" },
     currentSelection: { label: "Light Tritanopia", value: "light_tritanopia" },
@@ -184,7 +187,7 @@ const themeCommandCases = [
   },
   {
     commandId: "vscode-github-markdown.changeDarkTheme",
-    quickPickItems: themeItems,
+    quickPickItems: darkThemeItems,
     placeHolder: "Select a dark theme",
     newSelection: { label: "Dark dimmed", value: "dark_dimmed" },
     currentSelection: { label: "Dark Tritanopia", value: "dark_tritanopia" },


### PR DESCRIPTION
## Summary

- model light and dark GitHub palettes as separate write-side theme types
- show only the four light palettes in the light-theme command and the five dark palettes in the dark-theme command
- preserve all existing JSON configuration values for backward compatibility
- record the theme vocabulary and user-visible behavior

## Verification

- `nub run test`
- `nub run build`
- `nub run verify:release`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .vscodeignore CHANGELOG.md CONTEXT.md src/theme.ts src/commands.ts tests/extension.test.ts`