### PR TITLE
docs(research): refresh parity baselines

### DIFF
--- a/docs/agents/research/github-parity-coverage.md
+++ b/docs/agents/research/github-parity-coverage.md
@@ -1,130 +1,63 @@
 # GitHub Markdown 一致性覆盖矩阵
 
+- 核验日期：2026-09-01
+- 项目基线：`09f1a827b9b906e15e4a17f5ae2b9fb04f4d968f`
+
 ## 结论
 
-当前仓库对既有扩展能力的视觉基线较完整：57 个校验用例中，53 个要求与 GitHub 截图精确一致，4 个把语法高亮和客户端渲染器明确作为集成边界；桌面最低版本、桌面稳定版和 Web 稳定版的宿主冒烟测试也已通过。但宿主冒烟仅覆盖主题容器、任务列表、NOTE 提示框、`:rocket:` 表情和 CSS 可达性，不能证明其余语法在真实 VS Code 桌面与 Web 宿主中的行为。
+当前仓库已经关闭旧基线中的三个 GFM 候选缺口：单波浪线删除线、GFM tagfilter 和 RTL 自动方向。它们都有插件级测试，并通过 VS Code 1.74 桌面、桌面稳定版和 Web 稳定版的 `markdown.api.render` 宿主断言；固定桌面预览与 Web 预览还检查最终 Webview DOM。
 
-基于 GitHub 官方规范、GitHub Markdown API 的可复现输出和本地渲染链，v4.2 应只处理三个可验证候选：单波浪线删除线、GFM 禁用原始 HTML 标签、RTL 内容的 `dir="auto"`。三者均已确认 GitHub API 与仓库本地一致性渲染器存在差异；但真实 VS Code 桌面或 Web 宿主目前**没有已证实的新缺口**，必须先增加两端的 `markdown.api.render` 或最终 Webview DOM 断言，复现后才决定是否由扩展补齐，未复现则不实施。
+脚注不再只有静态 HTML 证据。固定桌面预览和 Web 预览会点击脚注引用、把焦点移到反向链接，并用键盘返回引用。九套主题、System/VS Code 主题模式、内置 Mermaid、KaTeX 长公式以及本地图片也进入了最终预览回归。
 
-图表、数学公式和语法高亮属于宿主或配套渲染器边界，放入 v4.3；漂移监控与基线治理放入 v4.4。GitHub 仓库上下文功能不应被误报为扩展缺陷。
+这些证据仍不等于 GitHub 页面逐像素或全功能等价。仓库上下文引用、上传、交互式任务、GeoJSON/TopoJSON/STL 等页面增强仍属于 GitHub 服务或客户端渲染器边界；滚动桌面稳定版目前只有 renderer smoke，完整客户端预览固定在 VS Code 1.129.0。
 
-## 证据方法与可信度
+## 证据等级
 
-证据按以下顺序使用：
+- **宿主渲染已验证**：真实 VS Code 桌面或 Web Extension Host 调用 `markdown.api.render` 并断言 HTML。
+- **最终预览已验证**：真实 Markdown Webview 完成客户端渲染后断言 DOM、交互或布局。
+- **本地基线已验证**：单元测试、语义快照或 Chromium parity 已通过，但不能替代宿主结果。
+- **集成边界**：行为由 GitHub 服务、VS Code 内置渲染器或可选配套扩展负责，本项目只验证不破坏既有组合。
 
-1. GitHub 官方文档与 [GFM 规范 0.29](https://github.github.com/gfm/) 定义目标语义。
-2. [GitHub Markdown REST API](https://docs.github.com/en/rest/markdown/markdown) 的 `gfm` 模式用于最小输入复现。该 API 能确认 GitHub 服务端 HTML，但不能代表 GitHub 页面上的全部客户端增强。
-3. 仓库源码、测试和校验产物用于确认扩展当前实现及覆盖范围。
-4. 真实 VS Code 宿主测试优先于仓库的本地一致性渲染器。后者直接运行 MarkdownIt 和扩展插件，且截图禁用 JavaScript，因此只证明其声明范围内的静态视觉结果。
+## 当前覆盖矩阵
 
-可信度定义：
+| 能力                                                 | 当前责任方                                   | 桌面 1.74 / 桌面稳定 / Web renderer                                | 固定桌面 / Web 最终预览                                              | 剩余边界                                                            |
+| ---------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| CommonMark 基础结构、表格、自动链接、允许的原始 HTML | VS Code 宿主解析，本扩展负责样式             | 常用样例已覆盖，未穷举全部 CommonMark 输入                         | 主题压力 fixture 覆盖标题、表格、链接、代码等主要结构                | GitHub 页面附加属性、完整无障碍 DOM 和相对导航仍需按具体复现补证据  |
+| 单、双波浪线删除线                                   | 本扩展 MarkdownIt 插件                       | 已验证；同时覆盖转义、行内代码、未闭合和长波浪线                   | 已验证 `<del>` / `<s>` 及字面量边界                                  | 无已知缺口                                                          |
+| GFM tagfilter                                        | 本扩展 MarkdownIt 插件                       | 已验证九类禁用标签；允许的 `strong`、`details`、`picture` 保持可用 | 已验证最终 DOM 不含禁用标签                                          | 这是渲染一致性结论，不据此单独声称安全边界                          |
+| RTL 自动方向                                         | 本扩展 MarkdownIt core 规则                  | 已验证标题、段落、混排、列表、提示框和脚注；显式方向保持不变       | 已验证最终 DOM；代码节点不添加方向属性                               | 更复杂的双向文本视觉效果仍按复现扩充                                |
+| 任务列表、五类提示框、Emoji                          | 本扩展插件                                   | 基本项已验证                                                       | 主题压力 fixture 已覆盖                                              | GitHub Issue 中的交互式任务和自定义 Emoji 图像属于平台边界          |
+| 脚注                                                 | 本扩展插件                                   | RTL 脚注语义已验证                                                 | 引用、定义、反向链接、点击与键盘返回已验证                           | 复杂嵌套与浏览器辅助技术组合未穷举                                  |
+| 九套 GitHub 主题                                     | 本扩展主题容器与 CSS                         | 主题模式和样式贡献可达                                             | 九套 Single 主题、System 亮暗/高对比度切换、VS Code 主题模式均已验证 | 不是九套主题对 GitHub 页面的逐像素截图证明                          |
+| Mermaid                                              | VS Code 内置或外置渲染器；本扩展同步亮暗主题 | renderer smoke 不执行客户端图表                                    | 固定桌面与 Web 均要求生成含预期节点的 SVG，并验证亮暗调色板切换      | 外置 `bierner.markdown-mermaid` 的旧宿主组合仍只有契约测试          |
+| 数学公式                                             | VS Code 内置 KaTeX                           | renderer smoke 不执行客户端公式                                    | 固定桌面与 Web 均验证公式可见、源码完整、页面只有一个纵向滚动区      | GitHub 使用的渲染实现与 VS Code 不同，不承诺逐像素等价              |
+| 根路径/相对图片与 `srcset`                           | 本扩展 URL 改写 + VS Code Webview            | renderer 语义和插件测试已覆盖                                      | 固定桌面与 Web 验证图片实际加载及根路径候选被改写                    | GitHub CDN、上传和权限上下文不在本地预览范围                        |
+| 代码语法高亮                                         | VS Code 宿主                                 | 作为宿主输出接受                                                   | 主题压力 fixture 只验证可读和不破坏布局                              | 不承诺与 GitHub 的高亮引擎逐 token 等价                             |
+| GeoJSON、TopoJSON、STL                               | GitHub 页面或第三方渲染器                    | 不适用                                                             | 未实现                                                               | 保持 integration boundary，不因 GitHub 页面支持而在扩展内复制运行时 |
+| 提及、Issue/PR/提交引用、上传、颜色预览、交互式任务  | GitHub 服务与页面上下文                      | 不适用                                                             | 不适用                                                               | 明确排除，除非未来建立独立产品目标与可复现上下文                    |
 
-- **已验证**：目标语义和当前行为均有可复现证据，或已在真实宿主断言。
-- **局部验证**：静态视觉或少量宿主样例已覆盖，但语义、交互、平台或完整输入范围未覆盖。
-- **未知**：没有足够证据判断桌面、Web 或 GitHub 页面行为；不得据此声称已支持或存在缺陷。
+## 当前优先级
 
-## 责任边界
-
-| 层级                  | 负责内容                                                                                                  | 本项目应做什么                                                                                              |
-| --------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| GitHub 服务与页面     | 仓库上下文解析、Issue/PR/提交引用、提及、自动链接规则、上传、颜色预览、任务状态交互、图表和数学等页面增强 | 作为目标或边界记录；没有可复现的本地预览等价物时不得伪造支持                                                |
-| VS Code Markdown 宿主 | CommonMark/GFM 基础解析、预览 Webview、链接导航、语法高亮及扩展贡献点加载                                 | 优先通过内置 `markdown.markdownItPlugins`、`markdown.previewStyles` 和现有宿主行为集成；先在桌面与 Web 验证 |
-| 本扩展                | 主题容器与样式、任务列表、提示框、表情、脚注、根路径 HTML 图片改写、Mermaid 主题同步                      | 只补齐宿主缺失且属于本地预览语义的高影响差异；保持 Web 扩展兼容，不引入自定义预览系统                       |
-| 配套扩展              | Mermaid 等客户端渲染器                                                                                    | 本项目只维护明确的集成契约，不捆绑渲染器或把配套扩展结果当作本扩展实现                                      |
-
-VS Code 官方文档说明，内置 Markdown 预览以 CommonMark 为基础，`markdown.previewStyles` 改变外观，`markdown.markdownItPlugins` 扩展语法，`markdown.previewScripts` 用于需要客户端脚本的高级渲染。本项目清单当前仅贡献 MarkdownIt 插件和预览样式，并同时声明桌面与 Web 入口；这决定了能力边界。[VS Code Markdown 扩展指南](https://code.visualstudio.com/api/extension-guides/markdown-extension)；[package.json](https://github.com/lzm0x219/vscode-github-markdown/blob/main/package.json)
-
-## 覆盖矩阵
-
-“桌面”和“Web”列只表示真实宿主证据，不用本地 Chromium 截图替代。
-
-| 能力                                                     | GitHub 上游行为                                                                                                | 当前实现与责任方                                                                              | 桌面                       | Web                        | 证据与覆盖缺口                                                                                      | 用户影响                                                                       | 建议版本                              |
-| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------- |
-| 标题、段落、强调、引用、列表、链接、图片、行内与围栏代码 | GFM 继承 CommonMark，并增加页面属性和仓库上下文行为                                                            | 基础解析由 VS Code 宿主负责；扩展负责主题样式                                                 | 局部验证                   | 局部验证                   | 本地精确视觉用例覆盖常用静态输入；宿主冒烟未覆盖完整基础语法，锚点、相对导航和语义属性未知          | 高频；当前无已确认回归                                                         | 保持，缺口随具体复现进入 v4.2 或 v4.4 |
-| GFM 表格                                                 | 支持表头、对齐和单元格内格式                                                                                   | VS Code 宿主解析，扩展样式                                                                    | 未知                       | 未知                       | 本地视觉精确一致；校验会归一化 GitHub 的无障碍表格包裹，因此未证明 DOM 等价                         | 高频；静态外观风险低，语义仍未知                                               | 保持；真实宿主断言纳入回归建设        |
-| GFM 删除线（双波浪线）                                   | `~~文本~~` 生成 `<del>`                                                                                        | VS Code 宿主解析                                                                              | 未知                       | 未知                       | 本地视觉精确一致；没有真实宿主专项断言                                                              | 中频；当前无已确认回归                                                         | 保持                                  |
-| GFM 删除线（单波浪线）                                   | GFM 允许一个或两个波浪线；GitHub API 将 `~文本~` 输出为 `<del>`                                                | 本地 MarkdownIt 保留原文；若真实宿主也缺失，应由扩展 MarkdownIt 插件补齐                      | 未知                       | 未知                       | 已确认 GitHub API 与本地渲染链差异；尚未运行桌面/Web `markdown.api.render` 最小复现                 | 中高频；预览会把有效 GitHub 格式误显示为普通文本                               | **v4.2 候选 1**                       |
-| GFM 自动链接                                             | URL、`www` 地址和邮箱可自动链接；页面还可能添加属性                                                            | VS Code 宿主解析                                                                              | 未知                       | 未知                       | 本地语义链接已复现；GitHub 的 `rel`、`dir` 等属性及真实宿主导航未覆盖                               | 高频；基本语义已有，交互未知                                                   | 保持；不单独进入 v4.2                 |
-| GFM 禁用原始 HTML 标签                                   | GFM tagfilter 转义 `title`、`textarea`、`style`、`xmp`、`iframe`、`noembed`、`noframes`、`script`、`plaintext` | 本地一致性渲染器会保留这些原始标签；真实 VS Code Webview 可能另有清理，责任须先按宿主结果判定 | 未知                       | 未知                       | GitHub API 与本地链差异已复现；截图只观察渲染结果，不能证明 Webview DOM 或清理阶段                  | 中频但差异明显；可能误导用户认为 GitHub 接受嵌入内容。当前证据不足以作安全结论 | **v4.2 候选 2，条件式**               |
-| 普通原始 HTML、`details`、`picture`                      | GitHub 在清理规则允许范围内渲染 HTML；`details` 支持折叠区域                                                   | VS Code 宿主负责 HTML；扩展仅改写原始 HTML `<img src="/...">` 根路径                          | 未知                       | 未知                       | 本地静态视觉与图片改写单测有覆盖；交互、允许标签集、`srcset`、Markdown 图片根路径和真实宿主结果未知 | 中频；错误改写会造成资源预览偏差                                               | 不扩入 v4.2；先补证据                 |
-| RTL 自动方向                                             | GitHub API 为阿拉伯语等标题和段落输出 `dir="auto"`                                                             | 本地 MarkdownIt 核心节点没有该属性；扩展生成的提示框含 `dir="auto"`，其余节点责任待宿主验证   | 未知                       | 未知                       | GitHub API 与本地链差异已复现；桌面/Web 对标题、段落、列表、脚注的结果未知                          | 对 RTL 用户为可访问性和混排方向问题                                            | **v4.2 候选 3，条件式**               |
-| 任务列表                                                 | GitHub 显示复选框；Issue 中还可交互和跟踪任务                                                                  | 扩展插件生成禁用复选框、GitHub 类名和本地化无障碍标签；交互状态属于 GitHub 平台               | 已验证基本项               | 已验证基本项               | 本地视觉精确一致，桌面/Web 宿主冒烟覆盖一个基本项；嵌套、跨 Issue 跟踪和交互不属于当前宿主证据      | 高频；静态写作预览已覆盖                                                       | 保持；平台交互排除                    |
-| 五类提示框                                               | GitHub 支持 NOTE、TIP、IMPORTANT、WARNING、CAUTION，且不支持嵌套                                               | 扩展 MarkdownIt 插件负责结构、图标和样式                                                      | 已验证 NOTE                | 已验证 NOTE                | 本地覆盖五类和多行内容；宿主只断言 NOTE，嵌套边界未形成宿主回归                                     | 高频文档能力；已有能力风险低                                                   | 保持；扩充宿主回归可进 v4.4           |
-| GitHub 表情短代码                                        | GitHub 将受支持别名渲染为表情或自定义图像；编辑器补全属于平台                                                  | 扩展用生成的别名表负责渲染                                                                    | 已验证 `:rocket:`          | 已验证 `:rocket:`          | 本地覆盖表情语料；宿主只覆盖一个别名，别名更新与自定义图像加载范围未全面验证                        | 高频；当前无已确认功能缺口                                                     | 保持；漂移治理进 v4.4                 |
-| 脚注                                                     | GitHub 支持脚注引用、定义和反向链接                                                                            | 扩展插件负责渲染                                                                              | 未知                       | 未知                       | 本地视觉和单元测试覆盖连续定义及简单多行定义；真实宿主、键盘导航、复杂嵌套未知                      | 中频；现有静态结果可信，宿主风险未量化                                         | 保持；先补宿主断言                    |
-| 主题、浅深色与链接下划线                                 | GitHub 外观随主题变化                                                                                          | 扩展主题容器和 CSS 负责九个主题、系统模式及下划线选项                                         | CSS 可达性已验证；视觉未知 | CSS 可达性已验证；视觉未知 | 主主题有广泛视觉语料；其余主题只覆盖简单格式。宿主冒烟只验证样式文件存在和容器输出                  | 高频；属于扩展核心，但无具体已确认差异                                         | 不凭空扩充 v4.2；后续以具体复现驱动   |
-| 代码语法高亮                                             | GitHub 根据语言标识高亮围栏代码                                                                                | VS Code 宿主负责高亮，扩展映射 GitHub 主题颜色                                                | 未知                       | 未知                       | 当前作为视觉集成边界，允许约 2.12 万差异像素；本地对照会归一化 token，不能证明高亮引擎一致          | 高频；版本和主题变化敏感                                                       | **v4.3**                              |
-| Mermaid                                                  | GitHub 页面客户端渲染 Mermaid                                                                                  | `bierner.markdown-mermaid` 负责渲染；本扩展只同步其主题设置并在卸载时恢复                     | 未知                       | 未知                       | 当前截图禁用 JavaScript，平台语料仅作为高阈值集成边界；没有配套扩展的桌面/Web 端到端证据            | 中高频；边界清晰但兼容性未知                                                   | **v4.3**                              |
-| GeoJSON、TopoJSON、STL                                   | GitHub 页面客户端渲染地图和 3D 模型                                                                            | VS Code 宿主或配套扩展责任；本扩展未实现渲染器                                                | 未知                       | 未知                       | 当前只保留源代码块并纳入高阈值边界，不能宣称与 GitHub 等价                                          | 低至中频；实现成本和 Web 风险高                                                | v4.3 调研或明确不支持                 |
-| 数学公式                                                 | GitHub 使用 MathJax 支持行内、块级和 `math` 围栏                                                               | VS Code 宿主或配套扩展责任；本扩展未实现渲染器                                                | 未知                       | 未知                       | 当前截图禁用 JavaScript，平台语料不能证明数学渲染                                                   | 中频；若捆绑渲染器会显著扩大范围                                               | v4.3 调研或明确不支持                 |
-| 提及、Issue/PR/提交引用、关闭关键字、自定义自动链接      | GitHub 依赖仓库、用户、权限和服务端上下文解析                                                                  | GitHub 平台责任；本地预览无可靠等价上下文                                                     | 不适用                     | 不适用                     | GitHub API `context` 只能覆盖部分引用，无法复制完整页面行为                                         | 用户可见但不属于扩展可独立实现的 Markdown 语义                                 | 排除 v4.2；文档说明边界               |
-| 上传附件、颜色预览、标题大纲、锚点 UI、交互式任务        | GitHub 编辑器或页面功能                                                                                        | GitHub 平台责任                                                                               | 不适用                     | 不适用                     | 不属于静态 Markdown 渲染；当前仓库没有实现声明                                                      | 用户可见但错误实现会制造虚假一致性                                             | 明确不实现，除非未来建立独立产品目标  |
-
-## v4.2 缺口排序与执行建议
-
-### 1. 补齐单波浪线删除线语义一致性
-
-这是证据最完整、范围最小的候选。GFM 规范明确允许一个或两个波浪线，GitHub API 可稳定复现 `<del>`，而当前本地渲染链保留字面文本。
-
-执行条件与验收：
-
-- 先为 VS Code 1.74 桌面、桌面稳定版和 Web 稳定版增加 `markdown.api.render('~文本~')` 断言。
-- 仅当宿主未生成 `<del>` 时，在现有 MarkdownIt 插件链中增加最小兼容实现；不得改变双波浪线、代码跨度和转义波浪线行为。
-- 增加 GitHub API 基准 fixture、DOM 语义断言和精确视觉用例；未知输入必须保持字面文本，而不是宽松吞并。
-
-### 2. 对齐 GFM 禁用原始 HTML 标签
-
-GitHub API 与本地链的差异已经确认，但实际 VS Code 预览 Webview 可能在后续阶段处理原始 HTML，因此该项只能作为条件式 v4.2 工作。
-
-执行条件与验收：
-
-- 在桌面最低版本、桌面稳定版与 Web 稳定版分别断言九类 tagfilter 标签的最终预览 DOM，而不只检查 MarkdownIt 中间 HTML。
-- 若宿主最终结果与 GitHub 不同，修复必须只影响 GFM 指定的九类标签，并保留普通允许 HTML、`details`、`picture` 和现有图片改写。
-- 把该项表述为渲染一致性，不在没有威胁路径证据时宣称安全漏洞。
-
-### 3. 对齐 RTL 内容自动方向
-
-GitHub API 对 RTL 标题和段落输出 `dir="auto"`，当前本地链缺失。该差异影响可访问性和双向文本布局，但责任仍需由真实宿主结果决定。
-
-执行条件与验收：
-
-- 在桌面与 Web 宿主覆盖阿拉伯语及中英混排的标题、段落、列表、提示框和脚注。
-- 比较最终 DOM 的 `dir` 语义与视觉方向；避免把 `dir="auto"` 重复或错误添加到代码节点。
-- 若需扩展处理，只修改扩展可控节点或通过最小 MarkdownIt core 规则补齐，不引入自定义预览。
-
-## v4.2 明确排除
-
-- 不实现或捆绑 Mermaid、GeoJSON、TopoJSON、STL、MathJax、语法高亮引擎；这些属于 v4.3 的宿主与配套渲染器兼容性工作。
-- 不实现提及、Issue/PR/提交引用、关闭关键字、自定义自动链接、上传、颜色预览、标题大纲或交互式任务；这些依赖 GitHub 服务和页面上下文。
-- 不新增 `markdown.previewScripts` 或自定义预览系统来绕过 VS Code 内置宿主。
-- 不在没有具体复现的情况下扩充主题、设置或重写已有提示框、表情、脚注、任务列表和图片逻辑。
-- 不把基线刷新、上游漂移监控或长期回归框架塞入 v4.2；这些属于 v4.4。
-
-## 未知项与取证路径
-
-1. **三个 v4.2 候选的真实宿主结果**：扩展 `tests/host/smoke.ts`，在 VS Code 1.74 桌面、桌面稳定版和 Web 稳定版检查 `markdown.api.render` 与最终 Webview DOM。中间 MarkdownIt HTML不能替代最终结果。
-2. **客户端渲染器**：为 Mermaid 等配套扩展建立单独的桌面/Web 集成测试，启用 JavaScript，并记录配套扩展版本。当前禁用 JavaScript 的 Chromium 截图不能回答此问题。
-3. **资源 URL 行为**：在已提交 fixture 中覆盖 Markdown 图片、原始 HTML `img`、`picture`/`source srcset`、相对路径和根路径，并在真实工作区预览验证桌面/Web。未取证前不扩大图片重写范围。
-4. **九个主题的广度**：目前附加主题只覆盖简单格式；后续应按用户证据选择高风险构造，而不是机械复制整个主主题语料。
-5. **链接、锚点和脚注交互**：用宿主 UI 测试检查点击、键盘焦点和返回导航，或在产品边界中明确不保证。截图零差异不证明交互。
-6. **GitHub 上下文差异**：同一 Markdown 在仓库文件、Issue、PR、讨论和 Wiki 中可能得到不同增强。任何新增承诺都要记录目标表面，并用对应官方页面或 API 复现。
+1. **滚动宿主漂移**：继续运行桌面稳定版 smoke 和每日 Insiders canary；出现具体失败后再扩大最终预览矩阵。
+2. **旧 Mermaid 组合**：若仍需承诺 VS Code 1.100–1.120 与外置渲染器，增加固定扩展版本的桌面/Web 端到端测试。
+3. **证据广度**：按真实 Issue 扩充表格无障碍结构、相对导航、复杂脚注和双向文本，不机械复制所有语法排列。
+4. **视觉边界**：客户端 Mermaid、KaTeX 和语法高亮维持语义、可读性与布局断言，不升级为无法稳定维护的逐像素承诺。
 
 ## 仓库证据
 
-- 扩展入口及插件链：[src/extension.ts](https://github.com/lzm0x219/vscode-github-markdown/blob/main/src/extension.ts)
-- 任务列表、提示框、表情、脚注、主题和图片改写：[src/plugins](https://github.com/lzm0x219/vscode-github-markdown/tree/main/src/plugins)
-- 一致性用例与边界声明：[scripts/parity/cases.ts](https://github.com/lzm0x219/vscode-github-markdown/blob/main/scripts/parity/cases.ts)
-- Chromium 截图禁用 JavaScript：[scripts/parity/browser.ts](https://github.com/lzm0x219/vscode-github-markdown/blob/main/scripts/parity/browser.ts)
-- 真实宿主冒烟范围：[tests/host/smoke.ts](https://github.com/lzm0x219/vscode-github-markdown/blob/main/tests/host/smoke.ts)
-- 桌面最低版、桌面稳定版和 Web 稳定版矩阵：[.github/workflows/ci.yml](https://github.com/lzm0x219/vscode-github-markdown/blob/main/.github/workflows/ci.yml)
-- 最近一次三类宿主任务均成功的主分支运行：[GitHub Actions 运行 29394603420](https://github.com/lzm0x219/vscode-github-markdown/actions/runs/29394603420)
+- 插件链：[src/markdown-it.ts](../../../src/markdown-it.ts)
+- renderer 宿主断言：[tests/host/smoke.ts](../../../tests/host/smoke.ts)
+- 最终预览语义与交互：[scripts/host/preview.ts](../../../scripts/host/preview.ts)
+- Mermaid、KaTeX 与滚动布局：[scripts/host/client-rendering.ts](../../../scripts/host/client-rendering.ts)
+- 宿主矩阵：[.github/workflows/ci.yml](../../../.github/workflows/ci.yml)
+- Insiders 漂移探针：[.github/workflows/host-canary.yml](../../../.github/workflows/host-canary.yml)
+- parity 能力与边界：[scripts/parity/cases.ts](../../../scripts/parity/cases.ts)
 
 ## 上游资料
 
+- [GFM 规范 0.29](https://github.github.com/gfm/)
+- [GitHub Markdown REST API](https://docs.github.com/en/rest/markdown/markdown)
 - [GitHub 基本写作与格式语法](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
-- [GitHub 表格](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables)
-- [GitHub 折叠区域](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections)
-- [GitHub 代码块与语法高亮](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks)
 - [GitHub 图表](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)
 - [GitHub 数学表达式](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions)
-- [GitHub 自动链接引用与 URL](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls)
+- [VS Code Markdown 扩展贡献点](https://code.visualstudio.com/api/extension-guides/markdown-extension)

--- a/docs/agents/research/host-integration-compatibility.md
+++ b/docs/agents/research/host-integration-compatibility.md
@@ -1,139 +1,82 @@
 # 跨宿主与伴生渲染器兼容矩阵
 
-- 调研日期：2026-07-15
-- 项目基线：`04bbb46aaa7e7bf03ade8ddab83f804b826e2903`
+- 核验日期：2026-09-01
+- 项目基线：`09f1a827b9b906e15e4a17f5ae2b9fb04f4d968f`
 
 ## 结论摘要
 
-1. **桌面端与 Web 端的基础扩展路径可用，但验证深度不足。** `main` 与 `browser` 指向同一 bundle；CI 在 VS Code 1.74.0、桌面稳定版和 Web 稳定版中验证激活、Markdown-it 插件链与预览样式文件。现有宿主测试没有验证九套主题的实际 CSS、运行时配色切换、Mermaid 或 KaTeX 的最终渲染。[扩展清单](../../../package.json)、[宿主 smoke](../../../tests/host/smoke.ts)、[CI](../../../.github/workflows/ci.yml)
-2. **VS Code 1.121 及以上存在已确认的 Mermaid 主题同步断点。** VS Code 1.121 将原 `markdown-mermaid` 合并为内置的 `vscode.mermaid-markdown-features`；它沿用 `markdown-mermaid.lightModeTheme` 和 `markdown-mermaid.darkModeTheme` 设置。当前实现却先检查 `bierner.markdown-mermaid` 是否存在，不存在便返回，因此只安装新内置扩展时不会同步 GitHub 主题。新内置扩展的两个槽位默认都是 `vscode`，而不是本项目期望的 `default`/`dark`。[VS Code 1.121 发布说明](https://code.visualstudio.com/updates/v1_121#_mermaid-diagrams-in-markdown-preview-and-notebooks)、[内置扩展清单（固定版本）](https://github.com/microsoft/vscode/blob/bc2ac764ddd66802104366c182d490a03253f7e1/extensions/mermaid-markdown-features/package.json)、[当前同步实现](../../../src/integrations/mermaid.ts)
-3. **九套 GitHub 主题的正文选择逻辑完整，Mermaid 只保持亮暗方向而非主题等价。** 四套亮色主题全部映射为 Mermaid `default`，五套暗色主题全部映射为 `dark`；色盲、高对比度、Tritanopia 与 Dimmed 的差异不会传递给 Mermaid。这符合当前 README 所承诺的“匹配亮色或暗色”，但不能证明与 GitHub 的图表配色一致。[主题逻辑](../../../src/theme.ts)、[Mermaid 映射](../../../src/integrations/mermaid.ts)、[README](../../../README.md#mermaid-diagrams)
-4. **System 模式依赖 CSS `prefers-color-scheme`，而不是 VS Code 明示的 Webview 主题类。** VS Code 官方为当前编辑器主题提供 `body.vscode-light`、`body.vscode-dark`、`body.vscode-high-contrast`；本项目生成的主题 CSS 只使用亮/暗媒体查询。操作系统自动配色时两者预期趋同，但手动切换 VS Code 主题、高对比度切换以及桌面/Web 是否完全一致仍缺少真实宿主证据，不能视为已验证。[主题 CSS 生成](../../../scripts/build/github-css.ts)、[VS Code Webview 主题契约](https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content)、[VS Code 自动配色说明](https://code.visualstudio.com/docs/configure/themes#_automatically-switch-based-on-os-color-scheme)
-5. **KaTeX 是应保留的回归边界，不是已确认的新缺陷。** VS Code 当前内置预览使用 KaTeX；项目历史 [Issue #604](https://github.com/lzm0x219/vscode-github-markdown/issues/604) 记录过长公式导致双滚动条。该问题已关闭，当前代码没有专门的真实宿主回归测试，因此 v4.3 应先复现再决定是否改 CSS。[VS Code Markdown 数学公式说明](https://code.visualstudio.com/docs/languages/markdown#_math-formula-rendering)
+1. **桌面与 Web 已共享同一扩展实现和同一组 GFM 语义契约。** VS Code 1.74.0、桌面稳定版和 Web 稳定版运行 renderer smoke；固定桌面 1.129.0 与 Web 稳定版还运行真实 Markdown Webview 预览。
+2. **旧基线的内置 Mermaid 断点已经关闭。** 同步逻辑同时识别 `vscode.mermaid-markdown-features` 与 `bierner.markdown-mermaid`；固定桌面和 Web 预览要求 Mermaid 生成 SVG，并验证亮暗调色板随主题切换。
+3. **System 模式已经使用 VS Code Webview 主题类。** 生成 CSS 同时处理 `body.vscode-light`、`body.vscode-dark` 和两类高对比度主题；宿主预览会真实切换 VS Code 主题并等待对应调色板。
+4. **KaTeX 长内容已有回归门禁。** 固定桌面和 Web 预览要求公式可见、源表达式完整、页面可滚动且不存在第二个纵向滚动容器。
+5. **当前主要风险已从“功能未知”转为“矩阵边缘”。** 滚动桌面稳定版只有 renderer smoke，旧版外置 Mermaid 没有端到端组合测试，多窗口下的设置所有权仍依赖单元契约。
 
-## 范围与风险定义
+## 宿主矩阵
 
-- **高：** 已有源码级确定性冲突，或会使 GitHub 可渲染内容退化、主题明显错误、预览不可用。
-- **中：** 基础路径存在，但缺少真实宿主/切换/组合验证，或历史上发生过用户可见故障。
-- **低：** 当前实现和至少一层宿主测试一致，剩余风险主要是视觉覆盖不足。
-- “当前行为”区分“由测试证明”和“由源码推断”；未在真实宿主复现的项目明确标为待验证。
+| 宿主                                | 运行方式                               | 当前验证                                                                                                                  | 未覆盖                                                               |
+| ----------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| 桌面 VS Code 1.74.0                 | `@vscode/test-electron` renderer smoke | 扩展激活、插件链、主题模式、单/双删除线、tagfilter、RTL、脚注语义                                                         | 内置 Mermaid/KaTeX 客户端渲染；该版本本身不提供当前内置 Mermaid 组合 |
+| 桌面稳定版                          | `@vscode/test-electron` renderer smoke | 与最低版相同，用于发现当前稳定 API 漂移                                                                                   | 不执行完整 Webview、九主题压力、脚注交互和客户端渲染器               |
+| 桌面 VS Code 1.129.0                | Playwright 驱动真实 VS Code            | 最终 GFM DOM、脚注点击/键盘导航、九套 Single 主题、System 亮暗/高对比度、VS Code 主题模式、Mermaid、KaTeX、图片和滚动布局 | 固定版本不会自动证明未来稳定版行为                                   |
+| Web 稳定版                          | `@vscode/test-web` + Chromium          | renderer smoke 与完整最终预览；使用与桌面相同的语义、主题、客户端渲染和布局断言                                           | 不能代表所有浏览器、远程权限或 `github.dev` 仓库上下文               |
+| VS Code Insiders                    | 每日计划任务                           | renderer smoke；失败时创建或更新去重 Issue                                                                                | 不执行完整最终预览，因此主要用于提前发现 API/解析漂移                |
+| 旧宿主 + `bierner.markdown-mermaid` | 单元与设置契约                         | 扩展 ID、主题槽位、恢复和用户接管语义                                                                                     | 未安装固定版本配套扩展运行桌面/Web 端到端图表测试                    |
 
-GitHub 的目标行为是：`mermaid` 围栏代码块在 Markdown 文件、Issue、PR、Discussion 和 Wiki 中渲染为图表，而不是普通代码块。GitHub 同时提醒第三方 Mermaid 插件可能产生错误，因此本项目应验证组合行为，不能只验证单个插件输出。[GitHub 图表文档](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams)
+## 主题与渲染器契约
 
-## 兼容矩阵
+| GitHub 主题类别                                                                   | 正文主题                 | Mermaid 同步值 | 最终预览证据                                                                  |
+| --------------------------------------------------------------------------------- | ------------------------ | -------------- | ----------------------------------------------------------------------------- |
+| `light`、`light_colorblind`、`light_high_contrast`、`light_tritanopia`            | 保留各自 GitHub CSS 变量 | `default`      | 四套 Single 主题都进入压力矩阵；System 亮色与高对比度亮色使用 VS Code body 类 |
+| `dark`、`dark_colorblind`、`dark_dimmed`、`dark_high_contrast`、`dark_tritanopia` | 保留各自 GitHub CSS 变量 | `dark`         | 五套 Single 主题都进入压力矩阵；System 暗色与高对比度暗色使用 VS Code body 类 |
 
-| 宿主                                           | 主题模式                                | 伴生/宿主渲染器                             | 预期行为                                                                         | 当前行为与证据                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 风险                           |
-| ---------------------------------------------- | --------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
-| 桌面 VS Code 1.74.0                            | Single，九主题任一                      | 无                                          | 扩展激活，GitHub 语法插件和固定主题生效                                          | CI 真实宿主 smoke 覆盖激活、插件链和样式文件；未截图或检查最终主题变量。[CI](../../../.github/workflows/ci.yml)、[宿主 smoke](../../../tests/host/smoke.ts)                                                                                                                                                                                                                                                                                                                    | 低（功能）/中（视觉）          |
-| 桌面稳定版                                     | Single，九主题任一                      | 无                                          | 与最低版本相同，且跟随当前 VS Code Markdown API                                  | CI 有稳定版 smoke；测试内容不含主题断言、Mermaid 或数学公式。[宿主 smoke](../../../tests/host/smoke.ts)                                                                                                                                                                                                                                                                                                                                                                        | 低（功能）/中（视觉）          |
-| Web 稳定版（`vscode.dev`/`github.dev` 类环境） | Single，九主题任一                      | 无                                          | 与桌面端产生相同插件 HTML 和 GitHub 主题                                         | `browser` 入口和 WebWorker 宿主 smoke 已覆盖；同一 bundle 避免了实现分叉，但测试仍只验证插件 HTML 与样式存在。[扩展清单](../../../package.json)、[CI](../../../.github/workflows/ci.yml)、[VS Code Web 扩展契约](https://code.visualstudio.com/api/extension-guides/web-extensions#web-extension-main-file)                                                                                                                                                                    | 低（功能）/中（视觉）          |
-| 桌面与 Web                                     | System，普通亮/暗系统配色               | 无                                          | 操作系统配色变化时，在配置的 GitHub 亮/暗主题之间切换                            | 包装元素写入 `data-color-mode="auto"`，生成 CSS 使用 `prefers-color-scheme`；单测只断言属性，没有在真实宿主触发切换。[主题插件](../../../src/plugins/markdown-it-github-theme.ts)、[主题单测](../../../tests/theme.test.ts)                                                                                                                                                                                                                                                    | 中，待真实宿主验证             |
-| 桌面与 Web                                     | System，手动切换 VS Code 主题或高对比度 | 无                                          | 必须明确产品语义：跟随 OS，或跟随当前 VS Code 主题；无论选哪一种都应在两宿主一致 | 官方 Webview 契约提供 VS Code 当前主题类及独立高对比度类别；当前 CSS 未使用这些信号，只区分媒体查询亮/暗。是否产生实际错配待复现。[VS Code Webview 主题契约](https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content)                                                                                                                                                                                                                               | 中                             |
-| 桌面与 Web，VS Code 1.100–1.120                | Single                                  | 外置 `bierner.markdown-mermaid` 当前版      | Mermaid 图表渲染；两个 Mermaid 槽位都与固定 GitHub 主题保持同一亮暗方向          | 当前实现把两个槽位都写为 `default` 或 `dark`；单元测试覆盖映射和恢复。外置扩展同时提供 `main`、`browser`、Markdown 插件和预览脚本，但项目没有真实双扩展宿主测试。[Mermaid 单测](../../../tests/integrations/mermaid.test.ts)、[外置扩展清单（固定版本）](https://github.com/mjbvz/vscode-markdown-mermaid/blob/9f4d37ded0cc7fdf05bbab17fb082a6fc118e269/package.json)                                                                                                          | 中                             |
-| 桌面与 Web，VS Code 1.100–1.120                | System                                  | 外置 `bierner.markdown-mermaid` 当前版      | Mermaid 分别使用与 GitHub 亮/暗槽位相符的主题，并可恢复用户原值                  | 源码与单测证明首次同步会保存全局值、写入 `default`/`dark`，关闭同步后恢复；尚未验证多窗口、用户在同步期间修改 Mermaid 设置或 Web 宿主重载。[同步实现](../../../src/integrations/mermaid.ts)、[Mermaid 单测](../../../tests/integrations/mermaid.test.ts)                                                                                                                                                                                                                       | 中                             |
-| 桌面与 Web，VS Code 1.121+                     | Single 或 System                        | 内置 `vscode.mermaid-markdown-features`     | Mermaid 图表渲染且继续与选定 GitHub 主题保持亮暗一致                             | 图表由 VS Code 内置扩展渲染；本项目只查找旧 ID，所以主题同步提前返回。内置扩展沿用设置键，但默认两个槽位均为 `vscode`。这是源码级可复现断点。[VS Code 1.121 发布说明](https://code.visualstudio.com/updates/v1_121#_mermaid-diagrams-in-markdown-preview-and-notebooks)、[内置扩展清单](https://github.com/microsoft/vscode/blob/bc2ac764ddd66802104366c182d490a03253f7e1/extensions/mermaid-markdown-features/package.json)、[同步实现](../../../src/integrations/mermaid.ts) | **高**                         |
-| 桌面与 Web                                     | Single 或 System                        | VS Code 内置 KaTeX                          | 长公式正常渲染，页面只有一个主滚动容器，正文主题不破坏公式可读性                 | 官方确认内置预览使用 KaTeX；历史 Issue 曾出现双滚动条，当前宿主 smoke 与视觉 parity 都没有执行真实 KaTeX 客户端渲染。[Issue #604](https://github.com/lzm0x219/vscode-github-markdown/issues/604)、[平台边界定义](../../../scripts/parity/cases.ts)                                                                                                                                                                                                                             | 中，待复现                     |
-| 桌面与 Web                                     | 任意                                    | GeoJSON、TopoJSON、STL 或其他第三方预览脚本 | 不破坏宿主或第三方渲染；是否追求 GitHub 功能等价由一致性覆盖矩阵决定             | GitHub 支持这些客户端渲染器；本项目只保留源代码块并把它们列为 integration boundary，没有伴生扩展或历史 Issue 证明应在 v4.3 实现。[GitHub 图表文档](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)、[平台边界测试](../../../tests/scripts/parity/platform-features.test.ts)                                                                                                                                       | 中（验证缺口），不直接纳入实现 |
+Mermaid 的契约是保持亮暗方向和可读性，不是复制 GitHub 每套图表配色。KaTeX 的契约是正确渲染、表达式完整和不制造第二个页面滚动区，不是与 GitHub MathJax 逐像素一致。
 
-## 九主题映射
+## 已关闭的旧风险
 
-| GitHub 主题           | 类别 | Single 正文选择            | System 槽位 | 外置 Mermaid 同步值 | VS Code 1.121+ 内置 Mermaid 当前结果 |
-| --------------------- | ---- | -------------------------- | ----------- | ------------------- | ------------------------------------ |
-| `light`               | 亮   | 固定 `light`               | light       | `default`           | 不由本扩展更新；新配置默认 `vscode`  |
-| `light_colorblind`    | 亮   | 固定 `light_colorblind`    | light       | `default`           | 同上                                 |
-| `light_high_contrast` | 亮   | 固定 `light_high_contrast` | light       | `default`           | 同上                                 |
-| `light_tritanopia`    | 亮   | 固定 `light_tritanopia`    | light       | `default`           | 同上                                 |
-| `dark`                | 暗   | 固定 `dark`                | dark        | `dark`              | 同上                                 |
-| `dark_colorblind`     | 暗   | 固定 `dark_colorblind`     | dark        | `dark`              | 同上                                 |
-| `dark_dimmed`         | 暗   | 固定 `dark_dimmed`         | dark        | `dark`              | 同上                                 |
-| `dark_high_contrast`  | 暗   | 固定 `dark_high_contrast`  | dark        | `dark`              | 同上                                 |
-| `dark_tritanopia`     | 暗   | 固定 `dark_tritanopia`     | dark        | `dark`              | 同上                                 |
+### 内置 Mermaid 扩展 ID 漂移
 
-正文映射由 [主题实现](../../../src/theme.ts) 和 [主题 CSS 生成器](../../../scripts/build/github-css.ts)确定；Mermaid 映射由 [集成实现](../../../src/integrations/mermaid.ts)确定。当前单测覆盖九主题枚举和亮暗分支，但没有逐主题真实宿主截图。[主题单测](../../../tests/theme.test.ts)
+`src/integrations/mermaid.ts` 同时识别内置与外置扩展 ID；渲染器移除或禁用时会释放仍由本扩展拥有的设置。固定桌面和 Web 最终预览验证 SVG 及亮暗调色板，避免只凭设置单测宣称兼容。
 
-## 可复现的高影响不一致
+### System 与 VS Code 主题信号脱节
 
-### 1. VS Code 1.121+ 内置 Mermaid 不再同步主题（已确认）
+`scripts/build/github-css.ts` 为 System 模式生成 VS Code 亮、暗和高对比度 body 类选择器。最终预览通过命令切换 VS Code 主题，检查容器元数据、正文压力 fixture 与 Mermaid 调色板。
 
-复现前提：VS Code 1.121 或以上，不安装已弃用的外置 `bierner.markdown-mermaid`。
+### KaTeX 双滚动条回归
 
-1. 保持 `githubMarkdown.mermaid.syncTheme = true`。
-2. 选择 Single `dark_dimmed`，或在 System 中配置任意 GitHub 亮/暗主题。
-3. 打开含 `mermaid` 围栏代码块的 Markdown 预览。
-4. 内置 Mermaid 能渲染图表，但 `updateMermaidThemeSync` 因找不到旧扩展 ID 而在读取设置前返回；`markdown-mermaid.*ModeTheme` 不会被本项目更新。
+`scripts/host/client-rendering.ts` 使用长公式 fixture，验证 KaTeX 可见尺寸、源表达式、主页面滚动和嵌套纵向滚动器数量。历史 Issue #604 继续作为背景，不再描述为“当前待确认缺陷”。
 
-影响：v4 当前稳定宿主的 Mermaid 图表会使用内置扩展的有效主题（新配置默认 `vscode`），而不是项目声明的 GitHub 主题亮暗映射。功能没有退化为代码块，但主题一致性承诺失效。
+## 当前待优化项
 
-### 2. System 模式与 VS Code 手动主题/高对比度的关系不明确（待真实宿主确认）
+1. **稳定版最终预览策略**：固定 1.129.0 保证可复现，稳定/Insiders smoke 保证低成本漂移提示；只有出现 renderer 与客户端行为分叉的证据时，再增加滚动最终预览任务。
+2. **外置 Mermaid 端到端**：若产品继续承诺旧宿主组合，应固定 `bierner.markdown-mermaid` 版本并在其支持的桌面/Web 宿主运行图表与主题切换。
+3. **设置所有权组合**：继续用多窗口、同步期间用户修改设置、安装/禁用渲染器的复现驱动改动；不在没有失败证据时重写现有事务模型。
+4. **浏览器与远程上下文**：Web CI 证明 Web Extension Host 兼容，不等于所有浏览器、Codespaces、`vscode.dev` 和 `github.dev` 权限组合。
 
-候选复现：固定 OS 为亮色，System 模式配置 `light`/`dark`，手动把 VS Code 从亮色切到暗色及高对比度，再分别观察桌面与 Web 预览。当前 CSS 只读 `prefers-color-scheme`，而官方推荐的当前 VS Code 主题信号是 `body.vscode-*`。在完成真实宿主验证前，不断言一定错配；但这必须在 v4.3 确定语义并锁定测试。
+## 范围边界
 
-### 3. 长 KaTeX 内容可能再次产生双滚动条（历史高影响回归，当前待确认）
+- 不创建自定义 Markdown 预览或 Webview；继续使用 VS Code 的 Markdown 贡献点。
+- 不内置 Mermaid 或 KaTeX 运行时；本扩展维护主题和布局兼容契约。
+- 不把 Notebook、Chat、独立 Mermaid 编辑器、GeoJSON/TopoJSON/STL 客户端渲染纳入当前宿主矩阵。
+- 不把 DOM/交互断言表述为 GitHub 页面逐像素等价。
 
-使用 [Issue #604](https://github.com/lzm0x219/vscode-github-markdown/issues/604) 的长公式场景，在桌面稳定版和 Web 稳定版打开预览，检查页面与公式容器的滚动区域。旧问题已关闭，只有当前版本复现后才能创建 CSS 修复 Ticket；无复现时只保留回归测试。
+## 仓库证据
 
-## 建议纳入 v4.3 的范围
+- 宿主 CI：[.github/workflows/ci.yml](../../../.github/workflows/ci.yml)
+- Insiders canary：[.github/workflows/host-canary.yml](../../../.github/workflows/host-canary.yml)
+- renderer smoke：[tests/host/smoke.ts](../../../tests/host/smoke.ts)
+- 最终预览与主题压力：[scripts/host/preview.ts](../../../scripts/host/preview.ts)
+- Mermaid、KaTeX 与滚动布局：[scripts/host/client-rendering.ts](../../../scripts/host/client-rendering.ts)
+- Mermaid 设置同步：[src/integrations/mermaid.ts](../../../src/integrations/mermaid.ts)
+- 主题 CSS 生成：[scripts/build/github-css.ts](../../../scripts/build/github-css.ts)
+- 固定宿主版本：[scripts/host/versions.ts](../../../scripts/host/versions.ts)
 
-### P0：兼容 VS Code 1.121+ 内置 Mermaid
+## 上游资料
 
-可拆为独立实现 Ticket：
-
-- 同时识别内置 `vscode.mermaid-markdown-features` 与旧 `bierner.markdown-mermaid`，或改为以设置能力检测为准；不得提高 `engines.vscode`。
-- 保持现有设置键和关闭同步时的恢复语义，补充旧扩展、内置扩展、两者均不存在三类单测。
-- 在桌面稳定版与 Web 稳定版真实渲染 Mermaid，验证 Single/System 的亮暗切换；最低版宿主继续验证无 Mermaid 依赖时扩展可用。
-
-### P1：建立真实宿主主题与客户端渲染回归
-
-可拆为独立测试 Ticket：
-
-- 桌面最低版、桌面稳定版、Web 稳定版继续作为宿主轴。
-- 以四个亮色与五个暗色的 DOM 主题属性全覆盖；视觉验证至少覆盖普通、色盲、高对比度、Dimmed/Tritanopia 各类别，不把九主题只压缩成一个亮暗样例。
-- System 模式分别验证浏览器/OS 亮暗切换、VS Code 手动主题切换和高对比度；根据结果明确“跟随 OS”还是“跟随 VS Code 当前主题”。
-- 在稳定宿主加入 Mermaid 与长 KaTeX 内容，断言不是原始代码块、文本可读且不存在第二个页面滚动条。
-
-### P2：收紧 Mermaid 设置所有权（复现后实施）
-
-当前同步写入 `ConfigurationTarget.Global`，只监听 `githubMarkdown` 配置变化，并用一次性快照恢复。先用多窗口、同步期间用户修改 Mermaid 设置、安装/禁用渲染器三种场景验证；只有证明会覆盖新值或跨窗口漂移后，再拆分实现 Ticket，避免凭假设重构。
-
-## 依赖与排除项
-
-### 依赖
-
-- 版本范围汇总应读取“一致性覆盖矩阵”对 GeoJSON、STL、数学等平台功能的归属决定；本调研只确定组合风险，不替代功能差距排序。
-- P0 依赖 VS Code 1.121 的内置扩展清单作为上游契约，同时必须保留旧扩展路径以覆盖最低版本区间。
-- P1 可与 P0 并行搭建，但内置 Mermaid 的通过断言要等 P0 完成。
-
-### 排除
-
-- 不创建自定义 Markdown 预览或 Webview；继续使用 VS Code 的 `markdown.markdownItPlugins`、`markdown.previewStyles` 与宿主脚本组合契约。[VS Code Markdown 扩展指南](https://code.visualstudio.com/api/extension-guides/markdown-extension)
-- 不重新内置 Mermaid 运行时。VS Code 1.121+ 已内置；旧版本继续通过可选伴生扩展兼容。
-- 不在没有用户/源码证据时新增 GeoJSON、TopoJSON、STL 伴生渲染器。
-- 不承诺 Mermaid、KaTeX 等宿主客户端渲染器的逐像素等价；v4.3 的门槛是正确渲染、主题方向一致、可读、无布局破坏。
-- 不把 Notebook、Chat 或独立 Mermaid 编辑器纳入本项目范围；本项目贡献点只面向 VS Code 内置 Markdown 预览。
-
-## 验证方式与通过标准
-
-| 轴           | 最小验证                                   | 通过标准                                                            |
-| ------------ | ------------------------------------------ | ------------------------------------------------------------------- |
-| 桌面最低版   | VS Code 1.74.0 宿主 smoke                  | 扩展激活、插件链与样式存在；未安装 Mermaid 渲染器时无异常           |
-| 桌面稳定版   | 内置 Markdown 预览端到端                   | 九主题元数据正确；Single/System 切换刷新；Mermaid 和 KaTeX 正常渲染 |
-| Web 稳定版   | `@vscode/test-web` Chromium                | 与桌面稳定版使用相同断言；不依赖 Node API                           |
-| 外置 Mermaid | 兼容其 `engines.vscode` 的旧宿主           | 两主题槽位同步、关闭后恢复原值、图表不是代码块                      |
-| 内置 Mermaid | VS Code 1.121+                             | 新内置 ID/能力被识别；Single/System 下图表亮暗与正文一致            |
-| System 模式  | OS/浏览器亮暗、手动 VS Code 主题、高对比度 | 产品语义明确且两宿主一致；每次切换无需重启预览                      |
-| KaTeX        | 长行与多行公式                             | 公式可读；页面只有一个主滚动区；无横向内容截断                      |
-
-现有像素 parity 把 Mermaid、GeoJSON、STL 和数学标为 `integration-boundary`，且本地路径只保留源代码块，因此不能替代上述真实宿主测试。[Parity cases](../../../scripts/parity/cases.ts)、[平台边界测试](../../../tests/scripts/parity/platform-features.test.ts)
-
-## 关键来源
-
-- [VS Code：Markdown 扩展贡献点](https://code.visualstudio.com/api/extension-guides/markdown-extension)
-- [VS Code：Web 扩展运行时与测试](https://code.visualstudio.com/api/extension-guides/web-extensions)
-- [VS Code：Webview 当前主题信号](https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content)
-- [VS Code 1.121：内置 Mermaid](https://code.visualstudio.com/updates/v1_121#_mermaid-diagrams-in-markdown-preview-and-notebooks)
-- [VS Code 内置 Mermaid 清单，固定提交](https://github.com/microsoft/vscode/blob/bc2ac764ddd66802104366c182d490a03253f7e1/extensions/mermaid-markdown-features/package.json)
-- [旧 `markdown-mermaid` 清单，固定提交](https://github.com/mjbvz/vscode-markdown-mermaid/blob/9f4d37ded0cc7fdf05bbab17fb082a6fc118e269/package.json)
-- [GitHub：创建 Mermaid、GeoJSON、TopoJSON 与 STL 图表](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)
-- [VS Code：内置 Markdown KaTeX](https://code.visualstudio.com/docs/languages/markdown#_math-formula-rendering)
+- [VS Code Markdown 扩展贡献点](https://code.visualstudio.com/api/extension-guides/markdown-extension)
+- [VS Code Web 扩展](https://code.visualstudio.com/api/extension-guides/web-extensions)
+- [VS Code Webview 主题](https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content)
+- [VS Code 1.121 内置 Mermaid](https://code.visualstudio.com/updates/v1_121#_mermaid-diagrams-in-markdown-preview-and-notebooks)
+- [VS Code Markdown 数学公式](https://code.visualstudio.com/docs/languages/markdown#_math-formula-rendering)
+- [GitHub 图表](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)
 - [历史 Mermaid 冲突 Issue #203](https://github.com/lzm0x219/vscode-github-markdown/issues/203)
 - [历史 KaTeX 双滚动条 Issue #604](https://github.com/lzm0x219/vscode-github-markdown/issues/604)


### PR DESCRIPTION
## Summary

- rebaseline GitHub parity evidence against the current v4.5.1 implementation
- replace completed v4.2/v4.3 candidates with verified host and final-preview coverage
- preserve explicit boundaries for GitHub context features, external Mermaid combinations, and rolling host drift

## Verification

- `nub run test`
- `nub run verify:release`
- `nubx oxfmt --check .`