### PR TITLE
ci(host): harden VS Code downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,19 +72,23 @@ jobs:
           - name: desktop-minimum
             kind: desktop
             vscode: 1.74.0
+            cache_vscode: true
             smoke: true
             preview: false
           - name: desktop-stable
             kind: desktop
             vscode: stable
+            cache_vscode: false
             smoke: true
             preview: false
           - name: desktop-preview-pinned
             kind: desktop
+            cache_vscode: true
             smoke: false
             preview: true
           - name: web-stable
             kind: web
+            cache_vscode: false
             smoke: true
             preview: true
 
@@ -94,6 +98,13 @@ jobs:
       - uses: jdx/mise-action@v4
 
       - run: pnpm install --frozen-lockfile
+
+      - name: Cache fixed VS Code host
+        if: matrix.cache_vscode
+        uses: actions/cache@v6
+        with:
+          path: .vscode-test
+          key: vscode-${{ runner.os }}-${{ matrix.name }}-${{ hashFiles('.github/workflows/ci.yml', 'scripts/host/versions.ts') }}
 
       - name: Cache Chromium
         if: matrix.kind == 'web'

--- a/scripts/host/desktop-download.ts
+++ b/scripts/host/desktop-download.ts
@@ -1,0 +1,39 @@
+import { downloadAndUnzipVSCode, type DownloadOptions } from "@vscode/test-electron";
+
+export type DesktopVSCodeDownloader = (options: Partial<DownloadOptions>) => Promise<string>;
+
+interface DesktopVSCodeDownloadDependencies {
+  downloader?: DesktopVSCodeDownloader;
+  retryDelayMilliseconds?: number;
+  wait?: (milliseconds: number) => Promise<void>;
+}
+
+const attempts = 3;
+const timeout = 60_000;
+
+export async function downloadDesktopVSCode(
+  version: DownloadOptions["version"],
+  dependencies: DesktopVSCodeDownloadDependencies = {}
+): Promise<string> {
+  const downloader = dependencies.downloader ?? downloadAndUnzipVSCode;
+  const retryDelayMilliseconds = dependencies.retryDelayMilliseconds ?? 1_000;
+  const wait = dependencies.wait ?? delay;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await downloader({ timeout, version });
+    } catch (error) {
+      if (attempt === attempts) {
+        throw error;
+      }
+
+      await wait(retryDelayMilliseconds * 2 ** (attempt - 1));
+    }
+  }
+
+  throw new Error("VS Code download retry loop exited unexpectedly");
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/scripts/host/desktop-preview.ts
+++ b/scripts/host/desktop-preview.ts
@@ -1,8 +1,8 @@
-import { downloadAndUnzipVSCode } from "@vscode/test-electron";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _electron as electron } from "playwright";
 import { project } from "../shared/project";
+import { downloadDesktopVSCode } from "./desktop-download";
 import { resolveDesktopPreviewDirectories } from "./desktop-preview-profile";
 import { assertClientRenderedPreview } from "./preview";
 import { hostVersions } from "./versions";
@@ -10,7 +10,7 @@ import { hostVersions } from "./versions";
 const version = process.env["VSCODE_TEST_VERSION"] ?? hostVersions.pinnedPreview.desktopVersion;
 const fixtures = join(project.root, "tests", "fixtures", "host");
 const directories = resolveDesktopPreviewDirectories(tmpdir(), version, project.root);
-const executablePath = await downloadAndUnzipVSCode(version);
+const executablePath = await downloadDesktopVSCode(version);
 const application = await electron.launch({
   executablePath,
   cwd: project.root,

--- a/scripts/host/desktop.ts
+++ b/scripts/host/desktop.ts
@@ -1,12 +1,14 @@
 import { runTests } from "@vscode/test-electron";
 import { join } from "node:path";
 import { project } from "../shared/project";
+import { downloadDesktopVSCode } from "./desktop-download";
 import { hostVersions } from "./versions";
 
 const version = process.env["VSCODE_TEST_VERSION"] ?? hostVersions.latestStableDesktop;
+const vscodeExecutablePath = await downloadDesktopVSCode(version);
 
 await runTests({
-  version,
+  vscodeExecutablePath,
   extensionDevelopmentPath: project.root,
   extensionTestsPath: join(project.root, ".cache", "host-tests", "smoke.js"),
   launchArgs: ["--disable-extensions"]

--- a/tests/scripts/host/desktop-download.test.ts
+++ b/tests/scripts/host/desktop-download.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  downloadDesktopVSCode,
+  type DesktopVSCodeDownloader
+} from "../../../scripts/host/desktop-download";
+
+describe("downloadDesktopVSCode", () => {
+  it("retries the download without retrying the host test", async () => {
+    const downloader = vi
+      .fn<DesktopVSCodeDownloader>()
+      .mockRejectedValueOnce(Object.assign(new Error("timed out"), { code: "ETIMEDOUT" }))
+      .mockRejectedValueOnce(Object.assign(new Error("reset"), { code: "ECONNRESET" }))
+      .mockResolvedValue("/tmp/vscode");
+    const wait = vi.fn<(milliseconds: number) => Promise<void>>(async () => undefined);
+
+    await expect(
+      downloadDesktopVSCode("1.129.0", {
+        downloader,
+        retryDelayMilliseconds: 100,
+        wait
+      })
+    ).resolves.toBe("/tmp/vscode");
+
+    expect(downloader).toHaveBeenCalledTimes(3);
+    expect(downloader).toHaveBeenNthCalledWith(1, {
+      timeout: 60_000,
+      version: "1.129.0"
+    });
+    expect(wait).toHaveBeenNthCalledWith(1, 100);
+    expect(wait).toHaveBeenNthCalledWith(2, 200);
+  });
+});

--- a/tests/scripts/host/versions.test.ts
+++ b/tests/scripts/host/versions.test.ts
@@ -35,6 +35,21 @@ describe("hostVersions", () => {
     expect(workflow).not.toContain(`vscode: ${hostVersions.pinnedPreview.desktopVersion}`);
   });
 
+  it("caches fixed desktop hosts without freezing the rolling stable channel", () => {
+    const workflow = readFileSync(
+      new URL("../../../.github/workflows/ci.yml", import.meta.url),
+      "utf8"
+    );
+
+    expect(workflow).toContain("- name: Cache fixed VS Code host");
+    expect(workflow).toContain("if: matrix.cache_vscode");
+    expect(workflow).toContain("path: .vscode-test");
+    expect(workflow).toContain(
+      "key: vscode-${{ runner.os }}-${{ matrix.name }}-${{ hashFiles('.github/workflows/ci.yml', 'scripts/host/versions.ts') }}"
+    );
+    expect(workflow).toMatch(/name: desktop-stable[\s\S]*?cache_vscode: false/);
+  });
+
   it("keeps Renovate from changing dependencies supplied by the pinned preview host", () => {
     const renovate = JSON.parse(
       readFileSync(new URL("../../../.github/renovate.json", import.meta.url), "utf8")


### PR DESCRIPTION
## Summary

- download fixed desktop hosts before launching tests, with bounded backoff retries
- keep test execution outside the retry boundary
- cache fixed VS Code hosts while leaving the rolling stable channel uncached

## Verification

- `nub run test`
- `nub run build`
- `nub run verify:release`
- `nubx oxfmt --check .`
- `nubx oxlint .`
- `nubx oxlint --type-aware .`