### PR TITLE
perf(markdown): scan task lists once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This file records notable changes that people can observe or act on when using t
 
 - Task-list and footnote labels now remain intact when a translation contains quotes, angle brackets, or ampersands.
 
+### Markdown preview
+
+- Large task lists now avoid progressively slower parent-list processing as more items are added.
+
 ### Themes and appearance
 
 - Light and dark theme commands now show only palettes that match their appearance slot, while existing JSON settings continue to work unchanged.

--- a/src/plugins/markdown-it-github-task-lists.ts
+++ b/src/plugins/markdown-it-github-task-lists.ts
@@ -14,8 +14,19 @@ export default function markdownItGitHubTaskLists(md: MarkdownIt): MarkdownIt {
 }
 
 function applyTaskLists(state: MarkdownState, escapeHtml: HtmlEscaper) {
-  for (let index = 0; index < state.tokens.length - 3; index += 1) {
+  const openLists = new Map<number, MarkdownToken>();
+
+  for (let index = 0; index < state.tokens.length; index += 1) {
     const listItemOpen = state.tokens[index];
+    if (listItemOpen?.type === "bullet_list_open" || listItemOpen?.type === "ordered_list_open") {
+      openLists.set(listItemOpen.level, listItemOpen);
+      continue;
+    }
+    if (listItemOpen?.type === "bullet_list_close" || listItemOpen?.type === "ordered_list_close") {
+      openLists.delete(listItemOpen.level);
+      continue;
+    }
+
     const paragraphOpen = state.tokens[index + 1];
     const inline = state.tokens[index + 2];
     const paragraphClose = state.tokens[index + 3];
@@ -62,7 +73,7 @@ function applyTaskLists(state: MarkdownState, escapeHtml: HtmlEscaper) {
     attrJoinOnce(listItemOpen, "class", "task-list-item");
     attrJoinOnce(paragraphOpen, "class", "task-list-item-paragraph");
 
-    const listOpen = findParentListOpen(state.tokens, index, listItemOpen.level - 1);
+    const listOpen = openLists.get(listItemOpen.level - 1);
     if (listOpen) {
       attrJoinOnce(listOpen, "class", "contains-task-list");
     }
@@ -76,27 +87,4 @@ function attrJoinOnce(token: MarkdownToken, name: string, value: string) {
   }
 
   token.attrJoin(name, value);
-}
-
-function findParentListOpen(
-  tokens: MarkdownToken[],
-  fromIndex: number,
-  level: number
-): MarkdownToken | undefined {
-  for (let index = fromIndex - 1; index >= 0; index -= 1) {
-    const token = tokens[index];
-    if (!token) {
-      continue;
-    }
-
-    if (token.level !== level || token.nesting !== 1) {
-      continue;
-    }
-
-    if (token.type === "bullet_list_open" || token.type === "ordered_list_open") {
-      return token;
-    }
-  }
-
-  return undefined;
 }

--- a/tests/plugins/task-lists.test.ts
+++ b/tests/plugins/task-lists.test.ts
@@ -85,4 +85,14 @@ describe("markdown-it-github-task-lists", () => {
 
     expect(taskListClassCounts).toEqual([0, 1]);
   });
+
+  it("renders a large task list without losing task metadata", () => {
+    const count = 2_000;
+    const markdown = Array.from({ length: count }, (_, index) => `- [ ] Task ${index}`).join("\n");
+
+    const html = new MarkdownIt().use(githubTaskLists).render(markdown);
+
+    expect(html.match(/task-list-item-checkbox/g)).toHaveLength(count);
+    expect(html.match(/class="contains-task-list"/g)).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary

- track open parent lists during one forward token pass
- remove the repeated backward scan for every task item
- preserve task metadata for a 2,000-item characterization case

## Complexity

- before: O(T x I) in the worst case
- after: O(T) time and O(D) auxiliary space

T is the token count, I is the task-item count, and D is list nesting depth.

## Verification

- nub run test
- nubx oxlint --type-aware .
- nub run build