### PR TITLE
fix: 修复最低支持 VS Code 的预览样式

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file records notable changes that people can observe or act on when using t
 ### Markdown preview
 
 - Paragraphs containing many emoji shortcodes render without interrupting the preview.
+- Links, syntax highlighting, and other preview styles display correctly in older supported VS Code versions, including 1.74.
 - Responsive images preserve embedded data URLs and commas within image paths, so valid images no longer break during preview URL conversion.
 - HTML images with apostrophes or quotation marks in their project-root paths now resolve correctly in preview.
 - Documents containing many GitHub alerts update more quickly in preview.

--- a/scripts/build/preview-css.ts
+++ b/scripts/build/preview-css.ts
@@ -19,6 +19,8 @@ export async function buildPreviewCss(): Promise<CssBuildResult> {
   const result = await bundleAsync({
     filename: project.paths.previewCssSource,
     minify: true,
+    // VS Code 1.74, our minimum supported host, embeds Chromium 102.
+    targets: { chrome: 102 << 16 },
     drafts: { customMedia: true },
     resolver: {
       read: (path) => readFile(path, "utf8"),

--- a/tests/scripts/build/preview-css.test.ts
+++ b/tests/scripts/build/preview-css.test.ts
@@ -1,0 +1,22 @@
+import { transform } from "lightningcss";
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { buildPreviewCss } from "../../../scripts/build/preview-css";
+
+describe("preview CSS browser compatibility", () => {
+  it("emits flat style rules for the minimum supported VS Code renderer", async () => {
+    const { path } = await buildPreviewCss();
+    let nestedRuleCount = 0;
+    transform({
+      filename: path,
+      code: await readFile(path),
+      visitor: {
+        Rule(rule) {
+          if (rule.type === "style") nestedRuleCount += rule.value.rules?.length ?? 0;
+        }
+      }
+    });
+
+    expect(nestedRuleCount).toBe(0);
+  });
+});


### PR DESCRIPTION
最低支持的 VS Code 1.74 使用 Chromium 102，无法解析产物中保留的嵌套 CSS，导致默认链接下划线等样式失效。构建现在按 Chromium 102 转换 CSS，保持最低支持版本和现有配置语义。

验证：新增整份构建产物的嵌套规则检查，修复前有 32 条、修复后为 0。使用实际 VS Code 1.74 / Electron 19.1.8 / Chromium 102 的隔离渲染进程，默认链接下划线、语法高亮、复制图标样式均从失败变为通过，关闭下划线仍有效。全量测试、类型感知 lint、格式检查和视觉基线通过；精确视觉用例保持 0 像素差异。
