### PR TITLE
refactor(theme): resolve configuration once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file records notable changes that people can observe or act on when using t
 ### Themes and appearance
 
 - Light and dark theme commands now show only palettes that match their appearance slot, while existing JSON settings continue to work unchanged.
+- Markdown previews and Mermaid theme synchronization now use documented defaults when stored theme settings contain unsupported values.
 
 ## [v4.5.1] - 2026-09-01
 

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -1,13 +1,6 @@
 import vscode from "vscode";
 import { getConfiguration } from "../configuration";
-import {
-  getCurrentDarkTheme,
-  getCurrentLightTheme,
-  getSingleTheme,
-  getThemeMode,
-  isLightTheme,
-  type Theme
-} from "../theme";
+import { getResolvedTheme, isLightTheme, type Theme } from "../theme";
 
 export const originSection = {
   namespace: "markdown-mermaid",
@@ -533,13 +526,17 @@ function enqueue(operation: () => Promise<void>): Promise<void> {
 }
 
 function resolveThemes(): readonly [MermaidTheme, MermaidTheme] {
-  const mode = getThemeMode();
-  if (mode === "vscode") return ["vscode", "vscode"];
-  if (mode === "single") {
-    const theme = resolveTheme(getSingleTheme());
+  const { colorMode, light, dark } = getResolvedTheme();
+  if (colorMode === "vscode") return ["vscode", "vscode"];
+  if (colorMode === "light") {
+    const theme = resolveTheme(light);
     return [theme, theme];
   }
-  return [resolveTheme(getCurrentLightTheme()), resolveTheme(getCurrentDarkTheme())];
+  if (colorMode === "dark") {
+    const theme = resolveTheme(dark);
+    return [theme, theme];
+  }
+  return [resolveTheme(light), resolveTheme(dark)];
 }
 
 function resolveTheme(theme: Theme): MermaidTheme {

--- a/src/plugins/markdown-it-github-theme.ts
+++ b/src/plugins/markdown-it-github-theme.ts
@@ -1,17 +1,18 @@
 import type MarkdownIt from "markdown-it";
 import { getLinkUnderlines } from "../accessibility";
-import { getThemeColorMode, getCurrentLightTheme, getCurrentDarkTheme } from "../theme";
+import { getResolvedTheme } from "../theme";
 
 export default function markdownItGitHubTheme(md: MarkdownIt): MarkdownIt {
   const render = md.renderer.render.bind(md.renderer);
 
   md.renderer.render = function (...args) {
+    const theme = getResolvedTheme();
     return `
       <div
         class="vscode-github-markdown"
-        data-color-mode="${getThemeColorMode()}"
-        data-light-theme="${getCurrentLightTheme()}"
-        data-dark-theme="${getCurrentDarkTheme()}"
+        data-color-mode="${theme.colorMode}"
+        data-light-theme="${theme.light}"
+        data-dark-theme="${theme.dark}"
         data-link-underlines="${getLinkUnderlines()}"
       >
         ${render.apply(md.renderer, args)}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -16,6 +16,12 @@ export type DarkTheme =
 
 export type Theme = LightTheme | DarkTheme;
 
+export type ResolvedTheme = Readonly<{
+  colorMode: ThemeColorMode;
+  light: Theme;
+  dark: Theme;
+}>;
+
 export const LightThemeKeys: readonly LightTheme[] = [
   "light",
   "light_colorblind",
@@ -80,7 +86,7 @@ async function updateThemeConfiguration<T>(
 }
 
 export function getThemeMode(): ThemeMode {
-  return getConfiguration().get(section.mode, "system");
+  return readThemeValue(getConfiguration(), section.mode, ThemeModeKeys, "system");
 }
 
 export async function setThemeMode(mode: ThemeMode): Promise<void> {
@@ -88,7 +94,7 @@ export async function setThemeMode(mode: ThemeMode): Promise<void> {
 }
 
 export function getSingleTheme(): Theme {
-  return getConfiguration().get<Theme>(section.single, "light");
+  return readThemeValue(getConfiguration(), section.single, ThemeKeys, "light");
 }
 
 export async function setSingleTheme(theme: Theme): Promise<void> {
@@ -96,7 +102,7 @@ export async function setSingleTheme(theme: Theme): Promise<void> {
 }
 
 export function getLightTheme(): Theme {
-  return getConfiguration().get<Theme>(section.light, "light");
+  return readThemeValue(getConfiguration(), section.light, ThemeKeys, "light");
 }
 
 export async function setLightTheme(theme: LightTheme): Promise<void> {
@@ -104,40 +110,25 @@ export async function setLightTheme(theme: LightTheme): Promise<void> {
 }
 
 export function getDarkTheme(): Theme {
-  return getConfiguration().get<Theme>(section.dark, "dark");
+  return readThemeValue(getConfiguration(), section.dark, ThemeKeys, "dark");
 }
 
 export async function setDarkTheme(theme: DarkTheme): Promise<void> {
   await updateThemeConfiguration(section.dark, theme);
 }
 
-export function getThemeColorMode(): ThemeColorMode {
-  const [mode, theme] = [getThemeMode(), getSingleTheme()];
-  if (mode === "vscode") {
-    return "vscode";
-  }
-  if (mode === "single") {
-    return isLightTheme(theme) ? "light" : "dark";
-  }
-  return "auto";
-}
+export function getResolvedTheme(): ResolvedTheme {
+  const configuration = getConfiguration();
+  const mode = readThemeValue(configuration, section.mode, ThemeModeKeys, "system");
+  const single = readThemeValue(configuration, section.single, ThemeKeys, "light");
+  const light = readThemeValue(configuration, section.light, ThemeKeys, "light");
+  const dark = readThemeValue(configuration, section.dark, ThemeKeys, "dark");
 
-export function getCurrentLightTheme(): Theme {
-  const themeMode = getThemeMode();
-  const singleTheme = getSingleTheme();
-  if (themeMode === "single") {
-    return isLightTheme(singleTheme) ? singleTheme : getLightTheme();
-  }
-  return getLightTheme();
-}
-
-export function getCurrentDarkTheme(): Theme {
-  const themeMode = getThemeMode();
-  const singleTheme = getSingleTheme();
-  if (themeMode === "single") {
-    return isLightTheme(singleTheme) ? getDarkTheme() : singleTheme;
-  }
-  return getDarkTheme();
+  if (mode === "vscode") return { colorMode: "vscode", light, dark };
+  if (mode === "system") return { colorMode: "auto", light, dark };
+  return isLightTheme(single)
+    ? { colorMode: "light", light: single, dark }
+    : { colorMode: "dark", light, dark: single };
 }
 
 export function getThemeModeList(): {
@@ -176,4 +167,14 @@ function themeList<T extends Theme>(themes: readonly T[]): { label: string; valu
     label: themeLabels[theme](),
     value: theme
   }));
+}
+
+function readThemeValue<T extends string>(
+  configuration: vscode.WorkspaceConfiguration,
+  key: string,
+  allowed: readonly T[],
+  fallback: T
+): T {
+  const value = configuration.get<unknown>(key);
+  return typeof value === "string" && allowed.includes(value as T) ? (value as T) : fallback;
 }

--- a/tests/plugins/theme.test.ts
+++ b/tests/plugins/theme.test.ts
@@ -31,6 +31,9 @@ describe("markdown-it-github-theme", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     config["theme.mode"] = "system";
+    config["theme.single"] = "light";
+    config["theme.light"] = "light";
+    config["theme.dark"] = "dark";
     config["accessibility.linkUnderlines"] = true;
   });
 
@@ -57,6 +60,19 @@ describe("markdown-it-github-theme", () => {
     const html = new MarkdownIt().use(githubTheme).render("Hello world");
 
     expect(html).toContain('data-color-mode="vscode"');
+  });
+
+  it("uses safe defaults for invalid persisted theme settings", () => {
+    config["theme.mode"] = "unknown";
+    config["theme.single"] = "unknown";
+    config["theme.light"] = "unknown";
+    config["theme.dark"] = "unknown";
+
+    const html = new MarkdownIt().use(githubTheme).render("Hello world");
+
+    expect(html).toContain('data-color-mode="auto"');
+    expect(html).toContain('data-light-theme="light"');
+    expect(html).toContain('data-dark-theme="dark"');
   });
 
   it("wraps complex markdown content", () => {

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -25,14 +25,7 @@ vi.mock("vscode", () => ({
   }
 }));
 
-import {
-  getCurrentDarkTheme,
-  getCurrentLightTheme,
-  getThemeColorMode,
-  getThemeList,
-  getThemeModeList,
-  type Theme
-} from "../src/theme";
+import { getResolvedTheme, getThemeList, getThemeModeList, type Theme } from "../src/theme";
 
 describe("theme logic", () => {
   beforeEach(() => {
@@ -46,81 +39,65 @@ describe("theme logic", () => {
     };
   });
 
-  describe("getThemeColorMode", () => {
-    it('returns "light" in single mode with light theme', () => {
-      configStore["theme.mode"] = "single";
-      configStore["theme.single"] = "light";
-      expect(getThemeColorMode()).toBe("light");
+  describe("getResolvedTheme", () => {
+    it("resolves system mode from configured light and dark themes", () => {
+      configStore["theme.light"] = "light_high_contrast";
+      configStore["theme.dark"] = "dark_tritanopia";
+
+      expect(getResolvedTheme()).toEqual({
+        colorMode: "auto",
+        light: "light_high_contrast",
+        dark: "dark_tritanopia"
+      });
     });
 
-    it('returns "dark" in single mode with dark theme', () => {
-      configStore["theme.mode"] = "single";
-      configStore["theme.single"] = "dark";
-      expect(getThemeColorMode()).toBe("dark");
-    });
-
-    it('returns "dark" in single mode with dark_dimmed theme', () => {
-      configStore["theme.mode"] = "single";
-      configStore["theme.single"] = "dark_dimmed";
-      expect(getThemeColorMode()).toBe("dark");
-    });
-
-    it('returns "light" in single mode with light_high_contrast theme', () => {
-      configStore["theme.mode"] = "single";
-      configStore["theme.single"] = "light_high_contrast";
-      expect(getThemeColorMode()).toBe("light");
-    });
-
-    it('returns "auto" in system mode regardless of theme', () => {
-      configStore["theme.mode"] = "system";
-      expect(getThemeColorMode()).toBe("auto");
-    });
-
-    it('returns "vscode" in VS Code mode', () => {
-      configStore["theme.mode"] = "vscode";
-      expect(getThemeColorMode()).toBe("vscode");
-    });
-  });
-
-  describe("getCurrentLightTheme", () => {
-    it("returns the single theme when it is a light theme", () => {
+    it("uses a light single theme without discarding the configured dark theme", () => {
       configStore["theme.mode"] = "single";
       configStore["theme.single"] = "light_colorblind";
-      expect(getCurrentLightTheme()).toBe("light_colorblind");
+      configStore["theme.dark"] = "dark_high_contrast";
+
+      expect(getResolvedTheme()).toEqual({
+        colorMode: "light",
+        light: "light_colorblind",
+        dark: "dark_high_contrast"
+      });
     });
 
-    it("falls back to configured light theme when single theme is dark", () => {
+    it("uses a dark single theme without discarding the configured light theme", () => {
       configStore["theme.mode"] = "single";
       configStore["theme.single"] = "dark_dimmed";
       configStore["theme.light"] = "light_tritanopia";
-      expect(getCurrentLightTheme()).toBe("light_tritanopia");
+
+      expect(getResolvedTheme()).toEqual({
+        colorMode: "dark",
+        light: "light_tritanopia",
+        dark: "dark_dimmed"
+      });
     });
 
-    it("returns configured light theme in system mode", () => {
-      configStore["theme.mode"] = "system";
-      configStore["theme.light"] = "light_high_contrast";
-      expect(getCurrentLightTheme()).toBe("light_high_contrast");
-    });
-  });
+    it("resolves VS Code mode", () => {
+      configStore["theme.mode"] = "vscode";
 
-  describe("getCurrentDarkTheme", () => {
-    it("returns the single theme when it is a dark theme", () => {
-      configStore["theme.mode"] = "single";
-      configStore["theme.single"] = "dark_colorblind";
-      expect(getCurrentDarkTheme()).toBe("dark_colorblind");
+      expect(getResolvedTheme()).toEqual({
+        colorMode: "vscode",
+        light: "light",
+        dark: "dark"
+      });
     });
 
-    it("falls back to configured dark theme when single theme is light", () => {
-      configStore["theme.mode"] = "single";
-      configStore["theme.single"] = "light";
-      configStore["theme.dark"] = "dark_high_contrast";
-      expect(getCurrentDarkTheme()).toBe("dark_high_contrast");
-    });
+    it("falls back when persisted theme settings are invalid", () => {
+      configStore = {
+        "theme.mode": "unknown",
+        "theme.single": "unknown",
+        "theme.light": "unknown",
+        "theme.dark": "unknown"
+      };
 
-    it("returns configured dark theme in system mode", () => {
-      configStore["theme.mode"] = "system";
-      configStore["theme.dark"] = "dark_tritanopia";
-      expect(getCurrentDarkTheme()).toBe("dark_tritanopia");
+      expect(getResolvedTheme()).toEqual({
+        colorMode: "auto",
+        light: "light",
+        dark: "dark"
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- validate persisted theme values against supported options
- expose one resolved theme snapshot to preview and Mermaid consumers
- fall back to documented defaults for unsupported stored values

## Verification

- nub run test
- nubx oxlint --type-aware .
- nub run build