### PR TITLE
fix(markdown): escape localized labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+### Accessibility
+
+- Task-list and footnote labels now remain intact when a translation contains quotes, angle brackets, or ampersands.
+
 ### Themes and appearance
 
 - Light and dark theme commands now show only palettes that match their appearance slot, while existing JSON settings continue to work unchanged.

--- a/src/plugins/markdown-it-github-footnotes.ts
+++ b/src/plugins/markdown-it-github-footnotes.ts
@@ -24,6 +24,7 @@ type FootnoteIndex = {
 };
 
 type FragmentRenderer = (tokens: MarkdownToken[], env: Record<string, unknown>) => string;
+type HtmlEscaper = (value: string) => string;
 
 const footnoteDefinitionLinePattern = /^\[\^([^\]\n]+)\]:[ \t]*(.*)$/;
 const footnoteReferencePattern = /\[\^([^\]\n]+)\]/g;
@@ -70,7 +71,7 @@ export default function markdownItGitHubFootnotes(md: MarkdownIt): MarkdownIt {
     const index = applyFootnoteReferences(markdownState, definitions, md);
 
     if (definitions.size > 0) {
-      appendFootnoteSection(markdownState, index, renderFragment);
+      appendFootnoteSection(markdownState, index, renderFragment, md.utils.escapeHtml);
     }
   });
 
@@ -323,7 +324,8 @@ function promoteSoftbreaks(tokens: MarkdownToken[]): void {
 function appendFootnoteSection(
   state: MarkdownState,
   footnotes: FootnoteIndex,
-  renderFragment: FragmentRenderer
+  renderFragment: FragmentRenderer,
+  escapeHtml: HtmlEscaper
 ) {
   if (footnotes.order.length === 0) {
     return;
@@ -338,7 +340,7 @@ function appendFootnoteSection(
 
       const number = index + 1;
       const backrefs = (footnotes.referencesByLabel.get(label) ?? [])
-        .map((reference) => renderBackref(reference.number, reference.referenceCount))
+        .map((reference) => renderBackref(reference.number, reference.referenceCount, escapeHtml))
         .join(" ");
       const content = renderFootnoteDefinition(tokens, backrefs, state, renderFragment);
       return `<li id="user-content-fn-${number}">
@@ -355,7 +357,7 @@ ${content}
   const footnotesToken = new state.Token("html_block", "", 0);
   footnotesToken.content =
     `<section data-footnotes="" class="footnotes">\n` +
-    `<h2 id="footnote-label" class="sr-only" dir="auto">${l10n.t("Footnotes")}</h2>\n` +
+    `<h2 id="footnote-label" class="sr-only" dir="auto">${escapeHtml(l10n.t("Footnotes"))}</h2>\n` +
     `<ol dir="auto">\n${items}\n</ol>\n` +
     `</section>\n`;
 
@@ -401,13 +403,14 @@ function renderFootnoteDefinition(
   return trailingParagraphInline ? content : `${content}\n${backrefs}`;
 }
 
-function renderBackref(number: number, referenceCount: number): string {
+function renderBackref(number: number, referenceCount: number, escapeHtml: HtmlEscaper): string {
   const suffix = referenceCount === 1 ? "" : `-${referenceCount}`;
   const marker = referenceCount === 1 ? "" : `<sup>${referenceCount}</sup>`;
+  const label = escapeHtml(l10n.t("Back to reference {0}{1}", number, suffix));
   return `<a href="#${footnoteReferenceId(
     number,
     referenceCount
-  )}" data-footnote-backref="" aria-label="${l10n.t("Back to reference {0}{1}", number, suffix)}" class="data-footnote-backref">↩${marker}</a>`;
+  )}" data-footnote-backref="" aria-label="${label}" class="data-footnote-backref">↩${marker}</a>`;
 }
 
 function renderFootnoteReferenceAnchor(number: number, referenceCount: number): string {

--- a/src/plugins/markdown-it-github-task-lists.ts
+++ b/src/plugins/markdown-it-github-task-lists.ts
@@ -3,16 +3,17 @@ import type MarkdownIt from "markdown-it";
 import type { MarkdownToken, MarkdownState } from "./shared";
 
 const taskListMarkerPattern = /^[ \t]*\[( |x|X)\][ \t]+/;
+type HtmlEscaper = (value: string) => string;
 
 export default function markdownItGitHubTaskLists(md: MarkdownIt): MarkdownIt {
   md.core.ruler.after("inline", "github-markdown-task-lists", (state) => {
-    applyTaskLists(state as unknown as MarkdownState);
+    applyTaskLists(state as unknown as MarkdownState, md.utils.escapeHtml);
   });
 
   return md;
 }
 
-function applyTaskLists(state: MarkdownState) {
+function applyTaskLists(state: MarkdownState, escapeHtml: HtmlEscaper) {
   for (let index = 0; index < state.tokens.length - 3; index += 1) {
     const listItemOpen = state.tokens[index];
     const paragraphOpen = state.tokens[index + 1];
@@ -44,10 +45,11 @@ function applyTaskLists(state: MarkdownState) {
     }
 
     const checked = marker.toLowerCase() === "x";
+    const label = escapeHtml(l10n.t(checked ? "Completed task" : "Incomplete task"));
     const checkboxToken = new state.Token("html_inline", "", 0);
     checkboxToken.content = checked
-      ? `<input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="${l10n.t("Completed task")}" checked=""> `
-      : `<input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="${l10n.t("Incomplete task")}"> `;
+      ? `<input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="${label}" checked=""> `
+      : `<input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="${label}"> `;
 
     const inlineChildren = inline.children ? [...inline.children] : [];
     firstChild.content = firstChild.content.slice(match[0].length);

--- a/tests/plugins/footnotes.test.ts
+++ b/tests/plugins/footnotes.test.ts
@@ -1,21 +1,25 @@
 import MarkdownIt from "markdown-it";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const localizedMessages = vi.hoisted(() => ({ values: {} as Record<string, string> }));
 
 vi.mock("vscode", () => ({
   default: {
     l10n: {
       t: (key: string, ...args: (string | number)[]) => {
+        const message = localizedMessages.values[key] ?? key;
         return args.length > 0
-          ? key.replace(/\{(\d+)\}/g, (_m, i) => String(args[Number(i)] ?? ""))
-          : key;
+          ? message.replace(/\{(\d+)\}/g, (_m, i) => String(args[Number(i)] ?? ""))
+          : message;
       }
     }
   },
   l10n: {
     t: (key: string, ...args: (string | number)[]) => {
+      const message = localizedMessages.values[key] ?? key;
       return args.length > 0
-        ? key.replace(/\{(\d+)\}/g, (_m, i) => String(args[Number(i)] ?? ""))
-        : key;
+        ? message.replace(/\{(\d+)\}/g, (_m, i) => String(args[Number(i)] ?? ""))
+        : message;
     }
   }
 }));
@@ -23,6 +27,10 @@ vi.mock("vscode", () => ({
 import githubFootnotes from "../../src/plugins/markdown-it-github-footnotes";
 
 describe("markdown-it-github-footnotes", () => {
+  beforeEach(() => {
+    localizedMessages.values = {};
+  });
+
   it("renders footnote reference", () => {
     const md = new MarkdownIt().use(githubFootnotes);
     const html = md.render("Text[^1].\n\n[^1]: My reference.");
@@ -30,6 +38,17 @@ describe("markdown-it-github-footnotes", () => {
     expect(html).toContain('href="#user-content-fn-1"');
     expect(html).toContain("footnotes");
     expect(html).toContain("My reference.");
+  });
+
+  it("escapes localized footnote labels", () => {
+    localizedMessages.values["Footnotes"] = 'Notes "<&';
+    localizedMessages.values["Back to reference {0}{1}"] = 'Back "<& {0}{1}';
+
+    const html = new MarkdownIt().use(githubFootnotes).render("Text[^1].\n\n[^1]: Note.");
+
+    expect(html).toContain(">Notes &quot;&lt;&amp;</h2>");
+    expect(html).toContain('aria-label="Back &quot;&lt;&amp; 1"');
+    expect(html).not.toContain('aria-label="Back "<& 1"');
   });
 
   it("keeps single-word footnote definitions out of Markdown link references", () => {

--- a/tests/plugins/task-lists.test.ts
+++ b/tests/plugins/task-lists.test.ts
@@ -1,20 +1,26 @@
 import MarkdownIt from "markdown-it";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const localizedMessages = vi.hoisted(() => ({ values: {} as Record<string, string> }));
 
 vi.mock("vscode", () => ({
   default: {
     l10n: {
-      t: (key: string) => key
+      t: (key: string) => localizedMessages.values[key] ?? key
     }
   },
   l10n: {
-    t: (key: string) => key
+    t: (key: string) => localizedMessages.values[key] ?? key
   }
 }));
 
 import githubTaskLists from "../../src/plugins/markdown-it-github-task-lists";
 
 describe("markdown-it-github-task-lists", () => {
+  beforeEach(() => {
+    localizedMessages.values = {};
+  });
+
   it("renders checked task list item", () => {
     const md = new MarkdownIt().use(githubTaskLists);
     const html = md.render("- [x] Completed task");
@@ -29,6 +35,15 @@ describe("markdown-it-github-task-lists", () => {
     const html = md.render("- [ ] Incomplete task");
     expect(html).toContain("task-list-item-checkbox");
     expect(html).not.toContain('checked=""');
+  });
+
+  it("escapes the localized checkbox label", () => {
+    localizedMessages.values["Completed task"] = 'Done "<&';
+
+    const html = new MarkdownIt().use(githubTaskLists).render("- [x] Done");
+
+    expect(html).toContain('aria-label="Done &quot;&lt;&amp;"');
+    expect(html).not.toContain('aria-label="Done "<&"');
   });
 
   it("renders mixed checked and unchecked items", () => {


### PR DESCRIPTION
## Summary

- escape localized task-list checkbox labels before inserting them into HTML attributes
- escape footnote section and backreference labels before rendering generated markup
- cover quotes, angle brackets, and ampersands in localized strings

## Verification

- nub run test
- nubx oxlint --type-aware .
- nub run build