### PR TITLE
fix: 保留代码与 URL 标签中的 emoji 原文

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file records notable changes that people can observe or act on when using t
 
 ### Markdown preview
 
+- Emoji shortcodes remain literal inside HTML code elements and URL link labels while ordinary link labels still display emoji.
 - Paragraphs containing many emoji shortcodes render without interrupting the preview.
 - Links, syntax highlighting, and other preview styles display correctly in older supported VS Code versions, including 1.74.
 - Responsive images preserve embedded data URLs and commas within image paths, so valid images no longer break during preview URL conversion.

--- a/src/plugins/markdown-it-github-emoji.ts
+++ b/src/plugins/markdown-it-github-emoji.ts
@@ -15,25 +15,48 @@ export default function markdownItGitHubEmoji(md: MarkdownIt): MarkdownIt {
 }
 
 function applyEmojiShortcodes(state: MarkdownState, md: MarkdownIt) {
+  let htmlCodeDepth = 0;
   for (const token of state.tokens) {
+    if (token.type === "html_block") {
+      htmlCodeDepth = codeDepthAfterHtml(token.content, htmlCodeDepth);
+      continue;
+    }
     if (token.type !== "inline" || !token.children) {
       continue;
     }
 
     const nextChildren: MarkdownToken[] = [];
     let automaticLinkDepth = 0;
+    let linkDepth = 0;
     for (const child of token.children) {
-      if (child.type === "link_open" && child.markup === "linkify") {
-        automaticLinkDepth += 1;
+      if (child.type === "html_inline") {
+        htmlCodeDepth = codeDepthAfterHtml(child.content, htmlCodeDepth);
         nextChildren.push(child);
         continue;
       }
-      if (child.type === "link_close" && child.markup === "linkify") {
+      if (child.type === "link_open") {
+        linkDepth += 1;
+        if (child.markup === "linkify" || child.markup === "autolink") {
+          automaticLinkDepth += 1;
+        }
         nextChildren.push(child);
-        automaticLinkDepth = Math.max(0, automaticLinkDepth - 1);
         continue;
       }
-      if (automaticLinkDepth > 0 || child.type !== "text" || !child.content.includes(":")) {
+      if (child.type === "link_close") {
+        nextChildren.push(child);
+        linkDepth = Math.max(0, linkDepth - 1);
+        if (child.markup === "linkify" || child.markup === "autolink") {
+          automaticLinkDepth = Math.max(0, automaticLinkDepth - 1);
+        }
+        continue;
+      }
+      if (
+        htmlCodeDepth > 0 ||
+        automaticLinkDepth > 0 ||
+        child.type !== "text" ||
+        !child.content.includes(":") ||
+        (linkDepth > 0 && isUrlLabel(child.content, md))
+      ) {
         nextChildren.push(child);
         continue;
       }
@@ -45,6 +68,65 @@ function applyEmojiShortcodes(state: MarkdownState, md: MarkdownIt) {
 
     token.children = nextChildren;
   }
+}
+
+function codeDepthAfterHtml(html: string, depth: number): number {
+  let position = 0;
+  while ((position = html.indexOf("<", position)) !== -1) {
+    // Consume comments and other opaque markup before looking for tag names.
+    const marker = html.startsWith("<!--", position)
+      ? "-->"
+      : html.startsWith("<![CDATA[", position)
+        ? "]]>"
+        : html.startsWith("<?", position)
+          ? "?>"
+          : undefined;
+    if (marker) {
+      const end = html.indexOf(marker, position + 2);
+      position = end === -1 ? html.length : end + marker.length;
+      continue;
+    }
+
+    const closing = html[position + 1] === "/";
+    const nameStart = position + (closing ? 2 : 1);
+    if (!/[a-z!]/i.test(html[nameStart] ?? "")) {
+      position += 1;
+      continue;
+    }
+    let nameEnd = nameStart;
+    while (/[a-z0-9-]/i.test(html[nameEnd] ?? "")) {
+      nameEnd += 1;
+    }
+    const name = html.slice(nameStart, nameEnd).toLowerCase();
+    if ((!name || !/[\s/>]/.test(html[nameEnd] ?? "")) && html[nameStart] !== "!") {
+      position += 1;
+      continue;
+    }
+
+    // Scan each tag once, keeping apparent tags inside quoted attributes opaque.
+    let quote: string | undefined;
+    let end = nameEnd;
+    for (; end < html.length; end += 1) {
+      const character = html[end];
+      if (quote) {
+        if (character === quote) quote = undefined;
+      } else if (character === '"' || character === "'") {
+        quote = character;
+      } else if (character === ">") {
+        break;
+      }
+    }
+    if (end === html.length) break;
+    if (name === "code") depth = closing ? Math.max(0, depth - 1) : depth + 1;
+    position = end + 1;
+  }
+  return depth;
+}
+
+function isUrlLabel(content: string, md: MarkdownIt): boolean {
+  // Explicit links are excluded from MarkdownIt's linkify rule. Reuse its URL
+  // recognition for complete URL labels, while keeping ordinary labels eligible.
+  return !/\s/.test(content) && md.linkify.match(content)?.[0]?.index === 0;
 }
 
 function emojiTokens(content: string, state: MarkdownState, md: MarkdownIt): MarkdownToken[] {

--- a/tests/plugins/emoji.test.ts
+++ b/tests/plugins/emoji.test.ts
@@ -71,4 +71,108 @@ describe("markdown-it-github-emoji", () => {
     expect(html).toContain("https://example.com/:rocket:");
     expect(html).not.toContain("🚀");
   });
+
+  it.each([
+    ["<code>:octocat:</code>", "<code>:octocat:</code>"],
+    ["<code><span>:smile:</span></code> :smile:", "<code><span>:smile:</span></code> 😄"],
+    [
+      "<code>:smile:<code>:smile:</code>:smile:</code> :smile:",
+      "<code>:smile:<code>:smile:</code>:smile:</code> 😄"
+    ],
+    ['<CODE title="a > b">:smile:</CODE> :smile:', '<CODE title="a > b">:smile:</CODE> 😄'],
+    ["<code><!-- </code> -->:smile:</code> :smile:", "<code><!-- </code> -->:smile:</code> 😄"],
+    ["<code/>:smile:</code> :smile:", "<code/>:smile:</code> 😄"],
+    ["</code> :smile:", "</code> 😄"],
+    ['<span title="<code>">:smile:</span> :smile:', '<span title="<code>">😄</span> 😄'],
+    ["<tt>:smile:</tt> <kbd>:smile:</kbd>", "<tt>😄</tt> <kbd>😄</kbd>"]
+  ])("preserves HTML code context in %s", (source, expected) => {
+    expect(new MarkdownIt({ html: true }).use(githubEmoji).renderInline(source)).toBe(expected);
+  });
+
+  it("keeps HTML code context across paragraphs and resumes outside it", () => {
+    const md = new MarkdownIt({ html: true }).use(githubEmoji);
+
+    expect(md.render("<code>:smile:\n\n:smile:</code> :smile:")).toBe(
+      "<p><code>:smile:</p>\n<p>:smile:</code> 😄</p>\n"
+    );
+    expect(md.render(":smile:")).toBe("<p>😄</p>\n");
+  });
+
+  it.each([
+    ["<code>foo\n\n</code>\n\n:smile:", "<code>foo\n\n</code>\n\n😄"],
+    [
+      "<div><code>\n\n:smile:\n\n</code></div>\n\n:smile:",
+      "<div><code>\n\n:smile:\n\n</code></div>\n\n😄"
+    ],
+    [
+      "<div>`<code>`\n\n:smile:\n\n</code></div>\n\n:smile:",
+      "<div>`<code>`\n\n:smile:\n\n</code></div>\n\n😄"
+    ],
+    ['<div title="<code>">\n\n:smile:', '<div title="<code>">\n\n😄'],
+    [
+      '<code>foo\n\n<div title="</code>">\n\n:smile:\n\n</code></div>\n\n:smile:',
+      '<code>foo\n\n<div title="</code>">\n\n:smile:\n\n</code></div>\n\n😄'
+    ],
+    ["<!-- <code> -->\n\n:smile:", "<!-- <code> -->\n\n😄"],
+    [
+      "<code>foo\n\n<!-- </code> -->\n\n:smile:\n\n</code>\n\n:smile:",
+      "<code>foo\n\n<!-- </code> -->\n\n:smile:\n\n</code>\n\n😄"
+    ],
+    ["<div><code>foo</code></div>\n\n:smile:", "<div><code>foo</code></div>\n\n😄"],
+    ["<div>&lt;code&gt;</div>\n\n:smile:", "<div>&lt;code&gt;</div>\n\n😄"],
+    ["<?instruction <code> ?>\n\n:smile:", "<?instruction <code> ?>\n\n😄"],
+    ["<![CDATA[<code>]]>\n\n:smile:", "<![CDATA[<code>]]>\n\n😄"]
+  ])("tracks code tags across HTML blocks in %s", (source, expectedSource) => {
+    const md = new MarkdownIt({ html: true }).use(githubEmoji);
+
+    expect(md.render(source)).toBe(new MarkdownIt({ html: true }).render(expectedSource));
+  });
+
+  it.each([
+    "<https://example.com/:smile:>",
+    "[https://example.com/:smile:](https://example.com/:smile:)",
+    "[https://other.com/:smile:](https://example.com/)",
+    "[www.example.com/:smile:](https://example.com/)",
+    "[ftp://example.com/:smile:](https://example.com/)",
+    "[**https://example.com/:smile:**](https://example.com/)",
+    "[<span>https://example.com/:smile:</span>](https://example.com/)",
+    "[https://example.com/:smile:][url]\n\n[url]: https://example.com/"
+  ])("preserves URL link text in %s", (source) => {
+    const md = new MarkdownIt({ html: true }).use(githubEmoji);
+
+    expect(md.render(source)).toBe(new MarkdownIt({ html: true }).render(source));
+  });
+
+  it("still replaces emoji in ordinary link labels and following text", () => {
+    const md = new MarkdownIt({ html: true }).use(githubEmoji);
+
+    expect(
+      md.renderInline(
+        '[see :smile: **:rocket:**](https://example.com/:smile: "title :smile:") :smile:'
+      )
+    ).toBe(
+      '<a href="https://example.com/:smile:" title="title :smile:">see 😄 <strong>🚀</strong></a> 😄'
+    );
+    expect(md.renderInline('<a href="https://example.com/">:smile:</a>')).toBe(
+      '<a href="https://example.com/">😄</a>'
+    );
+    expect(md.renderInline("[note: :smile:](https://example.com/)")).toBe(
+      '<a href="https://example.com/">note: 😄</a>'
+    );
+    expect(
+      md.renderInline("[:smile: https://example.com/:smile: :smile:](https://example.com/)")
+    ).toBe('<a href="https://example.com/">😄 https://example.com/😄 😄</a>');
+    expect(
+      md.renderInline("[<span>https://example.com/:smile:</span> :smile:](https://example.com/)")
+    ).toBe('<a href="https://example.com/"><span>https://example.com/:smile:</span> 😄</a>');
+  });
+
+  it("preserves Markdown code and escaped shortcodes", () => {
+    const md = new MarkdownIt().use(githubEmoji);
+    const source = "`:smile:` \\:smile: :smile:\n\n```\n:smile:\n```";
+
+    expect(md.render(source)).toBe(
+      "<p><code>:smile:</code> :smile: 😄</p>\n<pre><code>:smile:\n</code></pre>\n"
+    );
+  });
 });


### PR DESCRIPTION
HTML `<code>` 内的短代码和完整 URL 链接标签会被错误替换成 emoji。现在跟踪 HTML 代码标签的进入与退出，覆盖行内标签与 HTML 块之间的切换，同时保护自动链接和明确的完整 URL 标签；普通链接标签继续显示 emoji。

验证：对照 GitHub Markdown API 确认代码及 URL 原文行为；新增回归先复现失败，再覆盖嵌套标签、属性中的伪标签、注释、不同行块之间的关闭标签、周围正常文字、格式化链接和 Markdown 转义。审查发现初稿遗漏独立 HTML 块的关闭标签，已修正并补齐 11 个边界用例。重基后 58 个测试文件、448 项测试通过，覆盖率阈值、类型感知 lint、格式检查通过。

本项不把 GitHub 混合 URL 与普通文字节点的特殊替换行为推广为新规则；这类混合标签保留既有语义。
