### PR TITLE
fix: 保留 srcset data URL 与候选边界

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+### Markdown preview
+
+- Responsive images preserve embedded data URLs and commas within image paths, so valid images no longer break during preview URL conversion.
+
 ## [v4.5.2] - 2026-09-01
 
 v4.5.2 makes theme settings more resilient, keeps localized task and footnote labels intact, and reduces the work required to render large task lists. Existing settings continue to work unchanged.

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -52,9 +52,43 @@ function rewriteImgSrcset(
 }
 
 function rewriteSrcset(srcset: string, env: ImageRenderEnv | undefined): string {
-  return srcset.replace(/(^\s*|,\s*)(\/(?!\/)[^\s,]+)/g, (_match, separator, src) => {
-    return `${separator}${toProjectRootResourceUri(src, env)}`;
-  });
+  const parts: string[] = [];
+  let position = 0;
+  let unchangedStart = 0;
+
+  // Follow the HTML srcset tokenizer's URL and descriptor boundaries. Commas
+  // inside a URL (including data URLs) are not candidate separators.
+  // https://html.spec.whatwg.org/multipage/images.html#parse-a-srcset-attribute
+  while (position < srcset.length) {
+    while (position < srcset.length && /[\t\n\f\r ,]/.test(srcset[position]!)) position += 1;
+    const urlStart = position;
+    while (position < srcset.length && !/[\t\n\f\r ]/.test(srcset[position]!)) position += 1;
+    let urlEnd = position;
+    while (urlEnd > urlStart && srcset[urlEnd - 1] === ",") urlEnd -= 1;
+
+    const url = srcset.slice(urlStart, urlEnd);
+    if (isProjectRootPath(url)) {
+      parts.push(srcset.slice(unchangedStart, urlStart), toProjectRootResourceUri(url, env));
+      unchangedStart = urlEnd;
+    }
+    if (urlEnd < position) continue;
+
+    // Descriptors remain untouched, including unknown/future descriptors with
+    // parentheses. Let the browser decide whether a candidate is valid.
+    let inParens = false;
+    while (position < srcset.length) {
+      const character = srcset[position++];
+      if (inParens) {
+        if (character === ")") inParens = false;
+      } else if (character === "(") {
+        inParens = true;
+      } else if (character === ",") {
+        break;
+      }
+    }
+  }
+  parts.push(srcset.slice(unchangedStart));
+  return parts.join("");
 }
 
 function decodeHtmlAttribute(value: string, decodeNamedEntity: (value: string) => string): string {

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -167,6 +167,66 @@ describe("markdown-it-github-image-url", () => {
     expect(html).toContain('data-src="/lazy.png" src="//cdn.example.com/photo.png"');
   });
 
+  it.each([
+    [
+      "JPEG data URL",
+      "data:image/jpeg;base64,/9j/4AAQSkZJRg== 1x",
+      "data:image/jpeg;base64,/9j/4AAQSkZJRg== 1x"
+    ],
+    [
+      "data and root candidates",
+      "data:image/jpeg;base64,/9j/AA== 1x, /assets/large.jpg 2x",
+      "data:image/jpeg;base64,/9j/AA== 1x, https://webview.test/workspace/assets/large.jpg 2x"
+    ],
+    [
+      "descriptorless data candidate",
+      "data:image/jpeg;base64,/9j/AA==, /assets/large.jpg 2x",
+      "data:image/jpeg;base64,/9j/AA==, https://webview.test/workspace/assets/large.jpg 2x"
+    ],
+    [
+      "commas within a URL",
+      "/assets/a,/b.jpg 1x, /assets/c.jpg 2x",
+      "https://webview.test/workspace/assets/a,/b.jpg 1x, https://webview.test/workspace/assets/c.jpg 2x"
+    ],
+    [
+      "remote URL containing a slash after a comma",
+      "https://cdn.example/a,/b.jpg 1x",
+      "https://cdn.example/a,/b.jpg 1x"
+    ],
+    [
+      "trailing and leading separators",
+      ", /assets/a.jpg,,  /assets/b.jpg,",
+      ", https://webview.test/workspace/assets/a.jpg,,  https://webview.test/workspace/assets/b.jpg,"
+    ],
+    [
+      "descriptor commas without spaces",
+      "/assets/a.jpg 1x,/assets/b.jpg 2x",
+      "https://webview.test/workspace/assets/a.jpg 1x,https://webview.test/workspace/assets/b.jpg 2x"
+    ],
+    [
+      "parenthesized descriptor text",
+      "/assets/a.jpg future(a,/unchanged.jpg), /assets/b.jpg 2x",
+      "https://webview.test/workspace/assets/a.jpg future(a,/unchanged.jpg), https://webview.test/workspace/assets/b.jpg 2x"
+    ],
+    [
+      "unclosed descriptor parentheses",
+      "/assets/a.jpg future(a,/unchanged.jpg",
+      "https://webview.test/workspace/assets/a.jpg future(a,/unchanged.jpg"
+    ],
+    [
+      "ASCII whitespace",
+      "\t/assets/a.jpg\t1x,\n/assets/b.jpg\r2x ",
+      "\thttps://webview.test/workspace/assets/a.jpg\t1x,\nhttps://webview.test/workspace/assets/b.jpg\n2x "
+    ],
+    ["empty input", "", ""],
+    ["separators only", " , , ", " , , "]
+  ])("preserves srcset candidate boundaries for %s", (_case, srcset, expected) => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    expect(md.renderInline(`<source srcset="${srcset}">`, renderEnv())).toBe(
+      `<source srcset="${expected}">`
+    );
+  });
+
   it("rewrites only the src attribute on raw HTML images", () => {
     const md = new MarkdownIt({ html: true }).use(githubImageUrl);
     const html = md.render('<img data-src="/lazy.png" src="/actual.png">');


### PR DESCRIPTION
修复响应式图片中 JPEG data URL 被误当作根路径的问题，例如 `data:image/jpeg;base64,/9j/...` 原先会在逗号后插入 Webview 路径，导致图片解码失败。现在按照 HTML srcset 的 URL/描述符边界扫描，只转换完整的项目根路径候选，并保留候选内逗号、原有空白和描述符。

验证：新增 12 组边界测试，覆盖 data/root 混合、无描述符、URL 内逗号、无空格分隔、描述符括号和空值；修复前 7 组真实回归失败，修复后图片测试 39 项通过，全套 405 项与覆盖率门槛通过。完整插件链处理项目 JPEG 后，Chromium `img.decode()` 成功且宽度仍为 1086；类型感知 lint 和格式检查通过。HTML 规则依据：https://html.spec.whatwg.org/multipage/images.html#parse-a-srcset-attribute
