### PR TITLE
perf: 避免 Alerts 转换反复移动 token 数组

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file records notable changes that people can observe or act on when using t
 
 - Responsive images preserve embedded data URLs and commas within image paths, so valid images no longer break during preview URL conversion.
 - HTML images with apostrophes or quotation marks in their project-root paths now resolve correctly in preview.
+- Documents containing many GitHub alerts update more quickly in preview.
 
 ## [v4.5.2] - 2026-09-01
 

--- a/src/plugins/markdown-it-github-alerts.ts
+++ b/src/plugins/markdown-it-github-alerts.ts
@@ -48,9 +48,12 @@ function octicon(name: string, path: string): string {
 }
 
 function applyAlerts(state: MarkdownState) {
-  for (let index = 0; index < state.tokens.length - 2; index += 1) {
+  let nextTokens: MarkdownToken[] | undefined;
+  for (let index = 0; index < state.tokens.length; index += 1) {
     const blockquoteOpen = state.tokens[index];
-    if (blockquoteOpen?.type !== "blockquote_open" || blockquoteOpen.level !== 0) {
+    if (!blockquoteOpen) continue;
+    nextTokens?.push(blockquoteOpen);
+    if (blockquoteOpen.type !== "blockquote_open" || blockquoteOpen.level !== 0) {
       continue;
     }
 
@@ -91,11 +94,14 @@ function applyAlerts(state: MarkdownState) {
       bodyChildren.shift();
     }
 
-    state.tokens.splice(index + 1, 0, ...createTitleTokens(state, alertKind));
+    // Keep original token objects and source metadata; only add title tokens.
+    // Build once instead of shifting the remaining document for every alert.
+    nextTokens ??= state.tokens.slice(0, index + 1);
+    nextTokens.push(...createTitleTokens(state, alertKind));
     inline.content = bodyChildren.map((token) => token.content).join("");
     inline.children = bodyChildren;
-    index += 3;
   }
+  if (nextTokens) state.tokens = nextTokens;
 }
 
 function createTitleTokens(state: MarkdownState, alertKind: AlertKind): MarkdownToken[] {

--- a/tests/plugins/alerts.test.ts
+++ b/tests/plugins/alerts.test.ts
@@ -78,4 +78,56 @@ describe("markdown-it-github-alerts", () => {
     const html = md.render("> [!NOTE]\n> Content.");
     expect(html).not.toContain("<blockquote");
   });
+
+  it("keeps token-array work linear for many alerts", () => {
+    const md = new MarkdownIt().use(githubAlerts);
+    let tokenCount = 0;
+    let indexedOperations = 0;
+    md.core.ruler.before("github-markdown-alerts", "observe-token-work", (state) => {
+      tokenCount = state.tokens.length;
+      state.tokens = new Proxy(state.tokens, {
+        get(target, key, receiver) {
+          if (typeof key === "string" && /^\d+$/.test(key)) indexedOperations += 1;
+          return Reflect.get(target, key, receiver);
+        },
+        set(target, key, value, receiver) {
+          if (typeof key === "string" && /^\d+$/.test(key)) indexedOperations += 1;
+          return Reflect.set(target, key, value, receiver);
+        }
+      });
+    });
+
+    const count = 300;
+    const markdown = Array.from(
+      { length: count },
+      (_, index) => `> [!NOTE]\n> Note ${index}.`
+    ).join("\n\n");
+    const html = md.render(markdown);
+
+    expect(html.match(/class="markdown-alert markdown-alert-note"/g)).toHaveLength(count);
+    expect(html).toContain("Note 0.");
+    expect(html).toContain(`Note ${count - 1}.`);
+    // An operation budget verifies scaling without machine-dependent timings.
+    expect(indexedOperations).toBeLessThan(tokenCount * 12);
+  });
+
+  it("preserves surrounding content, nested quotes, and source token metadata", () => {
+    const md = new MarkdownIt().use(githubAlerts);
+    let originalTokens: ReturnType<MarkdownIt["parse"]> = [];
+    md.core.ruler.before("github-markdown-alerts", "capture-host-tokens", (state) => {
+      originalTokens = [...state.tokens];
+      for (const token of originalTokens) token.meta = { hostMarker: true };
+    });
+    const tokens = md.parse(
+      "Before.\n\n> [!NOTE]\n> First.\n>\n> > Nested quote.\n>\n> Last.\n\nBetween.\n\n> [!TIP]\n> Second.\n\nAfter.",
+      {}
+    );
+    expect(tokens.filter((token) => token.meta?.hostMarker)).toEqual(originalTokens);
+    for (const token of originalTokens) expect(tokens).toContain(token);
+    const html = md.renderer.render(tokens, md.options, {});
+    expect(html).toMatch(
+      /Before\.[\s\S]*markdown-alert-note[\s\S]*First\.[\s\S]*<blockquote>[\s\S]*Nested quote\.[\s\S]*<\/blockquote>[\s\S]*Last\.[\s\S]*Between\.[\s\S]*markdown-alert-tip[\s\S]*Second\.[\s\S]*After\./
+    );
+    expect(html.match(/class="markdown-alert-title"/g)).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
大量 GitHub alerts 原先会逐个在 token 数组中间插入标题，反复移动剩余文档。现在按原顺序一次组装结果数组，保留原 token 对象及宿主元数据；不含 alerts 时沿用原数组。

验证：新增线性操作预算测试，旧实现在 300 个 alerts 上触发 464,397 次数组索引操作，超过 18,000 的预算，修复后通过；另覆盖前后正文、普通/嵌套引用及元数据保留。全套 415 项测试与覆盖率门槛、类型感知 lint、Markdown 验证、视觉基线通过。

同机 Node 24.20.0、交替测量并取 5 次中位数：16,000 个 alerts（288 KB）解析从约 702 ms 降至 51.5 ms。1,000 个 alerts 约 5.7/6.2 ms，未宣称小文档也有提速。12 份既有 Markdown fixtures 和 343 种内容组合的旧/新渲染 HTML 完全相同。计时属于合成负载，不代表实际 Webview 的端到端延迟。
