### PR TITLE
fix: 修复大量 emoji 导致预览渲染中断

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file records notable changes that people can observe or act on when using t
 
 ### Markdown preview
 
+- Paragraphs containing many emoji shortcodes render without interrupting the preview.
 - Responsive images preserve embedded data URLs and commas within image paths, so valid images no longer break during preview URL conversion.
 - HTML images with apostrophes or quotation marks in their project-root paths now resolve correctly in preview.
 - Documents containing many GitHub alerts update more quickly in preview.

--- a/src/plugins/markdown-it-github-emoji.ts
+++ b/src/plugins/markdown-it-github-emoji.ts
@@ -38,7 +38,9 @@ function applyEmojiShortcodes(state: MarkdownState, md: MarkdownIt) {
         continue;
       }
 
-      nextChildren.push(...emojiTokens(child.content, state, md));
+      for (const emoji of emojiTokens(child.content, state, md)) {
+        nextChildren.push(emoji);
+      }
     }
 
     token.children = nextChildren;

--- a/tests/plugins/emoji.test.ts
+++ b/tests/plugins/emoji.test.ts
@@ -17,6 +17,13 @@ describe("markdown-it-github-emoji", () => {
     expect(html).toContain("🎉");
   });
 
+  it("renders a paragraph with more emoji tokens than the function argument limit", () => {
+    const md = new MarkdownIt().use(githubEmoji);
+    const count = 64_000;
+
+    expect(md.render(":smile: ".repeat(count))).toBe(`<p>${"😄 ".repeat(count).trimEnd()}</p>\n`);
+  });
+
   it("renders custom image emoji", () => {
     const md = new MarkdownIt().use(githubEmoji);
     const html = md.render(":shipit:");


### PR DESCRIPTION
单段包含大量 emoji 短代码时，预览会因一次展开过多函数参数抛出 `RangeError: Maximum call stack size exceeded`。改为逐项追加 token，保持输出顺序和线性处理，长段落可正常渲染。

验证：新增 64,000 个 `:smile:`（512 KB）回归用例，修复前失败、修复后通过；57 个测试文件、416 项测试通过，类型感知 lint、格式检查和提交检查通过。更新用户可观察的 changelog。
