### PR TITLE
fix: 正确处理图片属性中的引号字符

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file records notable changes that people can observe or act on when using t
 ### Markdown preview
 
 - Responsive images preserve embedded data URLs and commas within image paths, so valid images no longer break during preview URL conversion.
+- HTML images with apostrophes or quotation marks in their project-root paths now resolve correctly in preview.
 
 ## [v4.5.2] - 2026-09-01
 

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -5,9 +5,9 @@ import { replaceCodePoint } from "entities/decode";
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const responsiveImageTagPattern = /<(?:img|source)(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const projectRootSrcAttributePattern =
-  /(<img(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+src[\t\n\f\r ]*=[\t\n\f\r ]*)(?:(["'])(\/(?!\/)[^"']+)\2|(\/(?!\/)[^\t\n\f\r "'`=<>]+))/i;
+  /(<img(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+src[\t\n\f\r ]*=[\t\n\f\r ]*)(?:("\/(?!\/)[^"]*"|'\/(?!\/)[^']*')|(\/(?!\/)[^\t\n\f\r "'`=<>]+))/i;
 const projectRootSrcsetAttributePattern =
-  /(<(?:img|source)(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+srcset[\t\n\f\r ]*=[\t\n\f\r ]*)(?:(['"])([^"']*)\2|([^\t\n\f\r "'`=<>]+))/i;
+  /(<(?:img|source)(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+srcset[\t\n\f\r ]*=[\t\n\f\r ]*)(?:("[^"]*"|'[^']*')|([^\t\n\f\r "'`=<>]+))/i;
 const htmlEntityPattern = /&(?:#[xX][\da-fA-F]+;?|#\d+;?|[a-zA-Z][a-zA-Z0-9]{1,31};?)/g;
 const legacyHtmlEntityNames = new Set(
   "AElig AMP Aacute Acirc Agrave Aring Atilde Auml COPY Ccedil ETH Eacute Ecirc Egrave Euml GT Iacute Icirc Igrave Iuml LT Ntilde Oacute Ocirc Ograve Oslash Otilde Ouml QUOT REG THORN Uacute Ucirc Ugrave Uuml Yacute aacute acirc acute aelig agrave amp aring atilde auml brvbar ccedil cedil cent copy curren deg divide eacute ecirc egrave eth euml frac12 frac14 frac34 gt iacute icirc iexcl igrave iquest iuml laquo lt macr micro middot nbsp not ntilde oacute ocirc ograve ordf ordm oslash otilde ouml para plusmn pound quot raquo reg sect shy sup1 sup2 sup3 szlig thorn times uacute ucirc ugrave uml uuml yacute yen yuml".split(
@@ -25,13 +25,11 @@ function rewriteImgSrc(
   decodeNamedEntity: (value: string) => string
 ): string {
   return html.replace(imageTagPattern, (imageTag) =>
-    imageTag.replace(
-      projectRootSrcAttributePattern,
-      (_match, before, quote = "", quotedSrc, unquotedSrc) => {
-        const src = decodeHtmlAttribute(quotedSrc ?? unquotedSrc, decodeNamedEntity);
-        return `${before}${serializeAttributeValue(toProjectRootResourceUri(src, env), quote)}`;
-      }
-    )
+    imageTag.replace(projectRootSrcAttributePattern, (_match, before, quotedSrc, unquotedSrc) => {
+      const quote = quotedSrc?.[0] ?? "";
+      const src = decodeHtmlAttribute(quotedSrc?.slice(1, -1) ?? unquotedSrc, decodeNamedEntity);
+      return `${before}${serializeAttributeValue(toProjectRootResourceUri(src, env), quote)}`;
+    })
   );
 }
 
@@ -43,8 +41,12 @@ function rewriteImgSrcset(
   return html.replace(responsiveImageTagPattern, (imageTag) =>
     imageTag.replace(
       projectRootSrcsetAttributePattern,
-      (_match, before, quote = "", quotedSrcset, unquotedSrcset) => {
-        const srcset = decodeHtmlAttribute(quotedSrcset ?? unquotedSrcset, decodeNamedEntity);
+      (_match, before, quotedSrcset, unquotedSrcset) => {
+        const quote = quotedSrcset?.[0] ?? "";
+        const srcset = decodeHtmlAttribute(
+          quotedSrcset?.slice(1, -1) ?? unquotedSrcset,
+          decodeNamedEntity
+        );
         return `${before}${serializeAttributeValue(rewriteSrcset(srcset, env), quote)}`;
       }
     )

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -258,6 +258,44 @@ describe("markdown-it-github-image-url", () => {
     );
   });
 
+  it.each([
+    [
+      '<img src="/assets/it\'s.png" alt="author">',
+      '<img src="https://webview.test/workspace/assets/it\'s.png" alt="author">'
+    ],
+    [
+      "<img src='/assets/a\"b.png' alt='quote'>",
+      "<img src='https://webview.test/workspace/assets/a\"b.png' alt='quote'>"
+    ],
+    [
+      '<img srcset="/assets/it\'s.png 1x, /assets/other.png 2x">',
+      '<img srcset="https://webview.test/workspace/assets/it\'s.png 1x, https://webview.test/workspace/assets/other.png 2x">'
+    ],
+    [
+      "<source srcset='/assets/a\"b.png 1x'>",
+      "<source srcset='https://webview.test/workspace/assets/a\"b.png 1x'>"
+    ],
+    [
+      '<img title=\'literal src="/untouched.png"\' src="/actual.png">',
+      '<img title=\'literal src="/untouched.png"\' src="https://webview.test/workspace/actual.png">'
+    ],
+    [
+      '<source title="literal srcset=\'/untouched.png 1x\'" srcset="/actual.png 1x">',
+      '<source title="literal srcset=\'/untouched.png 1x\'" srcset="https://webview.test/workspace/actual.png 1x">'
+    ],
+    [
+      '<img data-src="/assets/it\'s.png" src="https://cdn.test/it\'s.png">',
+      '<img data-src="/assets/it\'s.png" src="https://cdn.test/it\'s.png">'
+    ],
+    [
+      "<img src=\"/assets/it's.png\"><img src='/assets/a\"b.png'>",
+      "<img src=\"https://webview.test/workspace/assets/it's.png\"><img src='https://webview.test/workspace/assets/a\"b.png'>"
+    ]
+  ])("respects HTML attribute quote boundaries in %s", (input, expected) => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    expect(md.renderInline(input, renderEnv())).toBe(expected);
+  });
+
   it("preserves a double-quoted src while escaping a decoded quotation mark", () => {
     const md = new MarkdownIt({ html: true }).use(githubImageUrl);
     const html = md.render('<img src="/assets/%22logo%22.svg" alt="logo">', renderEnv());


### PR DESCRIPTION
修复 HTML 图片根路径包含另一种引号时无法解析的问题：例如双引号属性中的 `/assets/it's.png`，以及单引号属性中的 `/assets/a"b.png`。`src` 和 `srcset` 现在分别遵循实际属性定界符，保留原引号并继续执行已有的实体转义。

新增 8 组用例：双/单引号、img/source、多个候选及标签、其他属性里的伪 src/srcset、data-src 与远程 URL。修复前 5 组失败，修复后 47 项图片测试和全套 413 项测试、覆盖率门槛通过；类型感知 lint、格式、Markdown 兼容性及视觉基线通过。
