### PR TITLE
fix: 保持 CSS 原子保存后的开发热更新

### DIFF
--- a/scripts/build/css-watcher.ts
+++ b/scripts/build/css-watcher.ts
@@ -1,0 +1,10 @@
+import { watch, type FSWatcher } from "node:fs";
+import { basename, dirname } from "node:path";
+
+export function watchPreviewCss(path: string, onChange: () => void): FSWatcher {
+  const fileName = basename(path);
+  // Watch the directory so an atomic save cannot leave us watching the old inode.
+  return watch(dirname(path), (_, changedFileName) => {
+    if (changedFileName === null || changedFileName === fileName) onChange();
+  });
+}

--- a/scripts/build/dev.ts
+++ b/scripts/build/dev.ts
@@ -1,9 +1,10 @@
+import type { FSWatcher } from "node:fs";
 import { spawn, type ChildProcess } from "node:child_process";
-import { watch, type FSWatcher } from "node:fs";
 import { localBinary, waitForChild } from "../shared/process";
 import { project } from "../shared/project";
 import { buildCss, formatCssBuild } from "./css";
 import { createCssBuildRunner } from "./css-runner";
+import { watchPreviewCss } from "./css-watcher";
 import { shouldOpenVisualizer } from "./options";
 import { buildPreviewCss } from "./preview-css";
 import { createRebuildQueue } from "./rebuild-queue";
@@ -21,7 +22,7 @@ const queue = createRebuildQueue(
   async () => console.log(formatCssBuild(await css.rebuild())),
   (error) => console.error("[css] Rebuild failed", error)
 );
-const cssWatcher = watch(project.paths.previewCssSource, () => queue.request());
+const cssWatcher = watchPreviewCss(project.paths.previewCssSource, () => queue.request());
 const tsdown = spawn(localBinary("tsdown"), ["--watch"], {
   cwd: project.root,
   stdio: "inherit"

--- a/tests/scripts/build/css-watcher.test.ts
+++ b/tests/scripts/build/css-watcher.test.ts
@@ -1,0 +1,75 @@
+import { once } from "node:events";
+import { readFileSync, type FSWatcher } from "node:fs";
+import { mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { watchPreviewCss } from "../../../scripts/build/css-watcher";
+
+const watchers: FSWatcher[] = [];
+const directories: string[] = [];
+
+afterEach(async () => {
+  for (const watcher of watchers.splice(0)) watcher.close();
+  await Promise.all(
+    directories.splice(0).map((path) => rm(path, { recursive: true, force: true }))
+  );
+});
+
+async function createStylesheet(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "github-markdown-css-watch-"));
+  directories.push(directory);
+  const path = join(directory, "extension.preview.css");
+  await writeFile(path, "a { color: black; }");
+  return path;
+}
+
+describe("preview CSS changes", () => {
+  it("continues notifying after atomic saves replace the stylesheet", async () => {
+    const path = await createStylesheet();
+    const observed: string[] = [];
+    watchers.push(watchPreviewCss(path, () => observed.push(readFileSync(path, "utf8"))));
+
+    for (const color of ["red", "green"]) {
+      const replaced = `a { color: ${color}; }`;
+      await writeFile(`${path}.tmp`, replaced);
+      await rename(`${path}.tmp`, path);
+      await vi.waitFor(() => expect(observed).toContain(replaced));
+
+      const saved = `${replaced}\n/* saved again */`;
+      await writeFile(path, saved);
+      await vi.waitFor(() => expect(observed).toContain(saved));
+    }
+  });
+
+  it("ignores other files in the stylesheet directory", async () => {
+    const path = await createStylesheet();
+    const onChange = vi.fn();
+    watchers.push(watchPreviewCss(path, onChange));
+    // macOS may deliver the fixture's creation event after the watcher is attached.
+    await delay(100);
+    onChange.mockClear();
+
+    await writeFile(join(dirname(path), "other.css"), "a { color: red; }");
+    await writeFile(`${path}.tmp`, "a { color: green; }");
+    await delay(100);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("closes its watcher and stops notifying after disposal", async () => {
+    const path = await createStylesheet();
+    const onChange = vi.fn();
+    const watcher = watchPreviewCss(path, onChange);
+    watchers.push(watcher);
+    const closed = once(watcher, "close");
+    watcher.close();
+    await closed;
+
+    await writeFile(path, "a { color: red; }");
+    await delay(100);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
开发模式直接监听 CSS 文件时，原子保存会替换文件并使监听停留在旧 inode，后续样式修改不再触发构建。改为监听父目录并过滤目标文件名；原有重建队列和关闭流程继续生效。

验证：真实文件系统回归先复现失败，再验证两次原子替换后的连续保存、忽略其他文件和关闭后停止通知。独立分支的 58 个测试文件、419 项测试通过；类型感知 lint 和格式检查通过。本项仅改善开发工具，按准入规则不写入用户 changelog。
