### PR TITLE
chore(deps): stop renovate from bumping @types/vscode

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,12 @@
       "enabled": false,
       "matchManagers": ["npm"],
       "matchPackageNames": ["markdown-it", "@types/markdown-it"]
+    },
+    {
+      "description": "Keep @types/vscode aligned with engines.vscode (the minimum supported host)",
+      "enabled": false,
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@types/vscode"]
     }
   ],
   "autoApprove": true,


### PR DESCRIPTION
Keep `@types/vscode` aligned with `engines.vscode` (the minimum supported VS Code host). The `@vscode/vsce` package step rejects `@types/vscode` versions greater than `engines.vscode`, so renovate PRs bumping it always fail (e.g. #1323).