### PR TITLE
fix: 保留图片 URI 编码与查询参数语义

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file records notable changes that people can observe or act on when using t
 
 - Paragraphs containing many emoji shortcodes render without interrupting the preview.
 - Links, syntax highlighting, and other preview styles display correctly in older supported VS Code versions, including 1.74.
+- Project-root images keep spaces and special characters encoded in preview URLs, including responsive images in workspaces with spaces in their names.
 - Responsive images preserve embedded data URLs and commas within image paths, so valid images no longer break during preview URL conversion.
 - HTML images with apostrophes or quotation marks in their project-root paths now resolve correctly in preview.
 - Documents containing many GitHub alerts update more quickly in preview.

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "unicode-case-folding": "1.1.1",
-    "vitest": "5.0.0"
+    "vitest": "5.0.0",
+    "vscode-uri": "3.2.0"
   },
   "l10n": "./l10n",
   "contributes": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       vitest:
         specifier: 5.0.0
         version: 5.0.0(@types/node@24.13.3)(@vitest/coverage-v8@5.0.0)(vite@8.0.16(@types/node@24.13.3))
+      vscode-uri:
+        specifier: 3.2.0
+        version: 3.2.0
 
 packages:
 

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -132,12 +132,17 @@ function toProjectRootResourceUri(src: string, env: ImageRenderEnv | undefined):
   if (!workspaceFolder || !resourceProvider) return `.${src}`;
 
   try {
-    const parsed = vscode.Uri.parse(`markdown-link:${src}`);
+    // Encode the resource path while preserving the URL query and fragment.
+    // URI query serialization treats separators such as '&' as component data.
+    const suffixStart = src.search(/[?#]/);
+    const path = suffixStart < 0 ? src : src.slice(0, suffixStart);
+    const suffix = suffixStart < 0 ? "" : src.slice(suffixStart);
+    const parsed = vscode.Uri.parse(`markdown-link:${path}`);
     const resource = vscode.Uri.joinPath(workspaceFolder.uri, parsed.path).with({
-      fragment: parsed.fragment,
-      query: parsed.query
+      fragment: "",
+      query: ""
     });
-    return resourceProvider.asWebviewUri(resource).toString(true);
+    return `${resourceProvider.asWebviewUri(resource).toString()}${suffix}`;
   } catch {
     return `.${src}`;
   }

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -1,7 +1,8 @@
 import MarkdownIt from "markdown-it";
 import { describe, expect, it, vi } from "vitest";
 
-const vscode = vi.hoisted(() => {
+const vscode = await vi.hoisted(async () => {
+  const { URI } = await import("vscode-uri");
   class MockUri {
     constructor(
       readonly scheme: string,
@@ -12,8 +13,14 @@ const vscode = vi.hoisted(() => {
       readonly fsPath = path
     ) {}
 
-    toString(): string {
-      return `${this.scheme}://${this.authority}${this.path}${this.query ? `?${this.query}` : ""}${this.fragment ? `#${this.fragment}` : ""}`;
+    toString(skipEncoding = false): string {
+      return URI.from({
+        scheme: this.scheme,
+        authority: this.authority,
+        path: this.path,
+        query: this.query,
+        fragment: this.fragment
+      }).toString(skipEncoding);
     }
 
     with(change: { fragment?: string; query?: string }): MockUri {
@@ -38,10 +45,15 @@ const vscode = vi.hoisted(() => {
         );
       },
       parse(value: string): MockUri {
-        const match = /^(.*?):(?:\/\/)?([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/.exec(value);
-        if (!match?.[1] || match[2] === undefined) throw new Error(`Invalid URI: ${value}`);
-        const path = decodeURIComponent(match[2]);
-        return new MockUri(match[1], path, match[3], match[4], "", path.replaceAll("/", "\\"));
+        const parsed = URI.parse(value);
+        return new MockUri(
+          parsed.scheme,
+          parsed.path,
+          parsed.query,
+          parsed.fragment,
+          parsed.authority,
+          parsed.path.replaceAll("/", "\\")
+        );
       }
     },
     workspace: {
@@ -99,6 +111,31 @@ describe("markdown-it-github-image-url", () => {
     expect(html).toContain('src="./images/photo.png"');
   });
 
+  it("keeps srcset candidates encoded when the workspace folder contains spaces", () => {
+    vscode.workspace.getWorkspaceFolder.mockReturnValueOnce({
+      uri: new vscode.MockUri("file", "/work folder")
+    });
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+
+    expect(md.renderInline('<img srcset="/assets/my%20logo.svg 1x">', renderEnv())).toBe(
+      '<img srcset="https://webview.test/work%20folder/assets/my%20logo.svg 1x">'
+    );
+  });
+
+  it.each([
+    ["/assets/a%2520b.svg", "/assets/a%2520b.svg"],
+    ["/assets/a%2Cb.svg", "/assets/a%2Cb.svg"],
+    [
+      "/assets/a.svg?theme=light&value=%26%3D%25#part%20one",
+      "/assets/a.svg?theme=light&amp;value=%26%3D%25#part%20one"
+    ]
+  ])("preserves URL semantics when rewriting %s", (input, expected) => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    expect(md.renderInline(`<img srcset="${input} 1x">`, renderEnv())).toBe(
+      `<img srcset="https://webview.test/workspace${expected} 1x">`
+    );
+  });
+
   it("does not touch external URLs", () => {
     const md = new MarkdownIt().use(githubImageUrl);
     const html = md.render("![alt](https://example.com/img.png)");
@@ -131,7 +168,7 @@ describe("markdown-it-github-image-url", () => {
     );
 
     expect(html).toBe(
-      '<p><picture><source data-srcset="/lazy.webp 1x" srcset="https://webview.test/workspace/assets/hero.webp?theme=light&amp;size=wide#top 1x, https://cdn.example.com/hero.webp 2x, ../hero.webp 3x, //cdn.example.com/hero.webp 4x"><img srcset="https://webview.test/workspace/assets/fallback.webp 1x, https://webview.test/workspace/assets/fallback@2x.webp 2x" src="https://webview.test/workspace/assets/fallback.webp" alt="hero"></picture></p>\n'
+      '<p><picture><source data-srcset="/lazy.webp 1x" srcset="https://webview.test/workspace/assets/hero.webp?theme=light&amp;size=wide#top 1x, https://cdn.example.com/hero.webp 2x, ../hero.webp 3x, //cdn.example.com/hero.webp 4x"><img srcset="https://webview.test/workspace/assets/fallback.webp 1x, https://webview.test/workspace/assets/fallback%402x.webp 2x" src="https://webview.test/workspace/assets/fallback.webp" alt="hero"></picture></p>\n'
     );
   });
 
@@ -143,7 +180,7 @@ describe("markdown-it-github-image-url", () => {
     );
 
     expect(html).toBe(
-      '<source srcset="  https://webview.test/workspace/assets/hero.webp 1x, https://webview.test/workspace/assets/hero@2x.webp 2x">'
+      '<source srcset="  https://webview.test/workspace/assets/hero.webp 1x, https://webview.test/workspace/assets/hero%402x.webp 2x">'
     );
   });
 
@@ -186,7 +223,7 @@ describe("markdown-it-github-image-url", () => {
     [
       "commas within a URL",
       "/assets/a,/b.jpg 1x, /assets/c.jpg 2x",
-      "https://webview.test/workspace/assets/a,/b.jpg 1x, https://webview.test/workspace/assets/c.jpg 2x"
+      "https://webview.test/workspace/assets/a%2C/b.jpg 1x, https://webview.test/workspace/assets/c.jpg 2x"
     ],
     [
       "remote URL containing a slash after a comma",
@@ -246,7 +283,7 @@ describe("markdown-it-github-image-url", () => {
       renderEnv("/workspace/docs/guide.md")
     );
 
-    expect(html).toBe('<img src="https://webview.test/workspace/assets/my logo.svg" alt=logo>');
+    expect(html).toBe('<img src="https://webview.test/workspace/assets/my%20logo.svg" alt=logo>');
   });
 
   it("preserves a single-quoted src while escaping a decoded apostrophe", () => {
@@ -254,26 +291,26 @@ describe("markdown-it-github-image-url", () => {
     const html = md.render("<img src='/assets/author%27s-logo.svg' alt='logo'>", renderEnv());
 
     expect(html).toBe(
-      "<img src='https://webview.test/workspace/assets/author&#39;s-logo.svg' alt='logo'>"
+      "<img src='https://webview.test/workspace/assets/author%27s-logo.svg' alt='logo'>"
     );
   });
 
   it.each([
     [
       '<img src="/assets/it\'s.png" alt="author">',
-      '<img src="https://webview.test/workspace/assets/it\'s.png" alt="author">'
+      '<img src="https://webview.test/workspace/assets/it%27s.png" alt="author">'
     ],
     [
       "<img src='/assets/a\"b.png' alt='quote'>",
-      "<img src='https://webview.test/workspace/assets/a\"b.png' alt='quote'>"
+      "<img src='https://webview.test/workspace/assets/a%22b.png' alt='quote'>"
     ],
     [
       '<img srcset="/assets/it\'s.png 1x, /assets/other.png 2x">',
-      '<img srcset="https://webview.test/workspace/assets/it\'s.png 1x, https://webview.test/workspace/assets/other.png 2x">'
+      '<img srcset="https://webview.test/workspace/assets/it%27s.png 1x, https://webview.test/workspace/assets/other.png 2x">'
     ],
     [
       "<source srcset='/assets/a\"b.png 1x'>",
-      "<source srcset='https://webview.test/workspace/assets/a\"b.png 1x'>"
+      "<source srcset='https://webview.test/workspace/assets/a%22b.png 1x'>"
     ],
     [
       '<img title=\'literal src="/untouched.png"\' src="/actual.png">',
@@ -289,7 +326,7 @@ describe("markdown-it-github-image-url", () => {
     ],
     [
       "<img src=\"/assets/it's.png\"><img src='/assets/a\"b.png'>",
-      "<img src=\"https://webview.test/workspace/assets/it's.png\"><img src='https://webview.test/workspace/assets/a\"b.png'>"
+      "<img src=\"https://webview.test/workspace/assets/it%27s.png\"><img src='https://webview.test/workspace/assets/a%22b.png'>"
     ]
   ])("respects HTML attribute quote boundaries in %s", (input, expected) => {
     const md = new MarkdownIt({ html: true }).use(githubImageUrl);
@@ -301,7 +338,7 @@ describe("markdown-it-github-image-url", () => {
     const html = md.render('<img src="/assets/%22logo%22.svg" alt="logo">', renderEnv());
 
     expect(html).toBe(
-      '<img src="https://webview.test/workspace/assets/&quot;logo&quot;.svg" alt="logo">'
+      '<img src="https://webview.test/workspace/assets/%22logo%22.svg" alt="logo">'
     );
   });
 
@@ -325,7 +362,7 @@ describe("markdown-it-github-image-url", () => {
     );
 
     expect(html).toBe(
-      '<img src="https://webview.test/workspace/assets/a\\&amp;b.svg?theme=light&amp;size=wide#hero" alt=logo>'
+      '<img src="https://webview.test/workspace/assets/a%5C%26b.svg?theme=light&amp;size=wide#hero" alt=logo>'
     );
   });
 
@@ -334,7 +371,7 @@ describe("markdown-it-github-image-url", () => {
     const html = md.render('<img src="/assets/a&amp?theme=light#hero" alt=logo>', renderEnv());
 
     expect(html).toBe(
-      '<img src="https://webview.test/workspace/assets/a&amp;?theme=light#hero" alt=logo>'
+      '<img src="https://webview.test/workspace/assets/a%26?theme=light#hero" alt=logo>'
     );
   });
 
@@ -348,7 +385,7 @@ describe("markdown-it-github-image-url", () => {
     const html = md.render(`<img src="/assets/a${reference}.svg" alt=logo>`, renderEnv());
 
     expect(html).toBe(
-      `<img src="https://webview.test/workspace/assets/a${expected}.svg" alt=logo>`
+      `<img src="https://webview.test/workspace/assets/a${encodeURIComponent(expected)}.svg" alt=logo>`
     );
   });
 
@@ -363,11 +400,14 @@ describe("markdown-it-github-image-url", () => {
     );
 
     expect(html).toBe(
-      '<img src="https://webview.test/second-workspace/assets/my logo.svg" alt=logo>'
+      '<img src="https://webview.test/second-workspace/assets/my%20logo.svg" alt=logo>'
     );
   });
 
   it("serializes the relative fallback when URI parsing fails", () => {
+    vi.spyOn(vscode.Uri, "parse").mockImplementationOnce(() => {
+      throw new Error("URI parsing failed");
+    });
     const md = new MarkdownIt({ html: true }).use(githubImageUrl);
     const html = md.render("<img src=/assets/bad%ZZ.svg alt=logo>", renderEnv());
 


### PR DESCRIPTION
工作区目录或图片路径包含空格时，根路径 `srcset` 会输出裸空格，浏览器无法选中图片候选。现在对转换后的资源路径进行 URI 编码，并保留原始查询参数和片段；百分号、逗号和引号也不会改变候选或 URL 的含义。

验证：新增使用实际 `vscode-uri` 序列化的回归用例，空格、百分号和逗号场景修复前失败，修复后通过；查询参数和已编码内容保持语义。Chromium 实际 `img.decode()` 成功，含空格工作区中的图片宽度正确，`v=%26%3D%25` 仍解码为 `&=%`。重基后全量 420 项测试通过；覆盖率、类型感知 lint、格式、Markdown 校验和视觉基线通过。`vscode-uri` 仅为测试显式引用已有锁定版本，不增加运行时依赖。
